### PR TITLE
mds/pools: create cephfs pools with smallest recommended pg_count

### DIFF
--- a/srv/salt/ceph/mds/pools/default.sls
+++ b/srv/salt/ceph/mds/pools/default.sls
@@ -9,12 +9,12 @@ prevent empty rendering:
 
 cephfs data:
   cmd.run:
-    - name: "ceph osd pool create cephfs_data 256"
+    - name: "ceph osd pool create cephfs_data 128"
     - unless: "rados lspools | grep -q cephfs_data"
 
 cephfs metadata:
   cmd.run:
-    - name: "ceph osd pool create cephfs_metadata 256"
+    - name: "ceph osd pool create cephfs_metadata 128"
     - unless: "rados lspools | grep -q cephfs_metadata"
 
 cephfs:


### PR DESCRIPTION
This should be adequate for even the smallest clusters and can be
increased for an existing pool if needed. The pg_count cannot be lowered
for an existing pool.

Signed-off-by: Jan Fajerski <jfajerski@suse.com>