### PR TITLE
iSCSI API: status, deploy and undeploy functions

### DIFF
--- a/srv/modules/runners/ui-iscsi.py
+++ b/srv/modules/runners/ui-iscsi.py
@@ -231,3 +231,28 @@ def images(**kwargs):
     if 'canned' in kwargs:
 	return iscsi.canned_images(int(kwargs['canned']), wrapped=False)
     return iscsi.images(wrapped=False)
+
+
+def status():
+    local = salt.client.LocalClient()
+    status = local.cmd('I@roles:igw', 'service.status', ['lrbd'], expr_form='compound')
+    result = True
+    for _, v in status.iteritems():
+        result = result and v
+    return result
+
+
+def deploy():
+    runner = salt.runner.RunnerClient(salt.config.client_config('/etc/salt/master'))
+    result = runner.cmd('state.orch', ['ceph.stage.iscsi'], print_event=False)
+    return result['data']['retcode'] == 0
+
+
+def undeploy():
+    local = salt.client.LocalClient()
+    results = local.cmd('I@roles:igw', 'service.stop', ['lrbd'], expr_form='compound')
+    result = True
+    for _, v in results.iteritems():
+        result = result and v
+    return result
+


### PR DESCRIPTION
This PR adds the functions to query the status of lrbd service, and allows to deploy/undeploy lrbd from the iSCSI API.

Signed-off-by: Ricardo Dias <rdias@suse.com>