### PR TITLE
is_prepared and is_activated needs correct device identifier

### DIFF
--- a/srv/salt/_modules/cephdisks.py
+++ b/srv/salt/_modules/cephdisks.py
@@ -319,12 +319,19 @@ class HardwareDetections(object):
         # TODO: Search for all possible codes:
         data = "Partition GUID code: 45B0969E-9B03-4F30-B4C6-B4B80CEFF106"
         journal = "Partition GUID code: 4FBD7E29-9D25-41B8-AFD0-062C0CEFF05D"
+        db = "Partition GUID code: 30CD0809-C2B2-499C-8879-2D6B78529876"
+        wal = "Partition GUID code: 5CE17FCE-4087-4169-B7FF-056CC58473F9"
+        osd_lockbox = "Partition GUID code: FB3AABF9-D25F-47CC-BF5E-721D1816496B"
         sgdisk_path = self._which('sgdisk')
         for partition_id in ids:
             cmd = "{} -i {} {}".format(sgdisk_path, partition_id, device)
             proc = Popen(cmd, stdout=PIPE, stderr=PIPE, shell=True)
             for line in proc.stdout:
-                if (line.startswith(data) or line.startswith(journal)):
+                if line.startswith(data) or \
+                   line.startswith(journal) or \
+                   line.startswith(db) or \
+                   line.startswith(wal) or \
+                   line.startswith(osd_lockbox):
                     return True
             for line in proc.stderr:
                 log.error(line)

--- a/srv/salt/_modules/osd.py
+++ b/srv/salt/_modules/osd.py
@@ -76,10 +76,6 @@ def configured(**kwargs):
     """
     osds = []
     devices = []
-    # That doesn't allow mixed configurations
-    # storage[osds] OR storage[data+journals]
-    # TODO: append devices from one config version
-    # See https://github.com/SUSE/DeepSea/issues/295
     if ('ceph' in __pillar__ and 'storage' in __pillar__['ceph']
         and 'osds' in __pillar__['ceph']['storage']):
         devices = __pillar__['ceph']['storage']['osds']

--- a/srv/salt/_modules/osd.py
+++ b/srv/salt/_modules/osd.py
@@ -79,6 +79,7 @@ def configured(**kwargs):
     # That doesn't allow mixed configurations
     # storage[osds] OR storage[data+journals]
     # TODO: append devices from one config version
+    # See https://github.com/SUSE/DeepSea/issues/295
     if ('ceph' in __pillar__ and 'storage' in __pillar__['ceph']
         and 'osds' in __pillar__['ceph']['storage']):
         devices = __pillar__['ceph']['storage']['osds']
@@ -888,6 +889,7 @@ class OSDCommands(object):
         """
         args = ""
         if self.osd.wal and self.osd.db:
+            # redundant check
             if self.osd.wal:
                 if self.is_partitioned(self.osd.wal):
                     partition = self._highest_partition(self.osd.wal, 'wal')
@@ -899,6 +901,7 @@ class OSDCommands(object):
                     args = "--block.wal {} ".format(self.osd.wal)
 
             if self.osd.db:
+            # redundant check
                 if self.is_partitioned(self.osd.db):
                     partition = self._highest_partition(self.osd.db, 'db')
                     if partition:
@@ -936,6 +939,9 @@ class OSDCommands(object):
                 else:
                     args += "--block.db {} ".format(self.osd.db)
 
+        # if the device is already partitioned
+        # but the partitionnumber is not 1
+        # this will fail
         if self.is_partitioned(self.osd.device):
             args += "{}1".format(self.osd.device)
         else:

--- a/srv/salt/_modules/osd.py
+++ b/srv/salt/_modules/osd.py
@@ -1126,7 +1126,7 @@ def is_prepared(device):
         log.error("Do not know which partition to check on {}".format(device))
         return "/bin/false"
 
-    if osdc.is_partition('osd', device, partition) and _fsck(device, partition):
+    if osdc.is_partition('osd', config.device, partition) and _fsck(config.device, partition):
         return "/bin/true"
     else:
         return "/bin/false"
@@ -1151,7 +1151,7 @@ def is_activated(device):
     config = OSDConfig(device)
     osdc = OSDCommands(config)
     partition = osdc.osd_partition()
-    pathname = "{}{}".format(device, partition)
+    pathname = "{}{}".format(config.device, partition)
     log.info("Checking /proc/mounts for {}".format(pathname))
     with open("/proc/mounts", "r") as mounts:
         for line in mounts:

