### PR TITLE
RGW: add users only if rgw_configurations are defined.

### DIFF
--- a/srv/salt/_modules/rgw.py
+++ b/srv/salt/_modules/rgw.py
@@ -67,6 +67,9 @@ def add_users(pathname="/srv/salt/ceph/rgw/cache"):
     """
     Write each user to its own file
     """
+    if 'rgw_configurations' not in __pillar__:
+        return
+    
     for role in __pillar__['rgw_configurations']:
         for user in __pillar__['rgw_configurations'][role]['users']:
             if 'uid' not in user or 'name' not in user:

--- a/srv/salt/ceph/stage/radosgw/default.sls
+++ b/srv/salt/ceph/stage/radosgw/default.sls
@@ -5,13 +5,11 @@ rgw auth:
     - tgt_type: compound
     - sls: ceph.rgw.auth
 
-{% if salt['pillar.get']('rgw_configurations',[]) != [] %}
 rgw users:
   salt.state:
     - tgt: {{ salt['pillar.get']('master_minion') }}
     - tgt_type: compound
     - sls: ceph.rgw.users
-{% endif %}
 
 {% for config in salt['pillar.get']('rgw_configurations', [ 'rgw' ]) %}
 {{ config }}:


### PR DESCRIPTION
Check in module instead of salt file
Signed-off-by: Supriti Singh <supriti.singh@suse.com>