### PR TITLE
push runner: policy.cfg strip comments at end of line

### DIFF
--- a/srv/modules/runners/push.py
+++ b/srv/modules/runners/push.py
@@ -211,6 +211,8 @@ class PillarData(object):
         common = {}
         with open(filename, "r") as policy:
             for line in policy:
+                # strip comments from the end of the line
+                line = re.sub(' #.*$', '', line)
                 line = line.rstrip()
                 if (line.startswith('#') or not line):
                     log.debug("Ignoring '{}'".format(line))
@@ -240,7 +242,6 @@ class PillarData(object):
                 log.debug("    {}".format(filename))
         return common
 
-
     def _parse(self, line):
         """
         Return globbed files constrained by optional slices or regexes.
@@ -262,11 +263,8 @@ class PillarData(object):
             files = glob.glob(line)
         return files
 
-
     def _shift_dir(self, path):
         """
         Remove the leftmost directory, expects beginning /
         """
         return "/".join(path.split('/')[2:])
-
-


### PR DESCRIPTION
If policy.cfg has a line like
profile-1Disk40GB-1/cluster/*sls #hey there
push would throw an exception. This commit strips comments before
further processing.
Fixes bsc#1030884.

Signed-off-by: Jan Fajerski <jfajerski@suse.com>