### PR TITLE
push: eat any white space preceding a comment

### DIFF
--- a/srv/modules/runners/push.py
+++ b/srv/modules/runners/push.py
@@ -212,7 +212,7 @@ class PillarData(object):
         with open(filename, "r") as policy:
             for line in policy:
                 # strip comments from the end of the line
-                line = re.sub(' #.*$', '', line)
+                line = re.sub('\s+#.*$', '', line)
                 line = line.rstrip()
                 if (line.startswith('#') or not line):
                     log.debug("Ignoring '{}'".format(line))


### PR DESCRIPTION
This takes care of tabs as well. Multiple white spaces get removed by
the following rstrip. '#' without a separating white space are not
stripped, since they might belong to an 're=' modifier. Comments at the
end of lines should be separated by a white space.

Signed-off-by: Jan Fajerski <jfajerski@suse.com>