### PR TITLE
Install and deploy prometheus exporters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -155,6 +155,11 @@ copy-files:
 	install -m 644 srv/salt/ceph/mon/files/*.j2 $(DESTDIR)/srv/salt/ceph/mon/files/
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/mon/restart
 	install -m 644 srv/salt/ceph/mon/restart/*.sls $(DESTDIR)/srv/salt/ceph/mon/restart
+	# state files - monitoring
+	install -d -m 755 $(DESTDIR)/srv/salt/ceph/monitoring
+	install -m 644 srv/salt/ceph/monitoring/*.sls $(DESTDIR)/srv/salt/ceph/monitoring/
+	install -d -m 755 $(DESTDIR)/srv/salt/ceph/monitoring/prometheus
+	install -m 644 srv/salt/ceph/monitoring/prometheus/*.sls $(DESTDIR)/srv/salt/ceph/monitoring/prometheus
 	# state files - noout
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/noout
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/noout/set

--- a/deepsea.spec
+++ b/deepsea.spec
@@ -122,6 +122,8 @@ systemctl try-restart salt-master > /dev/null 2>&1 || :
 %dir /srv/salt/ceph/mon/files
 %dir /srv/salt/ceph/mon/key
 %dir /srv/salt/ceph/mon/restart
+%dir /srv/salt/ceph/monitoring
+%dir /srv/salt/ceph/monitoring/prometheus
 %dir /srv/salt/ceph/noout
 %dir /srv/salt/ceph/noout/set
 %dir /srv/salt/ceph/noout/unset
@@ -290,6 +292,8 @@ systemctl try-restart salt-master > /dev/null 2>&1 || :
 %config /srv/salt/ceph/mon/files/*.j2
 %config /srv/salt/ceph/mon/key/*.sls
 %config /srv/salt/ceph/mon/restart/*.sls
+%config /srv/salt/ceph/monitoring/*.sls
+%config /srv/salt/ceph/monitoring/prometheus/*.sls
 %config /srv/salt/ceph/noout/set/*.sls
 %config /srv/salt/ceph/noout/unset/*.sls
 %config /srv/salt/ceph/openattic/*.sls

--- a/srv/salt/ceph/monitoring/default.sls
+++ b/srv/salt/ceph/monitoring/default.sls
@@ -1,0 +1,2 @@
+include:
+  - .prometheus

--- a/srv/salt/ceph/monitoring/disabled.sls
+++ b/srv/salt/ceph/monitoring/disabled.sls
@@ -1,0 +1,2 @@
+monitoring nop:
+  test.nop

--- a/srv/salt/ceph/monitoring/init.sls
+++ b/srv/salt/ceph/monitoring/init.sls
@@ -1,0 +1,4 @@
+
+
+include:
+  - .{{ salt['pillar.get']('monitoring_init', 'default') }}

--- a/srv/salt/ceph/monitoring/prometheus/ceph_exporter.sls
+++ b/srv/salt/ceph/monitoring/prometheus/ceph_exporter.sls
@@ -1,0 +1,11 @@
+{% if 'master' in salt['pillar.get']('roles') %}
+ceph exporter package:
+  pkg.installed:
+    - name: golang-github-digitalocean-ceph_exporter
+    - fire_event: True
+
+start ceph exporter:
+  service.running:
+    - name: prometheus-ceph_exporter
+    - enable: True
+{% endif %}

--- a/srv/salt/ceph/monitoring/prometheus/init.sls
+++ b/srv/salt/ceph/monitoring/prometheus/init.sls
@@ -1,0 +1,3 @@
+include:
+  - .node_exporter
+  - .ceph_exporter

--- a/srv/salt/ceph/monitoring/prometheus/node_exporter.sls
+++ b/srv/salt/ceph/monitoring/prometheus/node_exporter.sls
@@ -1,0 +1,9 @@
+node exporter package:
+  pkg.installed:
+    - name: golang-github-prometheus-node_exporter
+    - fire_event: True
+
+start node exporter:
+  service.running:
+    - name: prometheus-node_exporter
+    - enable: True


### PR DESCRIPTION
This adds support for installation and deployment of the prometheus exporters. Assumption is that the repos offer the requested packages. The ceph_exporter is installed on the salt_master (since it needs an admin keyring), the node_exporter is installed on all nodes that are targeted.

This is not yet integrated into any particular stage, but it's easy enough to do.