### PR TITLE
Wip nettest support long minion

### DIFF
--- a/srv/salt/ceph/diagnose/iperf3.sls
+++ b/srv/salt/ceph/diagnose/iperf3.sls
@@ -1,11 +1,11 @@
-{% for host in salt.saltutil.runner('select.minions', cluster='ceph', host=True) %}
+{% for host in salt.saltutil.runner('select.minions', cluster='ceph', host=False) %}
 iperf_server_start {{ host }}:
   salt.state:
     - tgt: {{ host }}
     - sls: ceph.iperf
 {% endfor %}
 
-{% for host_addr in salt.saltutil.runner('nettest.minion_link_ipv4', cluster='ceph', host=True) %}
+{% for host_addr in salt.saltutil.runner('nettest.minion_link_ipv4', cluster='ceph', host=False) %}
 {% set host = host_addr[0] %}
 {% set addr = host_addr[1] %}
 iperf3 {{ host_addr }}:
@@ -16,7 +16,7 @@ iperf3 {{ host_addr }}:
       - 'iperf3 -c {{ addr }} -f m -t 10 -P 1'
 {% endfor %}
 
-{% for host in salt.saltutil.runner('select.minions', cluster='ceph', host=True) %}
+{% for host in salt.saltutil.runner('select.minions', cluster='ceph', host=False) %}
 iperf_server_end {{ host }}:
   salt.state:
     - tgt: {{ host }}

--- a/srv/salt/ceph/diagnose/ping.sls
+++ b/srv/salt/ceph/diagnose/ping.sls
@@ -1,4 +1,4 @@
-{% for host_addr in salt.saltutil.runner('nettest.minion_link_ipv4', cluster='ceph', host=True) %}
+{% for host_addr in salt.saltutil.runner('nettest.minion_link_ipv4', cluster='ceph', host=False) %}
 {% set host = host_addr[0] %}
 {% set addr = host_addr[1] %}
 iperf3 {{ host_addr }}:


### PR DESCRIPTION
Minion id's are needed not short id's

To support minion id's correctly rather than use short names, we must use the
'host=False' argument.

Signed-off-by: Owen Synge osynge@suse.com
