### PR TITLE
cherrypy: Add '@wheel' permission to salt-api clients

### DIFF
--- a/srv/salt/ceph/cherrypy/files/eauth.conf
+++ b/srv/salt/ceph/cherrypy/files/eauth.conf
@@ -4,3 +4,4 @@ external_auth:
     admin:
       - .*
       - '@runner'
+      - '@wheel'


### PR DESCRIPTION
This permission is needed for salt-api client query the state of
minions keys.

Signed-off-by: Ricardo Dias <rdias@suse.com>