### PR TITLE
NFS-Ganesha: Disable kerberos.

### DIFF
--- a/srv/salt/ceph/ganesha/files/ganesha.conf.j2
+++ b/srv/salt/ceph/ganesha/files/ganesha.conf.j2
@@ -51,3 +51,11 @@ RGW {
 
 
 {% endif %}
+
+#NFS-Ganesha is compiled with kerberos support.
+#Set this value to true to use kerberos support.
+#Refer to man page "ganesha-core-config"
+NFS_KRB5
+{
+	Active_krb5 = false;
+}


### PR DESCRIPTION
NFS-Ganesha is compiled with kerberos. In system without
kerberos, it complain. Set "Active_Krb5" to False.

Signed-off-by: Supriti Singh <supriti.singh@suse.com>