--- a/srv/salt/_modules/osd.py
+++ b/srv/salt/_modules/osd.py
@@ -540,20 +540,6 @@ class OSDPartitions(object):
             self._bluestore_partitions(self.osd.device)
         return 0
 
-    #def _journal_default(self, device):
-    #    """
-    #    Return a default journal size when one is not provided.  Use 5G unless
-    #    the drive is under 10G, then use 10%.
-    #    """
-    #    
-    #    for disk in self.disks[__grains__['id']]:
-    #        if disk['Device File'] == device:
-    #            if int(disk['Bytes']) < 10000000000000: # 10GB
-    #                return "{}K".format(int(int(disk['Bytes']) * 0.0001))
-    #            else:
-    #                return "5242880K"
-    #    return 0
-
     def _xfs_partitions(self, device, disk_size):
         """
         Create partitions when journal_size is specified, use a default when
@@ -674,7 +660,8 @@ class OSDPartitions(object):
         types = {'osd': '4FBD7E29-9D25-41B8-AFD0-062C0CEFF05D',
                  'journal': '45B0969E-9B03-4F30-B4C6-B4B80CEFF106',
                  'wal': '5CE17FCE-4087-4169-B7FF-056CC58473F9',
-                 'db': '30CD0809-C2B2-499C-8879-2D6B78529876'}
+                 'db': '30CD0809-C2B2-499C-8879-2D6B78529876',
+                 'lockbox': 'FB3AABF9-D25F-47CC-BF5E-721D1816496B'}
 
         last_partition = self._last_partition(device)
         index = 1
@@ -698,7 +685,7 @@ class OSDPartitions(object):
         pathnames = glob.glob("{}?*".format(device))
         if pathnames:
             partitions = sorted([ p.replace(device, "") for p in pathnames ], key=int)
-            last_part = int(pathnames[-1].replace(device, ""))
+            last_part = int(partitions[-1].replace(device, ""))
             return last_part
         return 0
 
@@ -776,10 +763,12 @@ class OSDCommands(object):
         """
         Check partition type
         """
-        types = { 'osd': '4FBD7E29-9D25-41B8-AFD0-062C0CEFF05D',
-                  'journal': '45B0969E-9B03-4F30-B4C6-B4B80CEFF106',
-                  'wal': '5CE17FCE-4087-4169-B7FF-056CC58473F9',
-                  'db': '30CD0809-C2B2-499C-8879-2D6B78529876'}
+        types = {'osd': '4FBD7E29-9D25-41B8-AFD0-062C0CEFF05D',
+                 'journal': '45B0969E-9B03-4F30-B4C6-B4B80CEFF106',
+                 'wal': '5CE17FCE-4087-4169-B7FF-056CC58473F9',
+                 'db': '30CD0809-C2B2-499C-8879-2D6B78529876',
+                 'lockbox': 'FB3AABF9-D25F-47CC-BF5E-721D1816496B'}
+
         cmd = "/usr/sbin/sgdisk -i {} {}".format(partition, device)
         log.info(cmd)
         proc = Popen(cmd, stdout=PIPE, stderr=PIPE, shell=True)

--- a/srv/salt/_modules/osd.py
+++ b/srv/salt/_modules/osd.py
@@ -83,6 +83,7 @@ def configured(**kwargs):
         and 'osds' in __pillar__['ceph']['storage']):
         devices = __pillar__['ceph']['storage']['osds']
         devices = _filter_devices(devices, **kwargs)
+        devices = devices.keys()
     if 'storage' in __pillar__ and 'osds' in __pillar__['storage']:
         devices = __pillar__['storage']['osds']
         log.debug("devices: {}".format(devices))
@@ -470,7 +471,7 @@ class OSDConfig(object):
                 for disk in disks[__grains__['id']]:
                     # Check size of journal disk
                     if disk['Device File'] == self.journal:
-                        if int(disk['Bytes']) < 10000000000000: # 10GB
+                        if int(disk['Bytes']) < 10000000000: # 10GB
                             return "{}K".format(int(int(disk['Bytes']) * 0.0001))
                         else:
                             return "5242880K"


### PR DESCRIPTION
bare-metal returns by-id disk path while virtualized env return only the short path.

while the previous fixes for the disk identifier solved the initial problem, this is a followup fix for is_prepared() and is_activated()

fix: don't use the raw device as it comes from osd.configured() but rather the converted/sanitized attribute

part2)

data+journals struct wasn't correctly accessed hence not parsed.
