### PR TITLE
extend cephprocesses

### DIFF
--- a/srv/modules/runners/cephprocesses.py
+++ b/srv/modules/runners/cephprocesses.py
@@ -26,7 +26,7 @@ def check(cluster='ceph', roles=[], tolerate_down=0):
     search = "I@cluster:{}".format(cluster)
 
     if not roles:
-        roles_d, roles = _cached_roles(search)
+        roles = _cached_roles(search)
 
     status = _status(search, roles)
 
@@ -90,7 +90,7 @@ def _cached_roles(search):
                 roles.setdefault(role, []).append(minion)
 
     log.debug(pprint.pformat(roles))
-    return roles, roles.keys()
+    return roles.keys()
 
 
 def wait(cluster='ceph', **kwargs):

--- a/srv/modules/runners/cephprocesses.py
+++ b/srv/modules/runners/cephprocesses.py
@@ -64,7 +64,7 @@ def _status(search, roles):
         role_search = search + " and I@roles:{}".format(role)
         status[role] = local.cmd(role_search,
                                  'cephprocesses.check',
-                                 [],
+                                 [roles.keys()],
                                  expr_form="compound")
 
     log.debug(pprint.pformat(status))

--- a/srv/modules/runners/cephprocesses.py
+++ b/srv/modules/runners/cephprocesses.py
@@ -27,6 +27,10 @@ def check(cluster='ceph', **kwargs):
 
     roles = _cached_roles(search)
     if 'roles' in kwargs:
+        for role in kwargs['roles']:
+            if role not in roles:
+                log.error("You queried for role {} but there is no such role in your cluster. Aborting")
+                return False
         roles = {k: roles[k] for k in kwargs['roles']}
 
     status = _status(search, roles)

--- a/srv/modules/runners/cephprocesses.py
+++ b/srv/modules/runners/cephprocesses.py
@@ -26,7 +26,7 @@ def check(cluster='ceph', roles=[]):
     search = "I@cluster:{}".format(cluster)
 
     if not roles:
-        roles = _cached_roles(search)
+        roles_d, roles = _cached_roles(search)
 
     status = _status(search, roles)
     
@@ -34,11 +34,6 @@ def check(cluster='ceph', roles=[]):
     log.debug("status: {}".format(pprint.pformat(status)))
 
     ret = True
-    for role in roles:
-        for minion in roles[role]:
-            if minion not in status[role]:
-                log.error("ERROR: {} minion did not respond".format(minion))
-                ret = False
 
     for role in status.keys():
         for minion in status[role]:
@@ -63,7 +58,7 @@ def _status(search, roles):
         role_search = search + " and I@roles:{}".format(role)
         status[role] = local.cmd(role_search,
                                  'cephprocesses.check',
-                                 [roles.keys()],
+                                 roles=roles,
                                  expr_form="compound")
 
     log.debug(pprint.pformat(status))
@@ -91,7 +86,7 @@ def _cached_roles(search):
                 roles.setdefault(role, []).append(minion)
 
     log.debug(pprint.pformat(roles))
-    return roles
+    return roles, roles.keys()
 
 
 def wait(cluster='ceph', **kwargs):

--- a/srv/modules/runners/cephprocesses.py
+++ b/srv/modules/runners/cephprocesses.py
@@ -17,6 +17,7 @@ upgrade is safe.  All expected processes are running.
 A secondary purpose is a utility to check the current state of all processes.
 """
 
+
 def check(cluster='ceph', **kwargs):
     """
     Query the status of running processes for each role.  Also, verify that
@@ -26,9 +27,8 @@ def check(cluster='ceph', **kwargs):
 
     roles = _cached_roles(search)
     if 'roles' in kwargs:
-        roles = { k:roles[k] for k in kwargs['roles'] }
+        roles = {k: roles[k] for k in kwargs['roles']}
 
-	
     status = _status(search, roles)
     log.debug("roles: {}".format(pprint.pformat(roles)))
     log.debug("status: {}".format(pprint.pformat(status)))
@@ -45,7 +45,7 @@ def check(cluster='ceph', **kwargs):
 
     for role in status.keys():
         for minion in status[role]:
-            if status[role][minion] == False:
+            if status[role][minion] is False:
                 # Currently no checking for passive mds.
                 # status.pid returns None as the process is idling.
                 # therefore it will also report that i.e mon is not running

