### PR TITLE
Specify utf-8 encoding for python module files

### DIFF
--- a/srv/modules/runners/advise.py
+++ b/srv/modules/runners/advise.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 import time
 import logging

--- a/srv/modules/runners/benchmark.py
+++ b/srv/modules/runners/benchmark.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 import salt.client
 import salt.config

--- a/srv/modules/runners/cephprocesses.py
+++ b/srv/modules/runners/cephprocesses.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 import salt.client
 import pprint

--- a/srv/modules/runners/configure.py
+++ b/srv/modules/runners/configure.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 import salt.client
 import ipaddress

--- a/srv/modules/runners/disengage.py
+++ b/srv/modules/runners/disengage.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 import os
 import time

--- a/srv/modules/runners/filequeue.py
+++ b/srv/modules/runners/filequeue.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 import time
 import logging

--- a/srv/modules/runners/minions.py
+++ b/srv/modules/runners/minions.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 import salt.key
 import salt.client

--- a/srv/modules/runners/net.py
+++ b/srv/modules/runners/net.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 import logging
 import re

--- a/srv/modules/runners/populate.py
+++ b/srv/modules/runners/populate.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 import salt.client
 import salt.key

--- a/srv/modules/runners/push.py
+++ b/srv/modules/runners/push.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 import os
 import errno

--- a/srv/modules/runners/ready.py
+++ b/srv/modules/runners/ready.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 import salt.client
 import salt.utils.error

--- a/srv/modules/runners/rescinded.py
+++ b/srv/modules/runners/rescinded.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 import salt.client
 import pprint

--- a/srv/modules/runners/select.py
+++ b/srv/modules/runners/select.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 import salt.client
 import pprint

--- a/srv/modules/runners/validate.py
+++ b/srv/modules/runners/validate.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 import salt.client
 import salt.utils.error

--- a/srv/salt/_modules/advise.py
+++ b/srv/salt/_modules/advise.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 import time
 import logging

--- a/srv/salt/_modules/cephdisks.py
+++ b/srv/salt/_modules/cephdisks.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 import os
 import re

--- a/srv/salt/_modules/cephprocesses.py
+++ b/srv/salt/_modules/cephprocesses.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 import logging
 import time

--- a/srv/salt/_modules/ganesha.py
+++ b/srv/salt/_modules/ganesha.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 from sets import Set
 import salt.config

--- a/srv/salt/_modules/kernel.py
+++ b/srv/salt/_modules/kernel.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 from subprocess import call, Popen, PIPE
 import salt.client

--- a/srv/salt/_modules/keyring.py
+++ b/srv/salt/_modules/keyring.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 import os
 import struct

--- a/srv/salt/_modules/mon.py
+++ b/srv/salt/_modules/mon.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 import rados
 import json

--- a/srv/salt/_modules/multi.py
+++ b/srv/salt/_modules/multi.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 import logging
 import multiprocessing.dummy

--- a/srv/salt/_modules/osd.py
+++ b/srv/salt/_modules/osd.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 import os
 import glob

--- a/srv/salt/_modules/purge.py
+++ b/srv/salt/_modules/purge.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 import salt.config
 import logging

--- a/srv/salt/_modules/retry.py
+++ b/srv/salt/_modules/retry.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 import os
 import sys

--- a/srv/salt/_modules/rgw.py
+++ b/srv/salt/_modules/rgw.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 import salt.config
 import logging

--- a/srv/salt/_modules/wait.py
+++ b/srv/salt/_modules/wait.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 import rados
 import json

--- a/srv/salt/_modules/zypper_locks.py
+++ b/srv/salt/_modules/zypper_locks.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 import os
 import sys


### PR DESCRIPTION
Salt dictates that module files should have UTF-8 encoding, which is
done with a special comment per PEP-263. Inspecting the example modules
given by SaltStack at
https://github.com/saltstack/salt/tree/develop/salt/runners

Signed-off-by: Blaine Gardner <blaine.gardner@suse.com>

Fixes #176 