### PR TITLE
pkg.install: add distribution conditional

### DIFF
--- a/srv/salt/ceph/packages/common/default.sls
+++ b/srv/salt/ceph/packages/common/default.sls
@@ -1,7 +1,8 @@
+{% set os = salt['grains.get']('os') %}
 
+{% if os == 'SUSE' %}
 
-
-stage prep dependencies:
+stage prep dependencies suse:
   pkg.installed:
     - pkgs:
       - lsscsi
@@ -9,3 +10,19 @@ stage prep dependencies:
       - gptfdisk
     - fire_event: True
 
+{% elif os == 'Ubuntu' %}
+
+stage prep dependencies ubuntu:
+  pkg.installed:
+    - pkgs:
+      - lsscsi
+      - pciutils
+      - gdisk
+    - fire_event: True
+
+{% else %}
+
+nop:
+  test.nop
+
+{% endif %}


### PR DESCRIPTION
This accounts for different package names in various distros. More to be
added later.

Signed-off-by: Jan Fajerski <jfajerski@suse.com>