### PR TITLE
Add default-shared.sls to mds/rgw

### DIFF
--- a/srv/salt/ceph/igw/restart/init.sls
+++ b/srv/salt/ceph/igw/restart/init.sls
@@ -1,4 +1,4 @@
 
 include:
-  - .{{ salt['pillar.get']('restart', 'default') }}
+  - .{{ salt['pillar.get']('igw_restart_init', 'default') }}
 

--- a/srv/salt/ceph/mds/restart/default-shared.sls
+++ b/srv/salt/ceph/mds/restart/default-shared.sls
@@ -1,0 +1,5 @@
+restart:
+  cmd.run:
+    - name: "systemctl restart ceph-mds@mds.service"
+    - unless: "systemctl is-failed ceph-mds@mds.service"
+    - fire_event: True

--- a/srv/salt/ceph/mds/restart/init.sls
+++ b/srv/salt/ceph/mds/restart/init.sls
@@ -1,4 +1,4 @@
 
 include:
-  - .{{ salt['pillar.get']('restart', 'default') }}
+  - .{{ salt['pillar.get']('mds_restart_init', 'default') }}
 

--- a/srv/salt/ceph/mon/restart/init.sls
+++ b/srv/salt/ceph/mon/restart/init.sls
@@ -1,4 +1,4 @@
 
 include:
-  - .{{ salt['pillar.get']('restart', 'default') }}
+  - .{{ salt['pillar.get']('mon_restart_init', 'default') }}
 

--- a/srv/salt/ceph/osd/restart/init.sls
+++ b/srv/salt/ceph/osd/restart/init.sls
@@ -1,4 +1,4 @@
 
 include:
-  - .{{ salt['pillar.get']('restart', 'default') }}
+  - .{{ salt['pillar.get']('osd_restart_init', 'default') }}
 

--- a/srv/salt/ceph/rgw/restart/default-shared.sls
+++ b/srv/salt/ceph/rgw/restart/default-shared.sls
@@ -1,0 +1,8 @@
+{% for role in salt['pillar.get']('rgw_configurations', [ 'rgw' ]) %}
+    restart:
+      cmd.run:
+        - name: "systemctl restart ceph-radosgw@{{ role }}.service"
+        - unless: "systemctl is-failed ceph-radosgw@{{ role }}.service"
+        - fire_event: True
+{% endfor %}
+

--- a/srv/salt/ceph/rgw/restart/init.sls
+++ b/srv/salt/ceph/rgw/restart/init.sls
@@ -1,4 +1,4 @@
 
 include:
-  - .{{ salt['pillar.get']('restart', 'default') }}
+  - .{{ salt['pillar.get']('rgw_restart_init', 'default') }}
 


### PR DESCRIPTION
* adapt the init from 'restart' to '<role>_restart_init'
  * avoids collision and allows more fine grained control

resolves: #34 

Signed-off-by: Joshua Schmid <jschmid@suse.de>