--- a/srv/modules/runners/cephprocesses.py
+++ b/srv/modules/runners/cephprocesses.py
@@ -29,7 +29,7 @@ def check(cluster='ceph', **kwargs):
     if 'roles' in kwargs:
         for role in kwargs['roles']:
             if role not in roles:
-                log.error("You queried for role {} but there is no such role in your cluster. Aborting")
+                log.error("You queried for role {} but there is no such role in your cluster. Aborting".format(role))
                 return False
         roles = {k: roles[k] for k in kwargs['roles']}
 

--- a/srv/modules/runners/cephprocesses.py
+++ b/srv/modules/runners/cephprocesses.py
@@ -18,7 +18,7 @@ A secondary purpose is a utility to check the current state of all processes.
 """
 
 
-def check(cluster='ceph', roles=[]):
+def check(cluster='ceph', roles=[], tolerate_down=0):
     """
     Query the status of running processes for each role.  Also, verify that
     all minions assigned roles do respond.  Return False if any fail.
@@ -38,8 +38,10 @@ def check(cluster='ceph', roles=[]):
     for role in status.keys():
         for minion in status[role]:
             if status[role][minion] is False:
-                log.error("ERROR: {} process on {} is not running".format(role, minion))
-                ret = False
+		if tolerate_down == 0:
+                  log.error("ERROR: {} process on {} is not running".format(role, minion))
+                  ret = False
+                tolerate_down -= 1
 
     return ret
 

--- a/srv/modules/runners/cephprocesses.py
+++ b/srv/modules/runners/cephprocesses.py
@@ -29,7 +29,7 @@ def check(cluster='ceph', roles=[], tolerate_down=0):
         roles_d, roles = _cached_roles(search)
 
     status = _status(search, roles)
-    
+
     log.debug("roles: {}".format(pprint.pformat(roles)))
     log.debug("status: {}".format(pprint.pformat(status)))
 
@@ -38,12 +38,13 @@ def check(cluster='ceph', roles=[], tolerate_down=0):
     for role in status.keys():
         for minion in status[role]:
             if status[role][minion] is False:
-		if tolerate_down == 0:
-                  log.error("ERROR: {} process on {} is not running".format(role, minion))
-                  ret = False
+                if tolerate_down == 0:
+                    log.error("ERROR: {} process on {} is not running".format(role, minion))
+                    ret = False
                 tolerate_down -= 1
 
     return ret
+
 
 def _status(search, roles):
     """
@@ -67,6 +68,7 @@ def _status(search, roles):
 
     sys.stdout = _stdout
     return status
+
 
 def _cached_roles(search):
     """
@@ -109,16 +111,15 @@ def wait(cluster='ceph', **kwargs):
     local = salt.client.LocalClient()
     status = local.cmd(search,
                        'cephprocesses.wait',
-                       [ 'timeout={}'.format(settings['timeout']),
-                         'delay={}'.format(settings['delay']) ],
+                       ['timeout={}'.format(settings['timeout']),
+                        'delay={}'.format(settings['delay'])],
                        expr_form="compound")
-
 
     sys.stdout = _stdout
     log.debug("status: ".format(pprint.pformat(status)))
     if False in status.values():
         for minion in status.keys():
-            if status[minion] == False:
+            if status[minion] is False:
                 log.error("minion {} failed".format(minion))
         return False
     return True
