### PR TITLE
stage 1,3: support for multiple public/cluster networks

### DIFF
--- a/tests/unit/_modules/test_validate.py
+++ b/tests/unit/_modules/test_validate.py
@@ -50,3 +50,15 @@ class TestClusterAssignment():
         assert len(cluster.names) == 2
         assert set(cluster.names['ceph']) == set(["minionA","minionD"])
         assert set(cluster.names['kraken']) == set(["minionB","minionE"])
+
+
+class TestUtilMethods():
+    def test_parse_empty_string_list(self):
+        assert validate.Util.parse_list_from_string("", ",") == []
+
+    def test_parse_single_element_string_list(self):
+        assert validate.Util.parse_list_from_string("1", ",") == ['1']
+
+    def test_parse_string_list(self):
+        list_str = "1, 4     ,   5, , 7"
+        assert validate.Util.parse_list_from_string(list_str, ",") == ['1', '4', '5', '7']


### PR DESCRIPTION
The purpose of this patch is to generalize the public/cluster network Ceph config option to support more than one network, as discussed in http://lists.suse.com/pipermail/deepsea-users/2016-December/000022.html

The algorithm for assigning the public/cluster networks work as follows:

1. assign the network with more hosts as public network
2. assign the second network with more hosts (but with at least 2 hosts) as cluster network
3. any network with a single host is assigned as a public network
4. in the end, if cluster network does not have any assignment than it inherits the same networks as the public network

Signed-off-by: Ricardo Dias <rdias@suse.com>