### PR TITLE
populate: dont use double underscored functions from outside

### DIFF
--- a/srv/modules/runners/populate.py
+++ b/srv/modules/runners/populate.py
@@ -131,7 +131,7 @@ class CephStorage(object):
         """
         model_dir = "{}/{}/stack/default/{}/minions".format(self.root_dir, name, self.cluster)
         if not os.path.isdir(model_dir):
-            __create_dirs(model_dir, self.root_dir)
+            _create_dirs(model_dir, self.root_dir)
         filename = model_dir + "/" +  server + ".yml"
         contents = { 'storage': storage }
         self.writer.write(filename, contents)
@@ -142,7 +142,7 @@ class CephStorage(object):
         """
         cluster_dir = "{}/{}/cluster".format(self.root_dir, name)
         if not os.path.isdir(cluster_dir):
-            __create_dirs(cluster_dir, self.root_dir)
+            _create_dirs(cluster_dir, self.root_dir)
         #filename = cluster_dir + "/" +  server.split('.')[0] + ".sls"
         filename = cluster_dir + "/" +  server + ".sls"
         contents = {}
@@ -505,7 +505,7 @@ class CephRoles(object):
         for role in roles:
             role_dir = "{}/role-{}".format(self.root_dir, role)
             if not os.path.isdir(role_dir):
-                __create_dirs(role_dir, self.root_dir)
+                _create_dirs(role_dir, self.root_dir)
 
             # All minions are not necessarily storage - see CephStorage
             if role != 'storage':
@@ -548,7 +548,7 @@ class CephRoles(object):
         """
         cluster_dir = role_dir + "/cluster"
         if not os.path.isdir(cluster_dir):
-            __create_dirs(cluster_dir, self.root_dir)
+            _create_dirs(cluster_dir, self.root_dir)
         for server in self.servers:
             filename = cluster_dir + "/" +  server + ".sls"
             contents = {}
@@ -580,7 +580,7 @@ class CephRoles(object):
 
     def _add_pub_interface(self, minion_dir):
         if not os.path.isdir(minion_dir):
-            __create_dirs(minion_dir, self.root_dir)
+            _create_dirs(minion_dir, self.root_dir)
         for server in self.servers:
             filename = minion_dir + "/" +  server + ".yml"
             contents = {}
@@ -606,7 +606,7 @@ class CephRoles(object):
         if self.cluster:
             cluster_dir = "{}/config/stack/default/{}".format(self.root_dir, self.cluster)
             if not os.path.isdir(cluster_dir):
-                 __create_dirs(cluster_dir, self.root_dir)
+                 _create_dirs(cluster_dir, self.root_dir)
             filename = "{}/cluster.yml".format(cluster_dir)
             contents = {}
             contents['fsid'] = str(uuid.uuid3(uuid.NAMESPACE_DNS, os.urandom(32)))
@@ -733,7 +733,7 @@ class CephCluster(object):
             for minion in self.minions:
                 cluster_dir = "{}/cluster-{}/cluster".format(self.root_dir, cluster)
                 if not os.path.isdir(cluster_dir):
-                     __create_dirs(cluster_dir, self.root_dir)
+                     _create_dirs(cluster_dir, self.root_dir)
                 filename = "{}/{}.sls".format(cluster_dir, minion)
                 contents = {}
                 contents['cluster'] = cluster
@@ -746,7 +746,7 @@ class CephCluster(object):
         """
         stack_dir = "{}/config/stack/default".format(self.root_dir)
         if not os.path.isdir(stack_dir):
-             __create_dirs(stack_dir, self.root_dir)
+             _create_dirs(stack_dir, self.root_dir)
         filename = "{}/global.yml".format(stack_dir)
         contents = {}
         contents['time_server'] = '{{ pillar.get("master_minion") }}'
@@ -754,7 +754,7 @@ class CephCluster(object):
 
         self.writer.write(filename, contents)
 
-def __create_dirs(path, root):
+def _create_dirs(path, root):
     try:
         os.makedirs(path)
     except OSError as err:

--- a/srv/modules/runners/push.py
+++ b/srv/modules/runners/push.py
@@ -72,7 +72,7 @@ def proposal(filename = "/srv/pillar/ceph/proposals/policy.cfg", dryrun = False)
     pillar_data.output(common)
     return True
 
-def __create_dirs(path, root):
+def _create_dirs(path, root):
     try:
         os.makedirs(path)
     except OSError as err:
@@ -145,7 +145,7 @@ class PillarData(object):
         """
         path_dir = os.path.dirname(filename)
         if not os.path.isdir(path_dir):
-            __create_dirs(path_dir, self.pillar_dir)
+            _create_dirs(path_dir, self.pillar_dir)
         log.info("Writing {}".format(filename))
         if not self.dryrun:
             with open(filename, "w") as yml:
@@ -159,7 +159,7 @@ class PillarData(object):
         """
         path_dir = os.path.dirname(custom)
         if not os.path.isdir(path_dir):
-            __create_dirs(path_dir, self.pillar_dir)
+            _create_dirs(path_dir, self.pillar_dir)
         if not self.dryrun:
             if not os.path.isfile(custom):
                 log.info("Writing {}".format(custom))


### PR DESCRIPTION
Since python mangles anything inside a class with a double underscore
assuming private methods these would again raise NameErrors.

As an example:

```py
In [1]: def __foo():
   ...:     return 1
   ...:

In [2]: class A():
   ...:     def __init__(self):
   ...:         self.a = 1
   ...:     def bar(self):
   ...:         return __foo() + self.a
   ...:

In [3]: a = A()

In [4]: a.bar()
---------------------------------------------------------------------------
NameError                                 Traceback (most recent call last)
<ipython-input-4-4b57aad064bc> in <module>()
----> 1 a.bar()

<ipython-input-2-4bba0c494767> in bar(self)
      3         self.a = 1
      4     def bar(self):
----> 5         return __foo() + self.a
      6

NameError: global name '_A__foo' is not defined
```

Signed-off-by: Abhishek Lekshmanan <abhishek@suse.com>