@@ -131,8 +132,8 @@ def _timeout(cluster='ceph'):
     """
     local = salt.client.LocalClient()
     search = "I@cluster:{}".format(cluster)
-    virtual = local.cmd(search, 'grains.get', [ 'virtual' ], expr_form="compound")
-    if 'physical' in  virtual.values():
+    virtual = local.cmd(search, 'grains.get', ['virtual'], expr_form="compound")
+    if 'physical' in virtual.values():
         return 900
     else:
         return 120

--- a/srv/salt/_modules/cephprocesses.py
+++ b/srv/salt/_modules/cephprocesses.py
@@ -28,13 +28,19 @@ def check(roles=[]):
 
     def check_process(role):
         for process in processes[role]:
-            result = __salt__['status.pid'](process)
+            pid = __salt__['status.pid'](process)
             log.info("Pid for process {} is {}".format(process, result))
-            if result == '':
+            if not pid.isdigit():
                 log.error("ERROR: process {} for role {} is not running".format(process, role))
                 return False
             else:
                 return True
+
+    ignore_roles = [ 'admin', 'master' ]
+
+    for ig_role in ignore_roles:
+      if ig_role in roles:
+        roles.pop(ig_role)
 
     if 'roles' in __pillar__:
         for role in __pillar__['roles']:

--- a/srv/salt/_modules/cephprocesses.py
+++ b/srv/salt/_modules/cephprocesses.py
@@ -32,11 +32,16 @@ def check(**kwargs):
     roles = kwargs.get('roles', __pillar__['roles'])
 
     if not set(roles).issubset(__pillar__['roles']):
+      # or just return False
       raise ValueError("You checked for {}. Can't find that in assigned roles".format(roles))
 
     def check_process(role):
         for process in processes[role]:
             pid = __salt__['status.pid'](process)
+            if role == 'storage' and '\n' in pid:
+	       # There are of no use yet. We can only safe results on a per node basis
+               # Would require an even bigger rework. Keeping it there for future improvements
+               pid_list = pid.split('\n')
             if pid == '':
                 log.error("ERROR: process {} for role {} is not running".format(process, role))
                 return False
@@ -49,9 +54,11 @@ def check(**kwargs):
       if not role in ignored_roles:
         results[role] = check_process(role)
 
+
     for role, pid in results.iteritems():
       if pid is False:
         can_continue = False
+    
 
     return can_continue 
 

--- a/srv/salt/_modules/cephprocesses.py
+++ b/srv/salt/_modules/cephprocesses.py
@@ -12,7 +12,7 @@ upgrade is safe.  All expected services are running.
 A secondary purpose is a utility to check the current state of all services.
 """
 
-def check():
+def check(only_for=[]):
     """
     Query the status of running processes for each role.  Return False if any
     fail.
@@ -26,13 +26,24 @@ def check():
 
     ret = True
     if 'roles' in __pillar__:
-        for role in __pillar__['roles']:
-            if role in processes:
-                for process in processes[role]:
-                    result = __salt__['status.pid'](process)
-                    if result == '':
-                        log.error("ERROR: process {} for role {} is not running".format(process, role))
-                        ret = False
+        if only_for:
+          for role in only_for:
+            log.info("Checking {} for status".format(role)
+            for process in processes[role]:
+	      result = __salt__['status.pid'](process)
+              if result == '':
+                log.error("ERROR: process {} for role {} is not running".format(process, role))
+                ret = False
+        else:
+          for role in __pillar__['roles']:
+              if role in processes:
+                  for process in processes[role]:
+                      result = __salt__['status.pid'](process)
+                      print "ON ROLE: {}".format(role)
+                      print "RESULT: {}".format(result)
+                      if result == '':
+                          log.error("ERROR: process {} for role {} is not running".format(process, role))
+                          ret = False
 
     return ret
 

--- a/srv/salt/_modules/cephprocesses.py
+++ b/srv/salt/_modules/cephprocesses.py
@@ -12,6 +12,7 @@ upgrade is safe.  All expected services are running.
 A secondary purpose is a utility to check the current state of all services.
 """
 
+
 def check(**kwargs):
     """
     Query the status of running processes for each role.  Return False if any
@@ -23,7 +24,7 @@ def check(**kwargs):
                  'igw': ['lrbd'],
                  'rgw': ['radosgw'],
                  'ganesha': ['ganesha.nfsd', 'rpcbind', 'rpc.statd'],
-		 'admin': [],
+                 'admin': [],
                  'master': []}
 
     can_continue = True
@@ -32,16 +33,16 @@ def check(**kwargs):
     roles = kwargs.get('roles', __pillar__['roles'])
 
     if not set(roles).issubset(__pillar__['roles']):
-      # or just return False
-      raise ValueError("You checked for {}. Can't find that in assigned roles".format(roles))
+        # or just return False
+        raise ValueError("You checked for {}. Can't find that in assigned roles".format(roles))
 
     def check_process(role):
         for process in processes[role]:
             pid = __salt__['status.pid'](process)
             if role == 'storage' and '\n' in pid:
-	       # There are of no use yet. We can only safe results on a per node basis
-               # Would require an even bigger rework. Keeping it there for future improvements
-               pid_list = pid.split('\n')
+                # There are of no use yet. We can only safe results on a per node basis
+                # Would require an even bigger rework. Keeping it there for future improvements
+                pid_list = pid.split('\n')
             if pid == '':
                 log.error("ERROR: process {} for role {} is not running".format(process, role))
                 return False
@@ -51,16 +52,15 @@ def check(**kwargs):
     ignored_roles = ['admin', 'master']
 
     for role in roles:
-      if not role in ignored_roles:
-        results[role] = check_process(role)
-
+        if role not in ignored_roles:
+            results[role] = check_process(role)
 
     for role, pid in results.iteritems():
-      if pid is False:
-        can_continue = False
-    
+        if pid is False:
+            can_continue = False
 
-    return can_continue 
+    return can_continue
+
 
 def wait(**kwargs):
     """
