### PR TITLE
stage 2: bug fixes

### DIFF
--- a/srv/salt/ceph/stage/configure.sls
+++ b/srv/salt/ceph/stage/configure.sls
@@ -1,7 +1,7 @@
 
 time:
   salt.state:
-    - tgt: salt['pillar.get']('master_minion')
+    - tgt: {{ salt['pillar.get']('master_minion') }}
     - sls: ceph.event.begin
 
 

--- a/srv/salt/ceph/stage/configure.sls
+++ b/srv/salt/ceph/stage/configure.sls
@@ -2,7 +2,7 @@
 time:
   salt.state:
     - tgt: {{ salt['pillar.get']('master_minion') }}
-    - sls: ceph.event.begin
+    - sls: ceph.events.begin_prep
 
 
 include:


### PR DESCRIPTION
There were 2 bugs when running stage 2.

The first was the lack of curly brackets surrounding the target, and the second was due to the rename of the ceph.event.begin to  ceph.events.begin_prep