### PR TITLE
Disable unsupported kernel features for rbd images

### DIFF
--- a/srv/salt/ceph/configuration/files/ceph.conf-shared.j2
+++ b/srv/salt/ceph/configuration/files/ceph.conf-shared.j2
@@ -8,6 +8,7 @@ auth_client_required = cephx
 filestore_xattr_use_omap = true
 public_network = {{ salt['pillar.get']('public_network') }}
 cluster_network = {{ salt['pillar.get']('cluster_network') }}
+rbd default features = 3
 
 {% if 'rgw' in salt['pillar.get']('roles', []) %}
 {% set default_rgw = [ 'rgw' ] %}

--- a/srv/salt/ceph/configuration/files/ceph.conf.j2
+++ b/srv/salt/ceph/configuration/files/ceph.conf.j2
@@ -8,6 +8,7 @@ auth_client_required = cephx
 filestore_xattr_use_omap = true
 public_network = {{ salt['pillar.get']('public_network') }}
 cluster_network = {{ salt['pillar.get']('cluster_network') }}
+rbd default features = 3
 
 {% for config in salt['rgw.configurations']() %}
 {% set client = config + "." + grains['host'] %}


### PR DESCRIPTION
With the SES5 repo and kernel 4.4.38-93-default, iSCSI gateways fail to configure with the demo image.  Set rbd images to currently supported features.

Signed-off-by: Eric Jackson <ejackson@suse.com>