@@ -87,12 +87,13 @@ def wait(**kwargs):
     log.error("Timeout expired")
     return False
 
+
 def _timeout():
     """
     Assume 15 minutes for physical hardware since some hardware has long
     shutdown/reboot times.  Assume 2 minutes for complete virtual environments.
     """
-    if 'physical' ==  __grains__['virtual']:
+    if 'physical' == __grains__['virtual']:
         return 900
     else:
         return 120

--- a/tests/unit/runners/test_cephprocesses.py
+++ b/tests/unit/runners/test_cephprocesses.py
@@ -9,12 +9,12 @@ class TestCephProcesses():
 
     @patch('salt.client.LocalClient', autospec=True)
     def test_status(self, localclient):
-        result = {'mon1.ceph': True, 
-                  'mon3.ceph': True, 
+        result = {'mon1.ceph': True,
+                  'mon3.ceph': True,
                   'mon2.ceph': True}
 
         search = "I@cluster:ceph"
-        roles = [ 'mon' ]
+        roles = {'mon': ['mon1', 'mon2', 'mon3']}
 
         local = localclient.return_value
         local.cmd.return_value = result

--- a/tests/unit/runners/test_cephprocesses.py
+++ b/tests/unit/runners/test_cephprocesses.py
@@ -14,7 +14,7 @@ class TestCephProcesses():
                   'mon2.ceph': True}
 
         search = "I@cluster:ceph"
-        roles = {'mon': ['mon1', 'mon2', 'mon3']}
+        roles = ['mon']
 
         local = localclient.return_value
         local.cmd.return_value = result
@@ -24,58 +24,96 @@ class TestCephProcesses():
 
     @patch('srv.modules.runners.cephprocesses._status', autospec=True)
     @patch('srv.modules.runners.cephprocesses._cached_roles', autospec=True)
-    def test_check(self, status, cachedroles):
-        status.return_value = { 'mon': ['mon2.ceph', 'mon3.ceph', 'mon1.ceph'] }
+    def test_check(self, cachedroles, status):
+        cachedroles.return_value = ['mon']
 
-        cachedroles.return_value = { 'mon': {'mon1.ceph': True, 'mon2.ceph': True, 'mon3.ceph': True}}
+        status.return_value = {'mon': {'mon1.ceph': True,
+                                       'mon2.ceph': True,
+                                       'mon3.ceph': True}}
 
         result = cephprocesses.check()
-        assert result == True
+        assert cachedroles.called is True
+        assert result is True
 
-    @patch('srv.modules.runners.cephprocesses._status', autospec=True)
     @patch('srv.modules.runners.cephprocesses._cached_roles', autospec=True)
+    @patch('srv.modules.runners.cephprocesses._status', autospec=True)
     def test_check_fails_for_missing_process(self, status, cachedroles):
-        status.return_value = { 'mon': ['mon2.ceph', 'mon3.ceph', 'mon1.ceph'] }
+        cachedroles.return_value = ['mon']
 
-        cachedroles.return_value = { 'mon': {'mon1.ceph': True, 'mon2.ceph': False, 'mon3.ceph': True}}
+        status.return_value = {'mon': {'mon1.ceph': True,
+                                       'mon2.ceph': False,
+                                       'mon3.ceph': True}}
 
         result = cephprocesses.check()
-        assert result == False
+        assert cachedroles.called is True
+        assert result is False
 
-    @patch('srv.modules.runners.cephprocesses._status', autospec=True)
     @patch('srv.modules.runners.cephprocesses._cached_roles', autospec=True)
-    def test_check_fails_for_missing_minion(self, status, cachedroles):
-        status.return_value = { 'mon': ['mon2.ceph', 'mon3.ceph', 'mon1.ceph'] }
+    @patch('srv.modules.runners.cephprocesses._status', autospec=True)
+    def test_check_fails_specified_roles(self, status, cachedroles):
+        status.return_value = {'mon': {'mon1.ceph': False,
+                                       'mon3.ceph': False}}
 
