### PR TITLE
ganesha: import Set is deprecated, use builtin instead

### DIFF
--- a/srv/salt/_modules/ganesha.py
+++ b/srv/salt/_modules/ganesha.py
@@ -3,8 +3,6 @@
 import salt.config
 import logging
 from subprocess import call, Popen, PIPE
-import os
-import json
 
 log = logging.getLogger(__name__)
 

--- a/srv/salt/_modules/ganesha.py
+++ b/srv/salt/_modules/ganesha.py
@@ -1,6 +1,5 @@
 #!/usr/bin/python
 
-from sets import Set
 import salt.config
 import logging
 from subprocess import call, Popen, PIPE
@@ -19,8 +18,8 @@ def configurations():
     """
     if 'roles' in __pillar__:
         if 'ganesha_configurations' in __pillar__:
-            return list(Set(__pillar__['ganesha_configurations']) &
-                        Set(__pillar__['roles']))
+            return list(set(__pillar__['ganesha_configurations']) &
+                        set(__pillar__['roles']))
         if 'ganesha' in __pillar__['roles']:
             return [ 'ganesha' ]
     return []


### PR DESCRIPTION
https://docs.python.org/2/library/sets.html

-> Deprecated since version 2.6: The built-in set/frozenset types replace this module.

LGTM