### PR TITLE
spec: restart salt-master on install (bsc#1000620)

### DIFF
--- a/deepsea.spec
+++ b/deepsea.spec
@@ -268,6 +268,9 @@ cd %{buildroot}/%{_saltceph}/stage && ln -sf services.sls 4.sls
 %post 
 # Initialize to most likely value
 sed -i '/^master_minion:/s!_REPLACE_ME_!'`hostname -f`'!' /srv/pillar/ceph/master_minion.sls
+# Restart salt-master if it's running, so it picks up
+# the config changes in /etc/salt/master.d/modules.conf
+systemctl try-restart salt-master > /dev/null 2>&1 || :
 
 %postun 
 


### PR DESCRIPTION
Because we ship /etc/salt/master.d/modules.conf, salt-master
needs to be restarted after deepsea is installed, or it won't
notice the necessary config changes.

Signed-off-by: Tim Serong <tserong@suse.com>