-        cachedroles.return_value = { 'mon': {'mon1.ceph': True, 'mon3.ceph': True}}
+        result = cephprocesses.check(roles=['storage'])
+        assert cachedroles.called is False
+        assert result is False
 
-        result = cephprocesses.check()
-        assert result == False
+    @patch('srv.modules.runners.cephprocesses._cached_roles', autospec=True)
+    @patch('srv.modules.runners.cephprocesses._status', autospec=True)
+    def test_check_fails_specified_roles_mixed(self, status, cachedroles):
+        status.return_value = {'mon': {'mon1.ceph': False,
+                                       'mon3.ceph': True},
+                               'rgw': {'rgw1.ceph': True,
+                                       'rgw2.ceph': True}}
+
+        result = cephprocesses.check(roles=['rgw', 'mon'])
+        assert cachedroles.called is False
+        assert result is False
+
+    @patch('srv.modules.runners.cephprocesses._cached_roles', autospec=True)
+    @patch('srv.modules.runners.cephprocesses._status', autospec=True)
+    def test_check_tolerate_1(self, status, cachedroles):
+        status.return_value = {'mon': {'mon1.ceph': False,
+                                       'mon3.ceph': True}}
+
+        result = cephprocesses.check(roles=['storage'], tolerate_down=1)
+        assert cachedroles.called is False
+        assert result is True
+
+    @patch('srv.modules.runners.cephprocesses._cached_roles', autospec=True)
+    @patch('srv.modules.runners.cephprocesses._status', autospec=True)
+    def test_check_tolerate_0(self, status, cachedroles):
+        status.return_value = {'mon': {'mon1.ceph': False,
+                                       'mon3.ceph': True}}
+
+        result = cephprocesses.check(roles=['storage'], tolerate_down=0)
+        assert cachedroles.called is False
+        assert result is False
 
     @patch('salt.client.LocalClient', autospec=True)
     def test_wait(self, localclient):
         local = localclient.return_value
-        local.cmd.return_value = {'mon1.ceph': True, 
-                                  'mon3.ceph': True, 
+        local.cmd.return_value = {'mon1.ceph': True,
+                                  'mon3.ceph': True,
                                   'mon2.ceph': True}
 
         result = cephprocesses.wait(delay=0)
-        assert result == True
+        assert result is True
 
     @patch('salt.client.LocalClient', autospec=True)
     def test_wait_fails(self, localclient):
         local = localclient.return_value
-        local.cmd.return_value = {'mon1.ceph': True, 
-                                  'mon3.ceph': False, 
+        local.cmd.return_value = {'mon1.ceph': True,
+                                  'mon3.ceph': False,
                                   'mon2.ceph': True}
 
         result = cephprocesses.wait(delay=0)
-        assert result == False
+        assert result is False
 
     @patch('salt.client.LocalClient', autospec=True)
     def test_timeout(self, localclient):
         local = localclient.return_value
-        local.cmd.return_value = { 'virtual' : 'kvm' }
+        local.cmd.return_value = {'virtual': 'kvm'}
 
         ret = cephprocesses._timeout()
         assert ret == 120
@@ -83,9 +121,7 @@ class TestCephProcesses():
     @patch('salt.client.LocalClient', autospec=True)
     def test_physical_timeout(self, localclient):
         local = localclient.return_value
-        local.cmd.return_value = { 'virtual' : 'physical' }
+        local.cmd.return_value = {'virtual': 'physical'}
 
         ret = cephprocesses._timeout()
         assert ret == 900
-
-


### PR DESCRIPTION
That PR extends cephprocesses.py and allows more fine-grained control over the queried services

If you call `cephprocesses.check()` it will execute status.pid for every service that is registered on that node. There is no way to e.g. _only_ check if monitors are running if the targeted node has also a MDS assigned. By overwriting the `roles`  you can ignore colocated services.

Example: status.pid will return you None if executed on a _hot-stand-by mds_, therefore the 'mon-node' will be considered as failed. That should eventually be tackled in a separate PR.

`salt-run cephprocesses.check roles=['mon']` 

will now _ONLY_ check for the status.pid on every node that has the role 'mon' assigned.

`salt-run cephprocesses.check roles=['mon','mds']` 

will now _ONLY_ check for the status.pid on every node that has the role 'mon' and 'mds' assigned.

`salt-run cephprocesses.check `

 will now check for the status.pid on every node for every assigned role.