### PR TITLE
stage 0: fix mines update regression

### DIFF
--- a/srv/salt/ceph/stage/prep/minion/default.sls
+++ b/srv/salt/ceph/stage/prep/minion/default.sls
@@ -1,9 +1,3 @@
-
-mines:
-  salt.state:
-    - tgt: '*'
-    - sls: ceph.mines
-
 sync:
   salt.state:
     - tgt: '*'
@@ -18,6 +12,11 @@ common packages:
   salt.state:
     - tgt: '*'
     - sls: ceph.packages.common
+
+mines:
+  salt.state:
+    - tgt: '*'
+    - sls: ceph.mines
 
 {% if salt['saltutil.runner']('cephprocesses.mon') == True %}
 


### PR DESCRIPTION
The commit 20b528c introduces a regression on the salt mines,
which prevents the mines from being populated because the packages
necessary for the mine functions have not been installed yet
at that phase.

Signed-off-by: Ricardo Dias <rdias@suse.com>