### PR TITLE
try running py27 explicitly on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ matrix:
   include:
     - env: TOXENV=lint
       python: '2.7'
+    - env: TOXENV=py27
+      python: '2.7'
   allow_failures:
     - env: TOXENV=lint
 script:


### PR DESCRIPTION
Looks like travis changed their behaviour recently, run the tox job for 2.7 explicitly

Signed-off-by: Abhishek Lekshmanan <abhishek@suse.com>