### PR TITLE
Change the position where we wait for the cluster due to

### DIFF
--- a/srv/salt/ceph/igw/restart/default.sls
+++ b/srv/salt/ceph/igw/restart/default.sls
@@ -1,11 +1,3 @@
-wait:
-  module.run:
-   - name: wait.out
-   - kwargs:
-       'status': "HEALTH_ERR"
-   - fire_event: True
-   - failhard: True
-
 restart:
   cmd.run:
     - name: "lrbd"

--- a/srv/salt/ceph/mds/restart/default.sls
+++ b/srv/salt/ceph/mds/restart/default.sls
@@ -1,11 +1,3 @@
-wait:
-  module.run:
-   - name: wait.out
-   - kwargs:
-       'status': "HEALTH_ERR"
-   - fire_event: True
-   - failhard: True
-
 restart:
   cmd.run:
     - name: "systemctl restart ceph-mds@{{ grains['host'] }}.service"

--- a/srv/salt/ceph/mon/restart/default.sls
+++ b/srv/salt/ceph/mon/restart/default.sls
@@ -1,12 +1,4 @@
-wait for {{ grains['host'] }}:
-  module.run:
-   - name: wait.out
-   - kwargs:
-       'status': "HEALTH_ERR"
-   - fire_event: True
-   - failhard: True
-
-restart @{{ grains['host'] }}:
+restart:
   cmd.run:
     - name: "systemctl restart ceph-mon@{{ grains['host'] }}.service"
     - fire_event: True

--- a/srv/salt/ceph/osd/restart/default.sls
+++ b/srv/salt/ceph/osd/restart/default.sls
@@ -1,14 +1,8 @@
 {% for id in salt['osd.list']() %}
-    wait:
-      module.run:
-       - name: wait.out
-       - kwargs:
-           'status': "HEALTH_ERR"
-       - fire_event: True
-       - failhard: True
-     
-    restart {{ id }}:
+    restart osd #{{ id }}:
       cmd.run:
         - name: "systemctl restart ceph-osd@{{ id }}.service"
+        - unless: "systemctl status ceph-osd@{{ id }}.service | grep -q '^Active: failed'" 
         - fire_event: True
+        - failhard: True
 {% endfor %}

--- a/srv/salt/ceph/restart/default.sls
+++ b/srv/salt/ceph/restart/default.sls
@@ -1,5 +1,13 @@
 {% for host in salt.saltutil.runner('select.minions', cluster='ceph', roles='mon', host=True) %}
 
+    wait:
+      module.run:
+       - name: wait.out
+       - tgt: {{ salt['pillar.get']('master_minion') }}
+       - kwargs:
+           'status': "HEALTH_ERR"
+       - fire_event: True
+
     restarting mons on {{ host }}:
       salt.state:
         - tgt: {{ host }}
@@ -10,6 +18,14 @@
 {% endfor %}
 
 {% for host in salt.saltutil.runner('select.minions', cluster='ceph', roles='storage', host=True) %}
+
+    wait:
+      module.run:
+       - name: wait.out
+       - tgt: {{ salt['pillar.get']('master_minion') }}
+       - kwargs:
+           'status': "HEALTH_ERR"
+       - fire_event: True
 
     restarting osds on {{ host }}:
       salt.state:
@@ -22,6 +38,14 @@
 
 {% for host in salt.saltutil.runner('select.minions', cluster='ceph', roles='rgw', host=True) %}
 
+    wait:
+      module.run:
+       - name: wait.out
+       - tgt: {{ salt['pillar.get']('master_minion') }}
+       - kwargs:
+           'status': "HEALTH_ERR"
+       - fire_event: True
+
     restarting rgw on {{ host }}:
       salt.state:
         - tgt: {{ host }}
@@ -33,6 +57,14 @@
 
 {% for host in salt.saltutil.runner('select.minions', cluster='ceph', roles='mds', host=True) %}
 
+    wait:
+      module.run:
+       - name: wait.out
+       - tgt: {{ salt['pillar.get']('master_minion') }}
+       - kwargs:
+           'status': "HEALTH_ERR"
+       - fire_event: True
+
     restarting mds on {{ host }}:
       salt.state:
         - tgt: {{ host }}
@@ -43,6 +75,14 @@
 {% endfor %}
 
 {% for host in salt.saltutil.runner('select.minions', cluster='ceph', roles='igw', host=True) %}
+
+    wait:
+      module.run:
+       - name: wait.out
+       - tgt: {{ salt['pillar.get']('master_minion') }}
+       - kwargs:
+           'status': "HEALTH_ERR"
+       - fire_event: True
 
     restarting igw on {{ host }}:
       salt.state:

--- a/srv/salt/ceph/rgw/restart/default.sls
+++ b/srv/salt/ceph/rgw/restart/default.sls
@@ -1,10 +1,3 @@
-wait for:
-  module.run:
-   - name: wait.out
-   - kwargs:
-       'status': "HEALTH_ERR"
-   - fire_event: True
-         
 restart:
   cmd.run:
     - name: "systemctl restart ceph-radosgw@rgw.{{ grains['host'] }}.service"


### PR DESCRIPTION
Change the position where we wait for the cluster due to keyring/permissions
Also add failhard to OSDS to avoid ending up with N broken OSDS

Signed-off-by: Joshua Schmid <jschmid@suse.de>
(cherry picked from commit 415e9177d897330dd705d69af0bf172b4b58cb49)