### PR TITLE
spec file: add python-netaddr dependency for Opensuse 42.2

### DIFF
--- a/deepsea.spec
+++ b/deepsea.spec
@@ -32,6 +32,9 @@ BuildRequires:  salt-master
 Requires:       salt-master
 Requires:       salt-minion
 Requires:       python-ipaddress
+%if 0%{?leap_version} == 420200
+Requires:       python-netaddr
+%endif
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 BuildArch:      noarch
 


### PR DESCRIPTION
Signed-off-by: Jan Fajerski <jfajerski@suse.com>