### PR TITLE
The activate for journal on separate disk seems to be missing the par…

### DIFF
--- a/srv/salt/ceph/osd/default.sls
+++ b/srv/salt/ceph/osd/default.sls
@@ -28,7 +28,7 @@ prepare {{ data }}:
 
 activate {{ data }}:
   cmd.run:
-    - name: "ceph-disk -v activate --mark-init systemd --mount {{ data }}"
+    - name: "ceph-disk -v activate --mark-init systemd --mount {{ data }}1"
     - unless: "grep -q ^{{ data }} /proc/mounts"
     - fire_event: True
 


### PR DESCRIPTION
…tition number

I have added the "1" as otherwise the activate will fail in a setup where journal is on a separate disk.
(in case of storage:data+journals)