### PR TITLE
Adding nfs-ganesha state for cephfs in deepsea

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,13 @@ install:
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/diagnose
 	install -m 644 srv/salt/ceph/diagnose/*.md $(DESTDIR)/srv/salt/ceph/diagnose
 	install -m 644 srv/salt/ceph/diagnose/*.sls $(DESTDIR)/srv/salt/ceph/diagnose
+	# state files - ganesha
+	install -d -m 755 $(DESTDIR)/srv/salt/ceph/ganesha
+	install -m 644 srv/salt/ceph/ganesha/*.sls $(DESTDIR)/srv/salt/ceph/ganesha/
+	install -d -m 755 $(DESTDIR)/srv/salt/ceph/ganesha/configure
+	install -m 644 srv/salt/ceph/ganesha/configure/*.sls $(DESTDIR)/srv/salt/ceph/ganesha/configure/
+	install -d -m 755 $(DESTDIR)/srv/salt/ceph/ganesha/install
+	install -m 644 srv/salt/ceph/ganesha/install/*.sls $(DESTDIR)/srv/salt/ceph/ganesha/install/
 	# state files - igw
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/igw
 	install -m 644 srv/salt/ceph/igw/*.sls $(DESTDIR)/srv/salt/ceph/igw/
@@ -258,6 +265,8 @@ install:
 	install -m 644 srv/salt/ceph/stage/deploy/*.sls $(DESTDIR)/srv/salt/ceph/stage/deploy/
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/stage/discovery
 	install -m 644 srv/salt/ceph/stage/discovery/*.sls $(DESTDIR)/srv/salt/ceph/stage/discovery/
+	install -d -m 755 $(DESTDIR)/srv/salt/ceph/stage/ganesha
+	install -m 644 srv/salt/ceph/stage/ganesha/*.sls $(DESTDIR)/srv/salt/ceph/stage/ganesha/
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/stage/iscsi
 	install -m 644 srv/salt/ceph/stage/iscsi/*.sls $(DESTDIR)/srv/salt/ceph/stage/iscsi/
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/stage/openattic

--- a/deepsea.spec
+++ b/deepsea.spec
@@ -81,6 +81,9 @@ systemctl try-restart salt-master > /dev/null 2>&1 || :
 %dir /srv/salt/ceph/configuration/check
 %dir /srv/salt/ceph/diagnose
 %dir /srv/salt/ceph/events
+%dir /srv/salt/ceph/ganesha
+%dir /srv/salt/ceph/ganesha/configure
+%dir /srv/salt/ceph/ganesha/install
 %dir /srv/salt/ceph/igw
 %dir /srv/salt/ceph/igw/config
 %dir /srv/salt/ceph/igw/files
@@ -165,6 +168,7 @@ systemctl try-restart salt-master > /dev/null 2>&1 || :
 %dir /srv/salt/ceph/stage/deploy
 %dir /srv/salt/ceph/stage/discovery
 %dir /srv/salt/ceph/stage/iscsi
+%dir /srv/salt/ceph/stage/ganesha
 %dir /srv/salt/ceph/stage/openattic
 %dir /srv/salt/ceph/stage/prep
 %dir /srv/salt/ceph/stage/prep/master
@@ -202,6 +206,9 @@ systemctl try-restart salt-master > /dev/null 2>&1 || :
 /srv/salt/ceph/diagnose/README.md
 %config /srv/salt/ceph/diagnose/*.sls
 %config /srv/salt/ceph/events/*.sls
+%config /srv/salt/ceph/ganehsa/*.sls
+%config /srv/salt/ceph/ganehsa/configure/*.sls
+%config /srv/salt/ceph/ganehsa/install/*.sls
 %config /srv/salt/ceph/igw/*.sls
 %config /srv/salt/ceph/igw/files/*.j2
 %config /srv/salt/ceph/igw/config/*.sls
@@ -291,6 +298,7 @@ systemctl try-restart salt-master > /dev/null 2>&1 || :
 %config /srv/salt/ceph/stage/deploy/*.sls
 %config /srv/salt/ceph/stage/discovery/*.sls
 %config /srv/salt/ceph/stage/iscsi/*.sls
+%config /srv/salt/ceph/stage/ganesha/*.sls
 %config /srv/salt/ceph/stage/openattic/*.sls
 %config /srv/salt/ceph/stage/prep/*.sls
 %config /srv/salt/ceph/stage/prep/master/*.sls

--- a/srv/modules/runners/populate.py
+++ b/srv/modules/runners/populate.py
@@ -499,7 +499,7 @@ class CephRoles(object):
         Create role named directories and create corresponding yaml files
         for every server.
         """
-        roles = [ 'admin', 'mon', 'storage', 'mds', 'igw' ] + self._rgw_configurations()
+        roles = [ 'admin', 'mon', 'storage', 'mds', 'igw', 'ganesha' ] + self._rgw_configurations()
         self.available_roles.extend(roles)
 
         for role in roles:
@@ -575,6 +575,19 @@ class CephRoles(object):
         Note: identical to above
         """
         minion_dir = "{}/role-igw/stack/default/{}/minions".format(self.root_dir, self.cluster)
+        if not os.path.isdir(minion_dir):
+            create_dirs(minion_dir, self.root_dir)
+        for server in self.servers:
+            filename = minion_dir + "/" +  server + ".yml"
+            contents = {}
+            contents['public_address'] = self._public_interface(server)
+            self.writer.write(filename, contents)
+
+    def ganesha_members(self):
+        """
+        Create a file for ganesha hosts.
+        """
+        minion_dir = "{}/role-ganesha/stack/default/{}/minions".format(self.root_dir, self.cluster)
         if not os.path.isdir(minion_dir):
             create_dirs(minion_dir, self.root_dir)
         for server in self.servers:
@@ -822,6 +835,6 @@ def proposals(**kwargs):
         ceph_roles.cluster_config()
         ceph_roles.monitor_members()
         ceph_roles.igw_members()
-
+        ceph_roles.ganesha_members()
     return [ True ]
 

--- a/srv/salt/ceph/ganesha/configure/default.sls
+++ b/srv/salt/ceph/ganesha/configure/default.sls
@@ -1,0 +1,11 @@
+
+/etc/ganesha/ganesha.conf:
+  file.rename:
+  - name: /etc/ganesha/ganesha.conf.orig
+  - source: /etc/ganesha/ganesha.conf
+
+/etc/ganesha/ceph.conf:
+  file.symlink:
+  - name: /etc/ganesha/ganesha.conf
+  - target: /etc/ganesha/ceph.conf
+  - force: True

--- a/srv/salt/ceph/ganesha/configure/init.sls
+++ b/srv/salt/ceph/ganesha/configure/init.sls
@@ -1,0 +1,4 @@
+
+
+include:
+  - .{{ salt['pillar.get']('ganesha_configure', 'default') }}

--- a/srv/salt/ceph/ganesha/default.sls
+++ b/srv/salt/ceph/ganesha/default.sls
@@ -1,0 +1,20 @@
+
+nfs:
+  cmd.run:
+    - name: "systemctl start nfs "
+    - shell: /bin/bash
+rpc:
+  cmd.run:
+    - name: "systemctl start rpcbind "
+    - shell: /bin/bash
+
+rpc-statd:
+  cmd.run:
+    - name: "systemctl start rpc-statd "
+    - shell: /bin/bash
+
+ganesha:
+  cmd.run:
+    - name: "systemctl start nfs-ganesha"
+    - shell: /bin/bash
+

--- a/srv/salt/ceph/ganesha/init.sls
+++ b/srv/salt/ceph/ganesha/init.sls
@@ -1,0 +1,4 @@
+
+
+include:
+  - .{{ salt['pillar.get']('ganesha_service', 'default') }}

--- a/srv/salt/ceph/ganesha/install/default.sls
+++ b/srv/salt/ceph/ganesha/install/default.sls
@@ -1,0 +1,5 @@
+
+ganesha:
+  cmd.run:
+    - name: "zypper --non-interactive in nfs-ganesha nfs-ganesha-ceph "
+    - shell: /bin/bash

--- a/srv/salt/ceph/ganesha/install/init.sls
+++ b/srv/salt/ceph/ganesha/install/init.sls
@@ -1,0 +1,4 @@
+
+
+include:
+  - .{{ salt['pillar.get']('ganesha_install', 'default') }}

--- a/srv/salt/ceph/stage/ganesha/default.sls
+++ b/srv/salt/ceph/stage/ganesha/default.sls
@@ -1,0 +1,18 @@
+
+ganesha install:
+  salt.state:
+    - tgt: "I@roles:ganesha and I@cluster:ceph"
+    - tgt_type: compound
+    - sls: ceph.ganesha.install
+
+ganesha configure:
+  salt.state:
+    - tgt: "I@roles:ganesha and I@cluster:ceph"
+    - tgt_type: compound
+    - sls: ceph.ganesha.configure
+
+ganesha service:
+  salt.state:
+    - tgt: "I@roles:ganesha and I@cluster:ceph"
+    - tgt_type: compound
+    - sls: ceph.ganesha

--- a/srv/salt/ceph/stage/ganesha/init.sls
+++ b/srv/salt/ceph/stage/ganesha/init.sls
@@ -1,0 +1,3 @@
+
+include:
+  - .{{ salt['pillar.get']('ganesha_service', 'default') }}


### PR DESCRIPTION
In this commit: 
- Role "ganesha" is defined. Currently it is defined only for cephfs not for rgw. 
- nfs-ganesha and other packages required to run ganesha service is installed on the minion with ganesha role.
- nfs-Ganesha and nfs-ganesha-ceph package installs two conf files "ganesha.conf" and "ceph.conf" at /etc/ganesha. systemctl by default use ganesha.conf. Hence, we create a symlink for ceph.conf. 

Its still WIP. It requires at least the following changes to make it complete: 
- Better error and state handling.
- Adding more fields in ceph.conf for better flexibility
- Checking if cephfs is mounted on the server acting as nfs-ganesha server before doing anything else.
- Understanding if to extend this code further for rgw or to define a completely new role. 

Attaching two docs on how to manually setup nfs-ganesha for cephfs and rgw (the steps we are trying to automate).
[Nfs-Ganesha-CephFS.pdf](https://github.com/SUSE/DeepSea/files/619042/Nfs-Ganesha-CephFS.pdf)
[NFS-Ganesha_RGW.pdf](https://github.com/SUSE/DeepSea/files/619041/NFS-Ganesha_RGW.pdf)

