### PR TITLE
spec: leap_version conditional is not reliable.

### DIFF
--- a/deepsea.spec
+++ b/deepsea.spec
@@ -32,7 +32,7 @@ BuildRequires:  salt-master
 Requires:       salt-master
 Requires:       salt-minion
 Requires:       python-ipaddress
-%if 0%{?leap_version} == 420200
+%if 0%{?sle_version} == 120200 && 0%{?is_opensuse} == 1
 Requires:       python-netaddr
 %endif
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
use sle_version and is_opensuse instead.

Signed-off-by: Jan Fajerski <jfajerski@suse.com>