### PR TITLE
Fix certificate of origin

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -13,17 +13,40 @@ In order to keep a record of code attributions, we expect you to sign-off your
 patches. The rules are pretty simple and similar to many other open source
 projects like the Linux kernel. If you can certify the below:
 
+```
 Developer's Certificate of Origin 1.1
 
 By making a contribution to this project, I certify that:
 
-a. The contribution was created in whole or in part by me and I have the right to submit it under the open source license indicated in the file; or
-b. The contribution is based upon previous work that, to the best of my knowledge, is covered under an appropriate open source license and I have the right under that license to submit that work with modifications, whether created in whole or in part by me, under the same open source license (unless I am permitted to submit under a different license), as indicated in the file; or
-c. The contribution was provided directly to me by some other person who certified (a), (b) or (c) and I have not modified it.
-d. I understand and agree that this project and the contribution are public and that a record of the contribution (including all personal information I submit with it, including my sign-off) is maintained indefinitely and may be redistributed consistent with this project or the open source license(s) involved.
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.
+```
+
 then you just add a line saying
 
+```
 Signed-off-by: Random J Developer <random@developer.example.org>
+```
+
 using your real name (sorry, no pseudonyms or anonymous contributions.) in your
 commit message.
 

--- a/contributing.md
+++ b/contributing.md
@@ -1,5 +1,5 @@
 Contributor Guidelines
----------------------------
+======================
 
 Contributions to Deepsea are welcome and greatly appreciated, every little bit
 helps in making the project a little better for everyone.
@@ -7,7 +7,7 @@ helps in making the project a little better for everyone.
 The following are a few guidelines to get you started contributing to DeepSea.
 
 Signing your work
-=======================
+-----------------
 
 In order to keep a record of code attributions, we expect you to sign-off your
 patches. The rules are pretty simple and similar to many other open source
@@ -29,7 +29,7 @@ commit message.
 
 
 Sending Patches
-====================
+---------------
 
 We accept patches via Github Pull Requests. Here is a quick guide to get you
 going:
@@ -73,7 +73,7 @@ going:
    spurious merge commits.
 
 Reporting Issues
-======================
+----------------
 
 Report issues/ request features via the github issues interface at
 https://github.com/SUSE/DeepSea/issues/new


### PR DESCRIPTION
Replace the current Developer's Certificate of Origin 1.1 that
questionably may have had modifications with the verbatim version found
at https://developercertificate.org/.

From above website:
> Everyone is permitted to copy and distribute verbatim copies of this
> license document, but changing it is not allowed.

In addition, enclose the Certificate in a code block, as well as the
signed-off-by example so that the sections stand out more easily to the
reader, whether of the md file itself or of the rendered version.

Also fix header H1-H2 mix-up.

Signed-off-by: Blaine Gardner <blaine.gardner@suse.com>