### PR TITLE
Fix some issues.

### DIFF
--- a/srv/salt/ceph/rescind/igw/lrbd/default.sls
+++ b/srv/salt/ceph/rescind/igw/lrbd/default.sls
@@ -1,5 +1,4 @@
 
-
 {% if not salt['mine.get'](tgt='*', fun='roles.igw') %}
 
 wipe configuration:
@@ -14,9 +13,9 @@ stop lrbd:
   service.dead:
     - name: lrbd
     - enable: False
+    - onlyif: "test -f /usr/sbin/lrbd"
 
 uninstall lrbd:
   pkg.removed:
     - name: lrbd
     - onlyif: "test -f /usr/sbin/lrbd"
-

--- a/srv/salt/ceph/stage/removal/default.sls
+++ b/srv/salt/ceph/stage/removal/default.sls
@@ -18,7 +18,7 @@ empty osds:
     - tgt_type: compound
     - sls: ceph.remove.storage
 
-delete ganesha_auth:
+remove ganesha:
   salt.state:
     - tgt: {{ salt['pillar.get']('master_minion') }}
     - tgt_type: compound


### PR DESCRIPTION
* Stop lrbd service only if the binary exists.
* Rename ID to match the other ones.

If i apply state 'ceph.rescind' i get the following error:

```
dev-vtheile-ceph-1:~ # salt 'dev-*1*' state.apply ceph.rescind
dev-vtheile-ceph-1.xxx:
  Name: nop - Function: test.nop - Result: Clean Started: - 15:17:04.343550 Duration: 0.926 ms
  ..
  Name: . /etc/sysconfig/lrbd; /usr/sbin/lrbd $LRBD_OPTIONS -W || : - Function: cmd.run - Result: Clean Started: - 15:17:04.547318 Duration: 4.94 ms
----------
          ID: stop lrbd
    Function: service.dead
        Name: lrbd
      Result: False
     Comment: The named service lrbd is not available
     Started: 15:17:04.552419
    Duration: 7.528 ms
     Changes:
  Name: lrbd - Function: pkg.removed - Result: Clean Started: - 15:17:04.805288 Duration: 134.066 ms
  ..
  Name: client-nfs nop - Function: test.nop - Result: Clean Started: - 15:17:05.450213 Duration: 0.224 ms

Summary for dev-vtheile-ceph-1.xxx
-------------
Succeeded: 24
Failed:     1
-------------
Total states run:     25
Total run time:  701.909 ms
ERROR: Minions returned with non-zero exit code
```

Signed-off-by: Volker Theile <vtheile@suse.com>