### PR TITLE
rgw: import Set is deprecated, use builtin instead

### DIFF
--- a/srv/salt/_modules/rgw.py
+++ b/srv/salt/_modules/rgw.py
@@ -1,6 +1,5 @@
 #!/usr/bin/python
 
-from sets import Set
 import salt.config
 
 def configurations():
@@ -13,8 +12,8 @@ def configurations():
     """
     if 'roles' in __pillar__:
         if 'rgw_configurations' in __pillar__:
-            return list(Set(__pillar__['rgw_configurations']) &
-                        Set(__pillar__['roles']))
+            return list(set(__pillar__['rgw_configurations']) &
+                        set(__pillar__['roles']))
         if 'rgw' in __pillar__['roles']:
             return [ 'rgw' ]
     return []


### PR DESCRIPTION
use the `set` builtin instead of the `import Set` which was only around
for the older python 2.6 days. Also minions report a warning otherwise.
`DeprecationWarning: the sets module is deprecated
  from sets import Set`

Signed-off-by: Abhishek Lekshmanan <abhishek@suse.com>