### PR TITLE
Removed installing and enabling openattic-rpcd

### DIFF
--- a/srv/salt/ceph/openattic/default.sls
+++ b/srv/salt/ceph/openattic/default.sls
@@ -5,11 +5,6 @@ install openattic:
     - pkgs:
       - openattic
 
-enable openattic-rpcd:
-  service.running:
-    - name: openattic-rpcd
-    - enable: True
-
 enable openattic-systemd:
   service.running:
     - name: openattic-systemd


### PR DESCRIPTION
openATTIC 2.0.19 removed the XML-RPC API provided by the `openattic-rpcd` background service. Updated the Salt state file accordingly.

Signed-off-by: Lenz Grimmer <lgrimmer@suse.com>