### PR TITLE
stage 0: fix system update and restart procedure

### DIFF
--- a/srv/salt/ceph/updates/default.sls
+++ b/srv/salt/ceph/updates/default.sls
@@ -6,14 +6,4 @@ zypper update:
     - shell: /bin/bash
     - unless: "zypper lu | grep -sq 'No updates found'"
 
-kernel update:
-  cmd.run:
-    - name: "zypper --non-interactive --no-gpg-checks up kernel-default"
-    - shell: /bin/bash
-    - unless: "zypper info kernel-default | grep -q '^Status: up-to-date'"
-    - fire_event: True
-
-
-
-
 

--- a/srv/salt/ceph/updates/restart/default.sls
+++ b/srv/salt/ceph/updates/restart/default.sls
@@ -1,24 +1,29 @@
-
-
-{% set kernel = grains['kernelrelease'] | replace('-default', '')  %}
-{% set installed = salt['cmd.run']('rpm -q --last kernel-default | head -1 | cut -f1 -d\  ') | replace('kernel-default-', '') %}
+{% set kernel_version = grains['kernelrelease'] | replace('-default', '')  %}
+{% set cmd_kernel_package = ['zypper search -s "kernel-" | grep "^i" | grep "',
+                             kernel_version, '" | cut -d"|" -f2'] | join
+%}
+{% set kernel_package = salt['cmd.run'](cmd_kernel_package) | trim %}
+{% set cmd_installed = ['rpm -q --last ', kernel_package,
+                        ' | head -1 | cut -f1 -d\  '] | join
+%}
+{% set installed = salt['cmd.run'](cmd_installed) |
+                   replace([kernel_package, '-'] | join, '') | trim
+%}
 
 
 warning:
   module.run:
     - name: advise.reboot
-    - running: {{ kernel }}
+    - running: {{ kernel_version }}
     - installed: {{ installed }}
-    - unless: "echo {{ installed }} | grep -q {{ kernel }}"
+    - unless: "echo {{ installed }} | grep -q {{ kernel_version }}"
 
 
 reboot:
   cmd.run:
     - name: "shutdown -r now"
     - shell: /bin/bash
-    - unless: "echo {{ installed }} | grep -q {{ kernel }}"
+    - unless: "echo {{ installed }} | grep -q {{ kernel_version }}"
     - failhard: True
     - fire_event: True
-
-
 


### PR DESCRIPTION
Fixes: #61

In this patch we remove the explicit `kernel-default` update procedure -- all system packages are updated by `zypper upgrade`.
Fixes the restart detection to work with any kernel package installed.

Signed-off-by: Ricardo Dias <rdias@suse.com>