### PR TITLE
Fix runner parameter names in newer salt version (Boron)

### DIFF
--- a/srv/modules/runners/ready.py
+++ b/srv/modules/runners/ready.py
@@ -76,16 +76,16 @@ class Checks(object):
             print "{:25}: {}{}{}{}".format(attr, bcolors.BOLD, bcolors.WARNING, self.warnings[attr], bcolors.ENDC)
 
 
-def check(name, fail_on_warning=True, **kwargs):
+def check(cluster, fail_on_warning=True, **kwargs):
     """
     Check a cluster for runtime configurations that may cause issues for an
     installation.
     """
-    if name == None:
-        name = kwargs['name']
+    if cluster is None:
+        cluster = kwargs['cluster']
 
     # Restrict search to this cluster
-    search = "I@cluster:{}".format(name)
+    search = "I@cluster:{}".format(cluster)
 
     c = Checks(search)
     c.firewall()

--- a/srv/modules/runners/validate.py
+++ b/srv/modules/runners/validate.py
@@ -545,8 +545,8 @@ class Validate(object):
         self.printer.add(self.name, self.passed, self.errors)
 
 def usage():
-    print "salt-run validate.pillar cluster"
-    print "salt-run validate.pillar name=cluster"
+    print "salt-run validate.pillar cluster_name"
+    print "salt-run validate.pillar cluster=cluster_name"
     print "salt-run validate.pillars"
 
 
@@ -565,7 +565,7 @@ def pillars(**kwargs):
     printer.print_result()
 
 
-def pillar(name = None, printer=None, **kwargs):
+def pillar(cluster = None, printer=None, **kwargs):
     """
     Check that the pillar for each cluster meets the requirements to install
     a Ceph cluster.
@@ -574,19 +574,19 @@ def pillar(name = None, printer=None, **kwargs):
     if not has_printer:
         printer = get_printer(**kwargs)
 
-    if not name:
+    if not cluster:
         usage()
         exit(1)
 
     local = salt.client.LocalClient()
 
     # Restrict search to this cluster
-    search = "I@cluster:{}".format(name)
+    search = "I@cluster:{}".format(cluster)
 
     pillar_data = local.cmd(search , 'pillar.items', [], expr_form="compound")
     grains_data = local.cmd(search , 'grains.items', [], expr_form="compound")
 
-    v = Validate(name, pillar_data, grains_data, printer)
+    v = Validate(cluster, pillar_data, grains_data, printer)
     v.fsid()
     v.public_network()
     v.public_interface()

--- a/srv/salt/ceph/stage/deploy/default.sls
+++ b/srv/salt/ceph/stage/deploy/default.sls
@@ -1,7 +1,7 @@
 
 {% set FAIL_ON_WARNING = salt['pillar.get']('FAIL_ON_WARNING', 'True') %}
 
-{% if salt['saltutil.runner']('ready.check', name='ceph', fail_on_warning=FAIL_ON_WARNING)  == False %}
+{% if salt['saltutil.runner']('ready.check', cluster='ceph', fail_on_warning=FAIL_ON_WARNING)  == False %}
 ready check failed:
   salt.state:
     - name: "Fail on Warning is True"
@@ -18,7 +18,7 @@ ready check failed:
 {# Until return codes fail correctly and the above can be uncommented, #}
 {# rely on the side effect of the runner printing its output and failing #}
 {# on a bogus state #}
-{% if salt['saltutil.runner']('validate.pillar', name='ceph') == False %}
+{% if salt['saltutil.runner']('validate.pillar', cluster='ceph') == False %}
 validate failed:
   salt.state:
     - name: just.exit


### PR DESCRIPTION
The first parameter of a runner function cannot be named "name",
as it is used internally by salt.

Fixes: #50

Signed-off-by: Ricardo Dias <rdias@suse.com>