### PR TITLE
byte to gb conversion

### DIFF
--- a/srv/salt/_modules/osd.py
+++ b/srv/salt/_modules/osd.py
@@ -379,7 +379,7 @@ class OSDConfig(object):
         """
         Check disk is less than 10GB, useful in VM environments
         """
-        return self.size < 10000000000000 # 10GB
+        return self.size < 10000000000 # 10GB
 
     def _config_version(self):
         """


### PR DESCRIPTION
10000000000 bytes -> 10 gibabytes

The current version identifies any disk smaller than 10TB as 'small'
 