### PR TITLE
Makefile: add hint to restart salt-master

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -333,12 +333,15 @@ install:
 	ln -sf services		$(DESTDIR)/srv/salt/ceph/stage/4
 	ln -sf removal		$(DESTDIR)/srv/salt/ceph/stage/5
 
+        ##### Please restart you salt-master before using DeepSea...
+        ##### systemctl restart salt-master
+
 
 rpm: tarball
 	rpmbuild -bb deepsea.spec
 
 # Removing test dependency until resolved
-tarball: 
+tarball:
 	VERSION=`awk '/^Version/ {print $$2}' deepsea.spec`; \
 	git archive --prefix deepsea-$$VERSION/ -o ~/rpmbuild/SOURCES/deepsea-$$VERSION.tar.gz HEAD
 


### PR DESCRIPTION
Ran into this more then once. Its not obvious after installing via make install, since it half works but salt-master doesn't pick up the stack.cfg. This becomes a problem after stage 2.

Signed-off-by: Jan Fajerski <jfajerski@suse.com>