### PR TITLE
Makefile/spec: complete installation with make and rpm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ usage:
 	@echo -e "\tmake install\tInstall DeepSea on this host"
 	@echo -e "\tmake rpm\tBuild an RPM for installation elsewhere"
 
-install:
+copy-files:
 	# salt-master config files
 	install -d -m 755 $(DESTDIR)/etc/salt/master.d
 	install -m 644 etc/salt/master.d/modules.conf $(DESTDIR)/etc/salt/master.d/
@@ -338,6 +338,10 @@ install:
 	ln -sf services		$(DESTDIR)/srv/salt/ceph/stage/4
 	ln -sf removal		$(DESTDIR)/srv/salt/ceph/stage/5
 
+install: copy-files
+	sed -i '/^master_minion:/s!_REPLACE_ME_!'`hostname -f`'!' /srv/pillar/ceph/master_minion.sls
+	chown -R salt /srv/pillar/ceph
+	systemctl restart salt-master
 
 rpm: tarball
 	rpmbuild -bb deepsea.spec

--- a/deepsea.spec
+++ b/deepsea.spec
@@ -45,11 +45,13 @@ A collection of Salt files providing a deployment of Ceph as a series of stages.
 %build
 
 %install
-make DESTDIR=%{buildroot} install
+make DESTDIR=%{buildroot} copy-files
 
 %post
 # Initialize to most likely value
 sed -i '/^master_minion:/s!_REPLACE_ME_!'`hostname -f`'!' /srv/pillar/ceph/master_minion.sls
+# change owner to salt, so deepsea can create proposals
+chown -R salt /srv/pillar/ceph
 # Restart salt-master if it's running, so it picks up
 # the config changes in /etc/salt/master.d/modules.conf
 systemctl try-restart salt-master > /dev/null 2>&1 || :


### PR DESCRIPTION
Until now the Makefile only copied files to the correct location.
Further steps were necessary to get a functional installation. This
commit adds the necessary step while keeping the build process working.
Also a chown was added to the rpm's post section to complete
installation.

Signed-off-by: Jan Fajerski <jfajerski@suse.com>