### PR TITLE
Improve openATTIC orchestration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -223,6 +223,8 @@ copy-files:
 	install -m 644 srv/salt/ceph/remove/ganesha/*.sls $(DESTDIR)/srv/salt/ceph/remove/ganesha/
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/remove/storage
 	install -m 644 srv/salt/ceph/remove/storage/*.sls $(DESTDIR)/srv/salt/ceph/remove/storage/
+	install -d -m 755 $(DESTDIR)/srv/salt/ceph/remove/openattic
+	install -m 644 srv/salt/ceph/remove/openattic/*.sls $(DESTDIR)/srv/salt/ceph/remove/openattic/
 	# state files - rescind
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/rescind
 	install -m 644 srv/salt/ceph/rescind/*.sls $(DESTDIR)/srv/salt/ceph/rescind/
@@ -268,6 +270,10 @@ copy-files:
 	install -m 644 srv/salt/ceph/rescind/storage/*.sls $(DESTDIR)/srv/salt/ceph/rescind/storage/
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/rescind/storage/keyring
 	install -m 644 srv/salt/ceph/rescind/storage/keyring/*.sls $(DESTDIR)/srv/salt/ceph/rescind/storage/keyring/
+	install -d -m 755 $(DESTDIR)/srv/salt/ceph/rescind/openattic
+	install -m 644 srv/salt/ceph/rescind/openattic/*.sls $(DESTDIR)/srv/salt/ceph/rescind/openattic/
+	install -d -m 755 $(DESTDIR)/srv/salt/ceph/rescind/openattic/keyring
+	install -m 644 srv/salt/ceph/rescind/openattic/keyring/*.sls $(DESTDIR)/srv/salt/ceph/rescind/openattic/keyring/
 	# state files - repo
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/repo
 	install -m 644 srv/salt/ceph/repo/*.sls $(DESTDIR)/srv/salt/ceph/repo/
@@ -385,7 +391,7 @@ rpm: tarball test
 	rpmbuild -bb deepsea.spec
 
 # Removing test dependency until resolved
-tarball: 
+tarball:
 	VERSION=`awk '/^Version/ {print $$2}' deepsea.spec`; \
 	git archive --prefix deepsea-$$VERSION/ -o ~/rpmbuild/SOURCES/deepsea-$$VERSION.tar.gz HEAD
 

--- a/deepsea.spec
+++ b/deepsea.spec
@@ -154,6 +154,7 @@ systemctl try-restart salt-master > /dev/null 2>&1 || :
 %dir /srv/salt/ceph/remove/mds
 %dir /srv/salt/ceph/remove/rgw
 %dir /srv/salt/ceph/remove/storage
+%dir /srv/salt/ceph/remove/openattic
 %dir /srv/salt/ceph/reset
 %dir /srv/salt/ceph/rescind
 %dir /srv/salt/ceph/rescind/admin
@@ -176,6 +177,8 @@ systemctl try-restart salt-master > /dev/null 2>&1 || :
 %dir /srv/salt/ceph/rescind/rgw/keyring
 %dir /srv/salt/ceph/rescind/storage
 %dir /srv/salt/ceph/rescind/storage/keyring
+%dir /srv/salt/ceph/rescind/openattic
+%dir /srv/salt/ceph/rescind/openattic/keyring
 %dir /srv/salt/ceph/restart
 %dir /srv/salt/ceph/rgw
 %dir /srv/salt/ceph/rgw/files
@@ -310,6 +313,7 @@ systemctl try-restart salt-master > /dev/null 2>&1 || :
 %config /srv/salt/ceph/remove/mds/*.sls
 %config /srv/salt/ceph/remove/rgw/*.sls
 %config /srv/salt/ceph/remove/storage/*.sls
+%config /srv/salt/ceph/remove/openattic/*.sls
 %config /srv/salt/ceph/rescind/*.sls
 %config /srv/salt/ceph/rescind/admin/*.sls
 %config /srv/salt/ceph/rescind/client-iscsi/*.sls
@@ -331,6 +335,8 @@ systemctl try-restart salt-master > /dev/null 2>&1 || :
 %config /srv/salt/ceph/rescind/rgw/keyring/*.sls
 %config /srv/salt/ceph/rescind/storage/*.sls
 %config /srv/salt/ceph/rescind/storage/keyring/*.sls
+%config /srv/salt/ceph/rescind/openattic/*.sls
+%config /srv/salt/ceph/rescind/openattic/keyring/*.sls
 %config /srv/salt/ceph/reset/*.sls
 %config /srv/salt/ceph/restart/*.sls
 %config /srv/salt/ceph/rgw/*.sls
@@ -386,4 +392,4 @@ systemctl try-restart salt-master > /dev/null 2>&1 || :
 
 %changelog
 * Thu Sep  8 2016 Eric Jackson
-- 
+-

--- a/srv/modules/runners/populate.py
+++ b/srv/modules/runners/populate.py
@@ -516,7 +516,7 @@ class CephRoles(object):
         Create role named directories and create corresponding yaml files
         for every server.
         """
-        roles = [ 'admin', 'mon', 'mds', 'igw' ]
+        roles = [ 'admin', 'mon', 'mds', 'igw', 'openattic' ]
         roles += self._rgw_configurations()
         roles += self._ganesha_configurations()
         self.available_roles.extend(roles)
@@ -852,4 +852,3 @@ def proposals(**kwargs):
         ceph_roles.monitor_members()
         ceph_roles.igw_members()
     return [ True ]
-

--- a/srv/pillar/ceph/init.sls
+++ b/srv/pillar/ceph/init.sls
@@ -1,11 +1,8 @@
 
-
-
 {% include 'ceph/cluster/' + grains['id'] + '.sls' ignore missing %}
 
 {% include 'ceph/master_minion.sls' ignore missing %}
 
 {% include 'ceph/rgw.sls' ignore missing %}
 
-
-
+{% include 'ceph/openattic.sls' ignore missing %}

--- a/srv/pillar/ceph/openattic.sls-example
+++ b/srv/pillar/ceph/openattic.sls-example
@@ -1,0 +1,7 @@
+
+openattic_configurations:
+  drop_database: True
+  stop_services:
+    - apache2
+    - icinga
+    - postgresql

--- a/srv/salt/ceph/openattic/default.sls
+++ b/srv/salt/ceph/openattic/default.sls
@@ -9,4 +9,3 @@ enable openattic-systemd:
   service.running:
     - name: openattic-systemd
     - enable: True
-

--- a/srv/salt/ceph/openattic/oaconfig/default.sls
+++ b/srv/salt/ceph/openattic/oaconfig/default.sls
@@ -1,12 +1,14 @@
 
 restart apache2:
-  cmd.run:
-    - name: "systemctl restart apache2"
+  module.run:
+    - name: service.restart
+    - m_name: apache2
 
 oaconfig:
   cmd.run:
     - name: "oaconfig install --allow-broken-hostname"
 
 restart icinga:
-  cmd.run:
-    - name: "systemctl restart icinga"
+  module.run:
+    - name: service.restart
+    - m_name: icinga

--- a/srv/salt/ceph/remove/openattic/default.sls
+++ b/srv/salt/ceph/remove/openattic/default.sls
@@ -1,0 +1,11 @@
+
+remove openattic nop:
+  test.nop
+
+{% if salt.saltutil.runner('select.minions', cluster='ceph', roles='openattic') == [] %}
+
+remove openattic auth:
+  cmd.run:
+    - name: "ceph auth del client.openattic"
+
+{% endif %}

--- a/srv/salt/ceph/remove/openattic/init.sls
+++ b/srv/salt/ceph/remove/openattic/init.sls
@@ -1,0 +1,3 @@
+
+include:
+  - .{{ salt['pillar.get']('remove_openattic', 'default') }}

--- a/srv/salt/ceph/rescind/openattic/default.sls
+++ b/srv/salt/ceph/rescind/openattic/default.sls
@@ -1,0 +1,42 @@
+
+openattic nop:
+  test.nop
+
+{% if 'openattic' not in salt['pillar.get']('roles') %}
+
+{% if salt['service.available']('openattic-systemd') %}
+stop openattic-systemd:
+  service.dead:
+    - name: openattic-systemd
+    - enable: False
+{% endif %}
+
+{% if salt['pillar.get']('openattic_configurations:drop_database', False) %}
+{% if 'openattic' in salt['pkg.list_pkgs']() %}
+remove openattic database:
+  cmd.run:
+    - names:
+      - "su - postgres -c 'dropdb openattic'"
+      - "su - postgres -c 'dropuser openattic'"
+{% endif %}
+{% endif %}
+
+uninstall openattic:
+  pkg.removed:
+    - pkgs:
+      - openattic
+      - openattic-base
+      - openattic-pgsql
+
+{% for service in salt['pillar.get']('openattic_configurations:stop_services', []) %}
+{% if salt['service.available'](service) %}
+stop {{ service }}:
+  service.dead:
+    - name: {{ service }}
+{% endif %}
+{% endfor %}
+
+include:
+- .keyring
+
+{% endif %}

--- a/srv/salt/ceph/rescind/openattic/init.sls
+++ b/srv/salt/ceph/rescind/openattic/init.sls
@@ -1,0 +1,4 @@
+
+
+include:
+  - .{{ salt['pillar.get']('rescind_openattic', 'default') }}

--- a/srv/salt/ceph/rescind/openattic/keyring/default.sls
+++ b/srv/salt/ceph/rescind/openattic/keyring/default.sls
@@ -1,0 +1,3 @@
+
+/etc/ceph/ceph.client.openattic.keyring:
+  file.absent

--- a/srv/salt/ceph/rescind/openattic/keyring/init.sls
+++ b/srv/salt/ceph/rescind/openattic/keyring/init.sls
@@ -1,0 +1,3 @@
+
+include:
+  - .{{ salt['pillar.get']('rescind_openattic_keyring', 'default') }}

--- a/srv/salt/ceph/stage/openattic/default.sls
+++ b/srv/salt/ceph/stage/openattic/default.sls
@@ -1,4 +1,9 @@
 
+openattic nop:
+  test.nop
+
+{% if salt.saltutil.runner('select.minions', cluster='ceph', roles='openattic') %}
+
 openattic auth:
   salt.state:
     - tgt: {{ salt['pillar.get']('master_minion') }}
@@ -6,20 +11,20 @@ openattic auth:
 
 openattic:
   salt.state:
-    - tgt: "I@roles:master"
+    - tgt: "I@roles:openattic"
     - tgt_type: compound
     - sls: ceph.openattic
 
 openattic keyring:
   salt.state:
-    - tgt: "I@roles:master"
+    - tgt: "I@roles:openattic"
     - tgt_type: compound
     - sls: ceph.openattic.keyring
 
 openattic oaconfig:
   salt.state:
-    - tgt: "I@roles:master"
+    - tgt: "I@roles:openattic"
     - tgt_type: compound
     - sls: ceph.openattic.oaconfig
 
-
+{% endif %}

--- a/srv/salt/ceph/stage/removal/default.sls
+++ b/srv/salt/ceph/stage/removal/default.sls
@@ -41,3 +41,9 @@ remove rgw:
     - tgt: {{ salt['pillar.get']('master_minion') }}
     - tgt_type: compound
     - sls: ceph.remove.rgw
+
+remove openattic:
+  salt.state:
+    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt_type: compound
+    - sls: ceph.remove.openattic

--- a/srv/salt/ceph/stage/services/default.sls
+++ b/srv/salt/ceph/stage/services/default.sls
@@ -4,4 +4,4 @@ include:
   - ..cephfs
   - ..radosgw
   - ..ganesha
-
+  - ..openattic


### PR DESCRIPTION
* Make openATTIC configurable via policy.cfg.
* Use module.run instead of cmd.run to let Salt choose which init system to use to restart services.
* Remove packages openattic openattic-base openattic-pgsql (stage 5)
* If configured, then purge openattic postgres database during uninstall (stage 5)
* Add support for custom pillar data via /src/pillar/openattic.sls to customize oA orchestration.

Signed-off-by: Volker Theile <vtheile@suse.com>