### PR TITLE
stage 0: force ordering of salt state items

### DIFF
--- a/srv/salt/ceph/stage/prep/minion/default.sls
+++ b/srv/salt/ceph/stage/prep/minion/default.sls
@@ -9,11 +9,6 @@ sync:
     - tgt: '*'
     - sls: ceph.sync
 
-mines:
-  salt.state:
-    - tgt: '*'
-    - sls: ceph.mines
-
 repo:
   salt.state:
     - tgt: '*'
@@ -33,6 +28,11 @@ restart:
   salt.state:
     - tgt: '*'
     - sls: ceph.updates.restart
+
+mines:
+  salt.state:
+    - tgt: '*'
+    - sls: ceph.mines
 
 complete:
   salt.state:


### PR DESCRIPTION
This PR forces the ordering of salt states applied to the minions in stage 0 to guarantee that mine functions have all the package dependencies installed before executing.

Signed-off-by: Ricardo Dias <rdias@suse.com>