### PR TITLE
Wip nettests improved cleanup

### DIFF
--- a/srv/salt/ceph/iperf/init.sls
+++ b/srv/salt/ceph/iperf/init.sls
@@ -14,8 +14,14 @@ iperfd_service_add:
     - makedirs: True
 
 
+iperfd_service_add_reload_systemd:
+  cmd.run:
+    - name: systemctl daemon-reload
+    - watch:
+      - file: /usr/lib/systemd/system/iperfd.service
+
+
 iperd_running:
   service.running:
-    - enable: True
     - name : iperfd
     - running: True

--- a/srv/salt/ceph/iperf/remove.sls
+++ b/srv/salt/ceph/iperf/remove.sls
@@ -1,10 +1,16 @@
 iperd_stopped:
-  service.running:
+  service.dead:
     - enable: False
     - name : iperfd
-    - running: False
 
 
 iperfd_service_remove:
   file.absent:
     - name : /usr/lib/systemd/system/iperfd.service
+
+
+iperfd_service_remove_reload_systemd:
+  cmd.run:
+    - name: systemctl daemon-reload
+    - watch:
+      - file: /usr/lib/systemd/system/iperfd.service


### PR DESCRIPTION
The cleanup of iperf3 tests was not working correctly.

If you ran the iperf3 tests in parallel systemd could refuse to start iperf3 as a service.
