### PR TITLE
Fixes rescind of storage for ceph.purge

### DIFF
--- a/srv/modules/runners/populate.py
+++ b/srv/modules/runners/populate.py
@@ -468,7 +468,7 @@ class CephRoles(object):
         self.public_networks, self.cluster_networks = self.public_cluster(self.networks)
 
         #self.master_contents = {}
-        self.available_roles = []
+        self.available_roles = [ 'storage' ]
 
     def _rgw_configurations(self):
         """


### PR DESCRIPTION
Commit bbf8df8 removed the storage role to prevent the creation of a directory that confused users; however, available_roles must still contain storage.  This fixes the ceph.purge functionality.

Signed-off-by: Eric Jackson <ejackson@suse.com>