### PR TITLE
ntp: detect if ntp is running and if so do nothing

### DIFF
--- a/srv/salt/ceph/time/README
+++ b/srv/salt/ceph/time/README
@@ -1,0 +1,10 @@
+Setup ntp to manage system time
+
+Ceph relies on loosely synchronized clocks. DeepSea will by default start an ntp
+client on each client and point to the salt master as their ntp server if and
+only if the ntpd.service is not yet running.
+If you want DeepSea to overwrite and existing ntp configuration set "time_init:
+ntp" in the pillar.
+To disable all ntp management set "time_init: disabled" in the pillar. Note that
+the admin should have some for of time synchronisation set up in this case.
+Otherwise Ceph might not function reliably.

--- a/srv/salt/ceph/time/default.sls
+++ b/srv/salt/ceph/time/default.sls
@@ -1,3 +1,8 @@
 
+{% if salt['service.status']('ntpd') == False %}
 include:
   - .ntp
+{% else %}
+include:
+  - .disabled
+{% endif %}

--- a/srv/salt/ceph/time/ntp.sls
+++ b/srv/salt/ceph/time/ntp.sls
@@ -1,0 +1,3 @@
+
+include:
+  - .ntp


### PR DESCRIPTION
When ntp is running, do not overwrite ntp.conf since we can assume that
ntp is all setup. This should be a better default then blindly blowing
away a running ntp setup. The old behaviour can still be enabled by
setting 'time_init: ntp'.

Signed-off-by: Jan Fajerski <jfajerski@suse.com>