### PR TITLE
Stage 0: reorder ceph.mines before restart

### DIFF
--- a/srv/salt/ceph/stage/prep/minion/default.sls
+++ b/srv/salt/ceph/stage/prep/minion/default.sls
@@ -24,18 +24,17 @@ updates:
     - tgt: '*'
     - sls: ceph.updates
 
-restart:
-  salt.state:
-    - tgt: '*'
-    - sls: ceph.updates.restart
-
 mines:
   salt.state:
     - tgt: '*'
     - sls: ceph.mines
 
+restart:
+  salt.state:
+    - tgt: '*'
+    - sls: ceph.updates.restart
+
 complete:
   salt.state:
     - tgt: {{ salt['pillar.get']('master_minion') }}
     - sls: ceph.events.complete_prep
-


### PR DESCRIPTION
For more information about the issue in question, see
https://github.com/SUSE/DeepSea/issues/213

In summary, the restart is causing a race condition with `ceph.mines`
such that the run of `ceph.mines` is not populating the salt mine
appropriately despite the fact that Salt reports `ceph.mines` is running
successfully.

Fixes #213

Signed-off-by: Blaine Gardner <blaine.gardner@suse.com>