### PR TITLE
stage1: fix the creation of ganesha role directory

### DIFF
--- a/srv/modules/runners/populate.py
+++ b/srv/modules/runners/populate.py
@@ -611,7 +611,7 @@ class CephRoles(object):
         """
         minion_dir = "{}/role-ganesha/stack/default/{}/minions".format(self.root_dir, self.cluster)
         if not os.path.isdir(minion_dir):
-            create_dirs(minion_dir, self.root_dir)
+            _create_dirs(minion_dir, self.root_dir)
         for server in self.servers:
             filename = minion_dir + "/" +  server + ".yml"
             contents = {}


### PR DESCRIPTION
In the populate.py module runner, the creation of the ganesha role directory was using the missing `create_dirs` function, which was renamed to `_create_dirs` in a recent PR.

Signed-off-by: Ricardo Dias <rdias@suse.com>