### PR TITLE
Wip remove local includes

### DIFF
--- a/srv/salt/ceph/iperf/init.sls
+++ b/srv/salt/ceph/iperf/init.sls
@@ -1,5 +1,5 @@
 include:
-    - .packages
+    - ceph.iperf.packages
 
 
 iperfd_service_add:

--- a/srv/salt/ceph/iperf/packages.sls
+++ b/srv/salt/ceph/iperf/packages.sls
@@ -1,4 +1,4 @@
 include:
 {% if grains['os_family'] == 'Suse' %}
-    - .packages-suse
+    - ceph.iperf.packages-suse
 {% endif %}


### PR DESCRIPTION
Use absolute includes

Older salt versions need absolute include paths

Signed-off-by: Owen Synge osynge@suse.com
