### PR TITLE
rpm: add python-ipaddress to the rpm requires

### DIFF
--- a/deepsea.spec
+++ b/deepsea.spec
@@ -31,6 +31,7 @@ Source0:        deepsea-%{version}.tar.gz
 BuildRequires:  salt-master
 Requires:       salt-master
 Requires:       salt-minion
+Requires:       python-ipaddress
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 BuildArch:      noarch
 


### PR DESCRIPTION
We use ipaddress python module in validate, while it might be installed
in many systems there is no explicit requires and it would lead to
interesting failures if not installed

Signed-off-by: Abhishek Lekshmanan <abhishek@suse.com>