### PR TITLE
salt-api: use default host (0.0.0.0) for cherrypy

### DIFF
--- a/srv/salt/ceph/cherrypy/files/cherrypy.conf.j2
+++ b/srv/salt/ceph/cherrypy/files/cherrypy.conf.j2
@@ -1,5 +1,4 @@
 
 rest_cherrypy:
-  host: {{ salt['pillar.get']('master_minion') }}
   port: 8000
   disable_ssl: True


### PR DESCRIPTION
Signed-off-by: Ricardo Dias <rdias@suse.com>