### PR TITLE
stage3: don't do time sync if not configured

### DIFF
--- a/srv/salt/ceph/stage/deploy/default.sls
+++ b/srv/salt/ceph/stage/deploy/default.sls
@@ -28,11 +28,13 @@ validate failed:
 {% endif %}
 
 
+{% if salt['pillar.get']('time_service') != "disabled" %}
 time:
   salt.state:
     - tgt: 'I@cluster:ceph'
     - tgt_type: compound
     - sls: ceph.time
+{% endif %}
 
 packages:
   salt.state:


### PR DESCRIPTION
Currently if time service is set to disabled we still call ceph.time
which tries to sync to the configured ntp server (default master), and
we fail since the time server was disabled, there wouldn't be an ntp
server in master, the other option of actually creating a no op sls file
seems counterintuitive to the validate check and global option of
setting a value to disabled.

Fixes: #102
Signed-off-by: Abhishek Lekshmanan <abhishek@suse.com>