### PR TITLE
Bf network testing tools no ipv4

### DIFF
--- a/srv/modules/runners/nettest.py
+++ b/srv/modules/runners/nettest.py
@@ -2,6 +2,9 @@
 
 import salt.client
 import select
+import logging
+
+log = logging.getLogger(__name__)
 
 def minion_link_ipv4(host = False, **kwargs):
     """
@@ -17,6 +20,10 @@ def minion_link_ipv4(host = False, **kwargs):
     for node in node_list:
         ipv4_list = set()
         address_list = local_client.cmd(node, 'grains.get', ['ipv4'])
+        if not node in address_list.keys():
+            log.error("Failed getting ipv4 address from node:{node}".format(node=node))
+            log.warning("Skipping all tests for node:{node}".format(node=node))
+            continue
         for addr in address_list[node]:
             if addr == '127.0.0.1':
                 continue

--- a/srv/modules/runners/nettest.py
+++ b/srv/modules/runners/nettest.py
@@ -6,7 +6,7 @@ import logging
 
 log = logging.getLogger(__name__)
 
-def minion_link_ipv4(host = False, **kwargs):
+def minion_link_ipv4(**kwargs):
     """
     Return list of (minion, ipv4) touples
 
@@ -14,7 +14,7 @@ def minion_link_ipv4(host = False, **kwargs):
     that also match the search criteria, but returned touples are never for
     minions with thier own ip addresses.
     """
-    node_list = select.minions(host, **kwargs)
+    node_list = select.minions(**dict(kwargs, host=False))
     local_client = salt.client.LocalClient()
     node_ip_map = {}
     for node in node_list:
@@ -30,8 +30,8 @@ def minion_link_ipv4(host = False, **kwargs):
             ipv4_list.add(addr)
         node_ip_map[node] = ipv4_list
     output = []
-    for node_src in node_list:
-        for node_dest in node_list:
+    for node_src in node_ip_map.keys():
+        for node_dest in node_ip_map.keys():
             if node_dest == node_src:
                 continue
             for ipv4 in node_ip_map[node_dest]:

--- a/srv/salt/ceph/diagnose/ping.sls
+++ b/srv/salt/ceph/diagnose/ping.sls
@@ -1,7 +1,7 @@
 {% for host_addr in salt.saltutil.runner('nettest.minion_link_ipv4', cluster='ceph', host=True) %}
 {% set host = host_addr[0] %}
 {% set addr = host_addr[1] %}
-iperf3 {{ host_addr }}:
+ping {{ host_addr }}:
   salt.function:
     - tgt: {{ host }}
     - name: cmd.run


### PR DESCRIPTION
Check for node in return result.

In some situations salt does not return the ipv4 addresses for a node.
This fix logs this error and and issues a warning that this node will be skipped
in testing the network connectivity.

Signed-off-by: Owen Synge osynge@suse.com
