### PR TITLE
ui_rgw: fixed bugs in ui_rgw runner

### DIFF
--- a/srv/modules/runners/ui_rgw.py
+++ b/srv/modules/runners/ui_rgw.py
@@ -86,10 +86,11 @@ class Radosgw(object):
         urls.
         """
         search = "I@cluster:{}".format(self.cluster)
+        __opts__ = salt.config.client_config('/etc/salt/master')
         pillar_util = salt.utils.master.MasterPillarUtil(search, "compound",
                                                          use_cached_grains=True,
                                                          grains_fallback=False,
-                                                         opts='__opts__')
+                                                         opts=__opts__)
         cached = pillar_util.get_minion_pillar()
         for minion in cached:
             if 'rgw_endpoint' in cached[minion]:
@@ -119,7 +120,7 @@ class Radosgw(object):
                 self.credentials['urls'].append("http{}://{}".format(ssl, resource))
 
 
-def credentials(canned=None):
+def credentials(canned=None, **kwargs):
     """
     Return the administrative credentials for the RadosGW
     """

--- a/tests/unit/runners/test_ui_rgw.py
+++ b/tests/unit/runners/test_ui_rgw.py
@@ -81,10 +81,11 @@ class TestRadosgw():
         
         assert result == rg.credentials
 
+    @patch('salt.config.client_config', autospec=True)
     @patch('salt.utils.master.MasterPillarUtil', autospec=True)
     @patch('__builtin__.open', new=f_open)
     @patch('glob.glob', new=f_glob.glob)
-    def test_urls_dedicated_node(self, masterpillarutil):
+    def test_urls_dedicated_node(self, masterpillarutil, config):
         result = {'urls': ["http://rgw1:7480"],
                   'access_key': None, 
                   'secret_key': None,
@@ -98,10 +99,11 @@ class TestRadosgw():
         
         assert result == rg.credentials
 
+    @patch('salt.config.client_config', autospec=True)
     @patch('salt.utils.master.MasterPillarUtil', autospec=True)
     @patch('__builtin__.open', new=f_open)
     @patch('glob.glob', new=f_glob.glob)
-    def test_urls_dedicated_node_with_ssl(self, masterpillarutil):
+    def test_urls_dedicated_node_with_ssl(self, masterpillarutil, config):
         result = {'urls': ["https://rgw1:443"],
                   'access_key': None, 
                   'secret_key': None,
@@ -115,10 +117,11 @@ class TestRadosgw():
         
         assert result == rg.credentials
 
+    @patch('salt.config.client_config', autospec=True)
     @patch('salt.utils.master.MasterPillarUtil', autospec=True)
     @patch('__builtin__.open', new=f_open)
     @patch('glob.glob', new=f_glob.glob)
-    def test_urls_shared_node(self, masterpillarutil):
+    def test_urls_shared_node(self, masterpillarutil, config):
         result = {'urls': ["http://rgw:7480"],
                   'access_key': None, 
                   'secret_key': None,
@@ -132,10 +135,11 @@ class TestRadosgw():
         
         assert result == rg.credentials
 
+    @patch('salt.config.client_config', autospec=True)
     @patch('salt.utils.master.MasterPillarUtil', autospec=True)
     @patch('__builtin__.open', new=f_open)
     @patch('glob.glob', new=f_glob.glob)
-    def test_urls_shared_node_with_ssl(self, masterpillarutil):
+    def test_urls_shared_node_with_ssl(self, masterpillarutil, config):
         result = {'urls': ["https://rgw:443"],
                   'access_key': None, 
                   'secret_key': None,
@@ -149,10 +153,11 @@ class TestRadosgw():
         
         assert result == rg.credentials
 
+    @patch('salt.config.client_config', autospec=True)
     @patch('salt.utils.master.MasterPillarUtil', autospec=True)
     @patch('__builtin__.open', new=f_open)
     @patch('glob.glob', new=f_glob.glob)
-    def test_urls_malformed(self, masterpillarutil):
+    def test_urls_malformed(self, masterpillarutil, config):
         result = {'urls': [],
                   'access_key': None, 
                   'secret_key': None,
@@ -166,10 +171,11 @@ class TestRadosgw():
         
         assert result == rg.credentials
 
+    @patch('salt.config.client_config', autospec=True)
     @patch('salt.utils.master.MasterPillarUtil', autospec=True)
     @patch('__builtin__.open', new=f_open)
     @patch('glob.glob', new=f_glob.glob)
-    def test_urls_endpoint_defined(self, masterpillarutil):
+    def test_urls_endpoint_defined(self, masterpillarutil, config):
         result = {'urls': ["http://abc.def"],
                   'access_key': None, 
                   'secret_key': None,


### PR DESCRIPTION
The use of the string `'__opts__'` was triggering an exception inside salt code, and `**kwargs` was missing in the `credentials` function, which is required to call the runner from salt-api.

Signed-off-by: Ricardo Dias <rdias@suse.com>