### PR TITLE
Update to wip-ui

### DIFF
--- a/srv/modules/runners/ui-iscsi.py
+++ b/srv/modules/runners/ui-iscsi.py
@@ -153,7 +153,7 @@ class Iscsi(object):
 
 	Note: could add samples from lrbd for config
 	"""
-	self.data['config'] = ''
+	self.data['config'] = self.config()
 	self.data['interfaces'] = self.canned_interfaces(canned)
 	self.data['images'] = self.canned_images(canned)
 


### PR DESCRIPTION
Small changes to ui-iscsi:canned_populate() and ui-iscsi:save()

@swiftgist @rjfd and @ricardoasmarques - Can you guys take a look at ui-iscsi:save() and make sure it works for you? I modified the original to handle URI encoded kwargs['data'] which shouldn't require any changes to the oA frontend. However, I did remove json.dumps() and am relying that the frontend will perform it's own JSON.stringify() of the lrbd data before shipping it over to the salt-master. I found json.dumps() to misbehave and not format lrbd.conf properly. Should be just a small one line change at the oA frontend.
