### PR TITLE
Fix ordering of Storage node removal

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -226,6 +226,8 @@ copy-files:
 	install -m 644 srv/salt/ceph/remove/storage/*.sls $(DESTDIR)/srv/salt/ceph/remove/storage/
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/remove/openattic
 	install -m 644 srv/salt/ceph/remove/openattic/*.sls $(DESTDIR)/srv/salt/ceph/remove/openattic/
+	install -d -m 755 $(DESTDIR)/srv/salt/ceph/remove/storage/drain
+	install -m 644 srv/salt/ceph/remove/storage/drain/*.sls $(DESTDIR)/srv/salt/ceph/remove/storage/drain
 	# state files - rescind
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/rescind
 	install -m 644 srv/salt/ceph/rescind/*.sls $(DESTDIR)/srv/salt/ceph/rescind/
@@ -275,6 +277,8 @@ copy-files:
 	install -m 644 srv/salt/ceph/rescind/openattic/*.sls $(DESTDIR)/srv/salt/ceph/rescind/openattic/
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/rescind/openattic/keyring
 	install -m 644 srv/salt/ceph/rescind/openattic/keyring/*.sls $(DESTDIR)/srv/salt/ceph/rescind/openattic/keyring/
+	install -d -m 755 $(DESTDIR)/srv/salt/ceph/rescind/storage/terminate
+	install -m 644 srv/salt/ceph/rescind/storage/terminate/*.sls $(DESTDIR)/srv/salt/ceph/rescind/storage/terminate/
 	# state files - repo
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/repo
 	install -m 644 srv/salt/ceph/repo/*.sls $(DESTDIR)/srv/salt/ceph/repo/

--- a/deepsea.spec
+++ b/deepsea.spec
@@ -319,9 +319,10 @@ systemctl try-restart salt-master > /dev/null 2>&1 || :
 %config /srv/salt/ceph/remove/igw/auth/*.sls
 %config /srv/salt/ceph/remove/mon/*.sls
 %config /srv/salt/ceph/remove/mds/*.sls
+%config /srv/salt/ceph/remove/openattic/*.sls
 %config /srv/salt/ceph/remove/rgw/*.sls
 %config /srv/salt/ceph/remove/storage/*.sls
-%config /srv/salt/ceph/remove/openattic/*.sls
+%config /srv/salt/ceph/remove/storage/drain/*.sls
 %config /srv/salt/ceph/rescind/*.sls
 %config /srv/salt/ceph/rescind/admin/*.sls
 %config /srv/salt/ceph/rescind/client-iscsi/*.sls
@@ -346,6 +347,7 @@ systemctl try-restart salt-master > /dev/null 2>&1 || :
 %config /srv/salt/ceph/rescind/openattic/*.sls
 %config /srv/salt/ceph/rescind/openattic/keyring/*.sls
 %config /srv/salt/ceph/reset/*.sls
+%config /srv/salt/ceph/rescind/storage/terminate/*.sls
 %config /srv/salt/ceph/restart/*.sls
 %config /srv/salt/ceph/restart/osd/*.sls
 %config /srv/salt/ceph/restart/mon/*.sls

--- a/srv/salt/ceph/remove/storage/default.sls
+++ b/srv/salt/ceph/remove/storage/default.sls
@@ -3,10 +3,6 @@ reweight nop:
   test.nop
 
 {% for id in salt.saltutil.runner('rescinded.ids', cluster='ceph') %}
-clear osd.{{ id }}:
-  module.run:
-    - name: osd.zero_weight
-    - id: {{ id }}
 
 down id {{ id }}:
   module.run:
@@ -22,10 +18,8 @@ delete osd.{{ id }} key:
     - name: "ceph auth del osd.{{ id }}"
 
 remove id {{ id }}:
-  module.run:
-    - name: retry.cmd
-    - kwargs:
-        cmd: "ceph osd rm {{ id }}"
+  cmd.run:
+    - name: "ceph osd rm {{ id }}"
 
 {% endfor %}
 

--- a/srv/salt/ceph/remove/storage/default.sls
+++ b/srv/salt/ceph/remove/storage/default.sls
@@ -4,11 +4,6 @@ reweight nop:
 
 {% for id in salt.saltutil.runner('rescinded.ids', cluster='ceph') %}
 
-down id {{ id }}:
-  module.run:
-    - name: osd.down
-    - id: {{ id }}
-
 remove osd.{{ id }}:
   cmd.run:
     - name: "ceph osd crush remove osd.{{ id }}"

--- a/srv/salt/ceph/remove/storage/drain/default.sls
+++ b/srv/salt/ceph/remove/storage/drain/default.sls
@@ -1,0 +1,12 @@
+
+reweight nop:
+  test.nop
+
+{% for id in salt.saltutil.runner('rescinded.ids', cluster='ceph') %}
+drain osd.{{ id }}:
+  module.run:
+    - name: osd.zero_weight
+    - id: {{ id }}
+
+{% endfor %}
+

--- a/srv/salt/ceph/remove/storage/drain/default.sls
+++ b/srv/salt/ceph/remove/storage/drain/default.sls
@@ -8,5 +8,9 @@ drain osd.{{ id }}:
     - name: osd.zero_weight
     - id: {{ id }}
 
+set osd {{ id }} out:
+  cmd.run:
+    - name: "ceph osd out {{ id }}"
+
 {% endfor %}
 

--- a/srv/salt/ceph/remove/storage/drain/init.sls
+++ b/srv/salt/ceph/remove/storage/drain/init.sls
@@ -1,0 +1,4 @@
+
+
+include:
+  - .{{ salt['pillar.get']('remove_storage_drain', 'default') }}

--- a/srv/salt/ceph/rescind/storage/default.sls
+++ b/srv/salt/ceph/rescind/storage/default.sls
@@ -4,33 +4,6 @@ storage nop:
 
 {% if 'storage' not in salt['pillar.get']('roles') %}
 
-
-terminate osds:
-  module.run:
-  - name: retry.pkill
-  - kwargs:
-      pattern: "ceph-osd"
-
-{% for id in salt['osd.list']() %}
-
-# systemctl stop ceph-osd@id can hang
-#stop osd.{{ id }}:
-#  service.dead:
-#    - name: ceph-osd@{{ id }}
-#    - enable: False
-#
-# Does not work
-#systemctl terminate osds:
-#  cmd.run:
-#    - name: "systemctl kill ceph-osd*"
-#
-#systemctl kill osds:
-#  cmd.run:
-#    - name: "systemctl kill --signal=9 ceph-osd*"
-
-{% endfor %}
-
-
 {# 33 * 4096.  See https://en.wikipedia.org/wiki/GUID_Partition_Table #}
 
 {% for device, path in salt['osd.pairs']() %}

--- a/srv/salt/ceph/rescind/storage/terminate/default.sls
+++ b/srv/salt/ceph/rescind/storage/terminate/default.sls
@@ -1,0 +1,33 @@
+
+storage nop:
+  test.nop
+
+{% if 'storage' not in salt['pillar.get']('roles') %}
+
+terminate osds:
+  cmd.run:
+    - name: "pkill ceph-osd"
+    - onlyif: "pgrep ceph-osd"
+
+sleep 3 seconds:
+  module.run:
+    - name: test.sleep
+    - length: 3
+
+kill osds:
+  cmd.run:
+    - name: "pkill -9 ceph-osd"
+    - onlyif: "pgrep ceph-osd"
+
+{% for id in salt['osd.list']() %}
+
+# systemctl stop ceph-osd@id can hang
+#stop osd.{{ id }}:
+#  service.dead:
+#    - name: ceph-osd@{{ id }}
+#    - enable: False
+
+{% endfor %}
+
+
+{% endif %}

--- a/srv/salt/ceph/rescind/storage/terminate/default.sls
+++ b/srv/salt/ceph/rescind/storage/terminate/default.sls
@@ -4,6 +4,11 @@ storage nop:
 
 {% if 'storage' not in salt['pillar.get']('roles') %}
 
+# systemctl stop ceph-osd@id can hang
+stop osds:
+  cmd.run:
+    - name: "systemctl stop ceph-osd.target"
+
 terminate osds:
   cmd.run:
     - name: "pkill ceph-osd"
@@ -18,16 +23,5 @@ kill osds:
   cmd.run:
     - name: "pkill -9 ceph-osd"
     - onlyif: "pgrep ceph-osd"
-
-{% for id in salt['osd.list']() %}
-
-# systemctl stop ceph-osd@id can hang
-#stop osd.{{ id }}:
-#  service.dead:
-#    - name: ceph-osd@{{ id }}
-#    - enable: False
-
-{% endfor %}
-
 
 {% endif %}

--- a/srv/salt/ceph/rescind/storage/terminate/init.sls
+++ b/srv/salt/ceph/rescind/storage/terminate/init.sls
@@ -1,0 +1,4 @@
+
+
+include:
+  - .{{ salt['pillar.get']('rescind_storage_terminate', 'default') }}

--- a/srv/salt/ceph/stage/removal/default.sls
+++ b/srv/salt/ceph/stage/removal/default.sls
@@ -12,17 +12,29 @@ remove mon:
     - tgt_type: compound
     - sls: ceph.remove.mon
 
-empty osds:
+drain osds:
   salt.state:
     - tgt: {{ salt['pillar.get']('master_minion') }}
     - tgt_type: compound
-    - sls: ceph.remove.storage
+    - sls: ceph.remove.storage.drain
+
+terminate ceph osds:
+  salt.state:
+    - tgt: 'I@cluster:ceph'
+    - tgt_type: compound
+    - sls: ceph.rescind.storage.terminate
 
 remove ganesha:
   salt.state:
     - tgt: {{ salt['pillar.get']('master_minion') }}
     - tgt_type: compound
     - sls: ceph.remove.ganesha
+
+cleanup osds:
+  salt.state:
+    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt_type: compound
+    - sls: ceph.remove.storage
 
 rescind roles:
   salt.state:

--- a/srv/salt/ceph/stage/removal/default.sls
+++ b/srv/salt/ceph/stage/removal/default.sls
@@ -24,17 +24,17 @@ terminate ceph osds:
     - tgt_type: compound
     - sls: ceph.rescind.storage.terminate
 
-remove ganesha:
-  salt.state:
-    - tgt: {{ salt['pillar.get']('master_minion') }}
-    - tgt_type: compound
-    - sls: ceph.remove.ganesha
-
 cleanup osds:
   salt.state:
     - tgt: {{ salt['pillar.get']('master_minion') }}
     - tgt_type: compound
     - sls: ceph.remove.storage
+
+remove ganesha:
+  salt.state:
+    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt_type: compound
+    - sls: ceph.remove.ganesha
 
 rescind roles:
   salt.state:


### PR DESCRIPTION
I thought I had cherry-picked this from the SES4 branch in the past, but the logic is still broken in main.  I verified that removal works properly against master with these changes.

Signed-off-by: Eric Jackson <ejackson@suse.com>