### PR TITLE
runners: cephprocess avoid empty list as a default arg.

### DIFF
--- a/srv/modules/runners/cephprocesses.py
+++ b/srv/modules/runners/cephprocesses.py
@@ -18,7 +18,7 @@ A secondary purpose is a utility to check the current state of all processes.
 """
 
 
-def check(cluster='ceph', roles=[], tolerate_down=0, verbose=True):
+def check(cluster='ceph', roles=None, tolerate_down=0, verbose=True):
     """
     Query the status of running processes for each role.  Also, verify that
     all minions assigned roles do respond.  Return False if any fail.
@@ -68,6 +68,7 @@ def _status(search, roles, verbose):
 
     status = {}
     local = salt.client.LocalClient()
+    roles = roles or []
 
     for role in roles:
         role_search = search + " and I@roles:{}".format(role)


### PR DESCRIPTION
Since this would bring a whole world of pain that is hard to debug as
lists tend to be mutable, unless this is the expected behaviour. We are
doing a `if not roles` which should cover the case for an empty list.
Otherwise subsequent calls would have the value of roles filled from
previous cache, which may not be the expected behaviour.

Signed-off-by: Abhishek Lekshmanan <abhishek@suse.com>