### PR TITLE
rpm: add hwinfo to requires

### DIFF
--- a/deepsea.spec
+++ b/deepsea.spec
@@ -32,6 +32,7 @@ BuildRequires:  salt-master
 Requires:       salt-master
 Requires:       salt-minion
 Requires:       python-ipaddress
+Requires:       hwinfo
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 BuildArch:      noarch
 


### PR DESCRIPTION
We use hwinfo in stage1, in cephdisks module. Adding an explicit
requirement so that we install hwinfo with deepsea itself

Signed-off-by: Abhishek Lekshmanan <abhishek@suse.com>