### PR TITLE
configuration: add include for [global,osd,mon,mds,client].conf

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,7 @@ copy-files:
 	install -m 644 srv/salt/ceph/configuration/check/*.sls $(DESTDIR)/srv/salt/ceph/configuration/check/
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/configuration/files
 	install -m 644 srv/salt/ceph/configuration/files/ceph.conf* $(DESTDIR)/srv/salt/ceph/configuration/files/
+	install -d -m 755 $(DESTDIR)/srv/salt/ceph/configuration/files/ceph.conf.d
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/events
 	install -m 644 srv/salt/ceph/events/*.sls $(DESTDIR)/srv/salt/ceph/events/
 	# state files - diagnose

--- a/deepsea.spec
+++ b/deepsea.spec
@@ -86,6 +86,7 @@ systemctl try-restart salt-master > /dev/null 2>&1 || :
 %dir /srv/salt/ceph/salt-api/files
 %dir /srv/salt/ceph/configuration
 %dir /srv/salt/ceph/configuration/files
+%dir /srv/salt/ceph/configuration/files/ceph.conf.d
 %dir /srv/salt/ceph/configuration/check
 %dir /srv/salt/ceph/diagnose
 %dir /srv/salt/ceph/events

--- a/srv/salt/ceph/configuration/files/ceph.conf.j2
+++ b/srv/salt/ceph/configuration/files/ceph.conf.j2
@@ -1,3 +1,6 @@
+# DeepSea default configuration. Changes in this file will be overwritten on
+# package update. Include custom configuration fragments in
+# /srv/salt/ceph/configuration/files/ceph.conf.d/[global,osd,mon,mds,client].conf
 [global]
 fsid = {{ salt['pillar.get']('fsid') }}
 mon_initial_members = {{ salt['pillar.get']('mon_initial_members') | join(', ') }}
@@ -9,9 +12,21 @@ filestore_xattr_use_omap = true
 public_network = {{ salt['pillar.get']('public_network') }}
 cluster_network = {{ salt['pillar.get']('cluster_network') }}
 rbd default features = 3
+{% include "ceph/configuration/files/ceph.conf.d/global.conf" ignore missing %}
 
 {% for config in salt['rgw.configurations']() %}
 {% set client = config + "." + grains['host'] %}
 {% include "ceph/configuration/files/ceph.conf." + config %}
 {% endfor %}
 
+[osd]
+{% include "ceph/configuration/files/ceph.conf.d/osd.conf" ignore missing %}
+
+[mon]
+{% include "ceph/configuration/files/ceph.conf.d/mon.conf" ignore missing %}
+
+[mds]
+{% include "ceph/configuration/files/ceph.conf.d/mds.conf" ignore missing %}
+
+[client]
+{% include "ceph/configuration/files/ceph.conf.d/client.conf" ignore missing %}


### PR DESCRIPTION
This should provide an easy way to to add custom configuration options
to ceph.conf. Each file can contain global configuration (for the cluster
of a daemon type) and per daemon configuration. Note that per daemon
configuration must be preceded by the daemon name, e.g. [osd.1].
This addresses #205.

Signed-off-by: Jan Fajerski <jfajerski@suse.com>