### PR TITLE
NFS-Ganesha: Remove installation of service file.

### DIFF
--- a/srv/salt/ceph/ganesha/configure/default.sls
+++ b/srv/salt/ceph/ganesha/configure/default.sls
@@ -7,13 +7,3 @@
     - group: root
     - mode: 644
 {% endfor %}
-
-/etc/sysconfig/ganesha:
-  file.managed:
-    - source: salt://ceph/ganesha/files/ganesha.service
-    - template: jinja
-    - user: root
-    - group: root
-    - mode: 644
-
-

--- a/srv/salt/ceph/ganesha/files/ganesha.service
+++ b/srv/salt/ceph/ganesha/files/ganesha.service
@@ -1,7 +1,0 @@
-#Possible log levels in order of verbosity
-# - NIV_CRIT
-# - NIV_WARN
-# - NIV_DEBUG
-# - NIV_FULL_DEBUG
-
-OPTIONS= "-L /var/log/ganesha.log -N NIV_CRIT"


### PR DESCRIPTION
NFS-Ganesha package installs the service file "nfs-ganesha" at /etc/sysconfig.
For SUSE, we use the service file name as "nfs-ganesha". Other distributions require
service file to be named "ganesha".

Signed-off-by: Supriti Singh <supriti.singh@suse.com>