### PR TITLE
spec: require salt-minion

### DIFF
--- a/deepsea.spec
+++ b/deepsea.spec
@@ -30,6 +30,7 @@ Source0:        deepsea-%{version}.tar.gz
 
 BuildRequires:  salt-master
 Requires:       salt-master
+Requires:       salt-minion
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 BuildArch:      noarch
 


### PR DESCRIPTION
DeepSea needs the salt master to also be a salt minion.
May as well make this easy for people and add salt-minion to
the Requires in the spec file.

Signed-off-by: Tim Serong <tserong@suse.com>