### PR TITLE
minion_id: Use fqnd instead of id

### DIFF
--- a/srv/pillar/ceph/init.sls
+++ b/srv/pillar/ceph/init.sls
@@ -1,7 +1,7 @@
 
 
 
-{% include 'ceph/cluster/' + grains['id'] + '.sls' ignore missing %}
+{% include 'ceph/cluster/' + grains['fqdn'] + '.sls' ignore missing %}
 
 {% include 'ceph/master_minion.sls' ignore missing %}
 


### PR DESCRIPTION
When calling salt-runner on master, that is also a minion,
grains['id'] will append the suffix "_master" to the minion_id.

This caused me problems, since the admin node is also the salt-master, and instead of reading the admin.ceph.sls file, was trying to read the admin.ceph_master.sls file that didn't exist.

Signed-off-by: Ricardo Dias <rdias@suse.com>