### PR TITLE
Do not start salt-api.service twice.

### DIFF
--- a/srv/salt/ceph/cherrypy/start.sls
+++ b/srv/salt/ceph/cherrypy/start.sls
@@ -1,9 +1,8 @@
 
 
 enable salt-api:
-  service.running:
+  service.enabled:
     - name: salt-api
-    - enable: True
 
 restart salt-master:
   module.run:


### PR DESCRIPTION
Only enable the service in 'enable salt-api' as the target name implies. It is not necessary to start/restart it there because this will be done in the 'restart salt-api' target.

Signed-off-by: Volker Theile <vtheile@suse.com>