### PR TITLE
[wip] Single node update 

### DIFF
--- a/srv/modules/runners/orderednodes.py
+++ b/srv/modules/runners/orderednodes.py
@@ -16,7 +16,7 @@ def _preserve_order_sorted(seq):
     return [x for x in seq if x not in seen and not seen.add(x)]
 
 
-def unique(cluster='ceph', exclude=[]):
+def unique(cluster='ceph', exclude=[], single=False):
     """ 
     Assembling a list of nodes.
     Ordered(MON, OSD, MDS, RGW, IGW)  
@@ -42,6 +42,9 @@ def unique(cluster='ceph', exclude=[]):
     for role in roles:
         nodes = client.cmd("I@roles:{} and {}".format(role, cluster_assignment), 'pillar.get', ['roles'], expr_form="compound")
         all_clients += nodes.keys()
+
+    if single:
+        all_clients = all_clients[:1]
 
     sys.stdout = _stdout
     return _preserve_order_sorted(all_clients)

--- a/srv/salt/ceph/maintenance/upgrade/minion/default.sls
+++ b/srv/salt/ceph/maintenance/upgrade/minion/default.sls
@@ -41,7 +41,11 @@ common packages:
 #    - sls: ceph.warning.noout
 #    - failhard: True
 
-{% for host in salt.saltutil.runner('orderednodes.unique', cluster='ceph') %}
+{% set clustername = salt['pillar.get']('cluster', 'ceph') %}
+{% set exclude = salt['pillar.get']('exclude_from_upgrade', []) %}
+{% set single = salt['pillar.get']('single_node_upgrade', False) %}
+
+{% for host in salt.saltutil.runner('orderednodes.unique', cluster=clustername, exclude=exclude, single=single ) %}
 
 upgrading {{ host }}:
   salt.runner:


### PR DESCRIPTION
closes #224

I'm still puzzled on salt's behavior.

when 'single_node_upgrade' is set:

`salt '*' state.show_sls ceph.maintenance.upgrade.minion`

I get the expected rendered output with only one node.(I also get all nodes when 'single_node_upgrade' is unset).

When actually executed, though, it iterates through _all_ nodes.. 

any thoughts?