### PR TITLE
cherrypy: add state files to Makefile and RPM spec files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -132,6 +132,11 @@ install:
 	install -m 644 srv/salt/ceph/mds/files/*.j2 $(DESTDIR)/srv/salt/ceph/mds/files/
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/mds/restart
 	install -m 644 srv/salt/ceph/mds/restart/*.sls $(DESTDIR)/srv/salt/ceph/mds/restart
+	# state files - salt-api
+	install -d -m 755 $(DESTDIR)/srv/salt/ceph/cherrypy
+	install -m 644 srv/salt/ceph/cherrypy/*.sls $(DESTDIR)/srv/salt/ceph/cherrypy
+	install -d -m 755 $(DESTDIR)/srv/salt/ceph/cherrypy/files
+	install -m 644 srv/salt/ceph/cherrypy/files/*.conf* $(DESTDIR)/srv/salt/ceph/cherrypy/files
 
 	# state files - mines
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/mines

--- a/deepsea.spec
+++ b/deepsea.spec
@@ -77,6 +77,8 @@ systemctl try-restart salt-master > /dev/null 2>&1 || :
 %dir /srv/salt/ceph/cephfs
 %dir /srv/salt/ceph/cephfs/benchmarks
 %dir /srv/salt/ceph/cephfs/benchmarks/files
+%dir /srv/salt/ceph/cherrypy
+%dir /srv/salt/ceph/cherrypy/files
 %dir /srv/salt/ceph/configuration
 %dir /srv/salt/ceph/configuration/files
 %dir /srv/salt/ceph/configuration/check
@@ -211,6 +213,8 @@ systemctl try-restart salt-master > /dev/null 2>&1 || :
 %config /srv/salt/ceph/benchmarks/*.sls
 %config /srv/salt/ceph/cephfs/benchmarks/*.sls
 %config /srv/salt/ceph/cephfs/benchmarks/files/fio.service
+%config /srv/salt/ceph/cherrypy/*.sls
+%config /srv/salt/ceph/cherrypy/files/*.conf*
 %config /srv/salt/ceph/configuration/*.sls
 %config /srv/salt/ceph/configuration/check/*.sls
 %config /srv/salt/ceph/configuration/files/ceph.conf*


### PR DESCRIPTION
Adding state files to the Makefile (and RPM spec file), to allow the installation and usage of the salt-api.

Signed-off-by: Ricardo Dias <rdias@suse.com>