### PR TITLE
qa: implement basic CephFS integration test

### DIFF
--- a/qa/common/common.sh
+++ b/qa/common/common.sh
@@ -62,30 +62,42 @@ function run_stage_5 {
   _run_stage 5 "$@"
 }
 
-
-function gen_policy_cfg {
+function gen_policy_cfg_base {
   cat <<EOF > /srv/pillar/ceph/proposals/policy.cfg
 # Cluster assignment
 cluster-ceph/cluster/*.sls
-# All nodes get the admin keyring
-role-admin/cluster/*.sls
-# Hardware Profile - no OSDs on the last node
-profile-*-1/cluster/*.sls slice=[:-1]
-profile-*-1/stack/default/ceph/minions/*yml slice=[:-1]
 # Common configuration
 config/stack/default/global.yml
 config/stack/default/ceph/cluster.yml
 # Role assignment - master
 role-master/cluster/${SALT_MASTER}*.sls
-# Role assignment - mon (just one, on the first node)
+# Role assignment - admin
+role-admin/cluster/*.sls
+# Role assignment - mon
 role-mon/cluster/*.sls slice=[:1]
 role-mon/stack/default/ceph/minions/*.yml slice=[:1]
 EOF
 }
 
+function gen_policy_cfg_no_client {
+  cat <<EOF >> /srv/pillar/ceph/proposals/policy.cfg
+# Hardware Profile
+profile-*-1/cluster/*.sls
+profile-*-1/stack/default/ceph/minions/*yml
+EOF
+}
+
+function gen_policy_cfg_client {
+  cat <<EOF >> /srv/pillar/ceph/proposals/policy.cfg
+# Hardware Profile
+profile-*-1/cluster/*.sls slice=[:-1]
+profile-*-1/stack/default/ceph/minions/*yml slice=[:-1]
+EOF
+}
+
 function gen_policy_cfg_mds {
   cat <<EOF >> /srv/pillar/ceph/proposals/policy.cfg
-# Role assignment - MDS (all but the last test node)
+# Role assignment - mds
 role-mds/cluster/*.sls slice=[:-1]
 EOF
 }

--- a/qa/common/common.sh
+++ b/qa/common/common.sh
@@ -83,17 +83,14 @@ role-mon/stack/default/ceph/minions/*.yml slice=[:3]
 EOF
 }
 
-function gen_policy_cfg_client {
-  cat <<EOF > /srv/pillar/ceph/proposals/policy.cfg
-# Role assignment - client (last test node)
-role-client/cluster/*.sls slice=[-1:]
-EOF
-}
-
 function gen_policy_cfg_mds {
-  cat <<EOF > /srv/pillar/ceph/proposals/policy.cfg
+  cat <<EOF >> /srv/pillar/ceph/proposals/policy.cfg
 # Role assignment - MDS (all but the last test node)
 role-mds/cluster/*.sls slice=[:-1]
 EOF
+}
+
+function cat_policy_cfg {
+  cat /srv/pillar/ceph/proposals/policy.cfg
 }
 

--- a/qa/common/common.sh
+++ b/qa/common/common.sh
@@ -94,3 +94,25 @@ function cat_policy_cfg {
   cat /srv/pillar/ceph/proposals/policy.cfg
 }
 
+function ceph_health_test {
+  ceph -s | tee /dev/stderr | grep -q 'HEALTH_OK\|HEALTH_WARN'
+}
+
+function cephfs_mount_and_sanity_test {
+  #
+  # mounts cephfs in /mnt, touches a file, asserts that it exists
+  #
+  local mons=$(ceph-conf --lookup 'mon_initial_members' | tr -d '[:space:]')
+  local secr=$(grep 'key =' /etc/ceph/ceph.client.admin.keyring | awk '{print $NF}')
+  #sleep 10
+  echo "Running as: $(whoami)"
+  echo "Mounting cephfs"
+  echo "MONs: $mons"
+  echo "admin secret: $secr"
+  test -d /mnt
+  mount -t ceph ${mons}:/ /mnt -o name=admin,secret="$secr"
+  touch /mnt/bubba
+  test -f /mnt/bubba
+  umount /mnt
+}
+

--- a/qa/common/common.sh
+++ b/qa/common/common.sh
@@ -21,10 +21,10 @@ function _run_stage {
   echo ""
 
   salt-run --no-color state.orch ceph.stage.${stage_num} | tee /tmp/stage.${stage_num}.log
-  STAGE_FINISHED=$(fgrep 'Total states run' /tmp/stage.${stage_num}.log)
+  STAGE_FINISHED=$(grep -F 'Total states run' /tmp/stage.${stage_num}.log)
 
   if [[ ! -z $STAGE_FINISHED ]]; then
-    FAILED=$(fgrep 'Failed: ' /tmp/stage.${stage_num}.log | sed 's/.*Failed:\s*//g' | head -1)
+    FAILED=$(grep -F 'Failed: ' /tmp/stage.${stage_num}.log | sed 's/.*Failed:\s*//g' | head -1)
     if [[ "$FAILED" -gt "0" ]]; then
       echo "********** Stage $stage_num failed with $FAILED failures **********"
       echo "Check /tmp/stage.${stage_num}.log for details"
@@ -98,21 +98,44 @@ function ceph_health_test {
   ceph -s | tee /dev/stderr | grep -q 'HEALTH_OK\|HEALTH_WARN'
 }
 
+function _client_node {
+  #
+  # FIXME: migrate this to "salt --static --out json ... | jq ..."
+  #
+  salt --no-color -C 'not I@roles:storage' test.ping | grep -o -P '^\S+(?=:)' | head -1
+}
+
+function _mds_node {
+  salt --no-color -C 'I@roles:mds' test.ping | grep -o -P '^\S+(?=:)' | head -1
+}
+
 function cephfs_mount_and_sanity_test {
   #
+  # run cephfs mount test script on the client node
   # mounts cephfs in /mnt, touches a file, asserts that it exists
   #
-  local mons=$(ceph-conf --lookup 'mon_initial_members' | tr -d '[:space:]')
-  local secr=$(grep 'key =' /etc/ceph/ceph.client.admin.keyring | awk '{print $NF}')
-  #sleep 10
-  echo "Running as: $(whoami)"
-  echo "Mounting cephfs"
-  echo "MONs: $mons"
-  echo "admin secret: $secr"
-  test -d /mnt
-  mount -t ceph ${mons}:/ /mnt -o name=admin,secret="$secr"
-  touch /mnt/bubba
-  test -f /mnt/bubba
-  umount /mnt
+  local TESTSCRIPT=/tmp/cephfs_test.sh
+  cat << 'EOF' > $TESTSCRIPT
+set -ex
+trap 'echo "Result: NOT_OK"' ERR
+echo "cephfs mount test script running as $(whoami) on $(hostname --fqdn)"
+TESTMONS=$(ceph-conf --lookup 'mon_initial_members' | tr -d '[:space:]')
+TESTSECR=$(grep 'key =' /etc/ceph/ceph.client.admin.keyring | awk '{print $NF}')
+echo "MONs: $TESTMONS"
+echo "admin secret: $TESTSECR"
+test -d /mnt
+mount -t ceph ${TESTMONS}:/ /mnt -o name=admin,secret="$TESTSECR"
+touch /mnt/bubba
+test -f /mnt/bubba
+umount /mnt
+echo "Result: OK"
+EOF
+  local CLIENTNODE=$(_client_node)
+  # FIXME: assert no MDS running on $CLIENTNODE
+  salt-cp $CLIENTNODE $TESTSCRIPT $TESTSCRIPT
+  local LOGFILE=/tmp/cephfs_test.log
+  salt $CLIENTNODE cmd.run "sh $TESTSCRIPT" | tee $LOGFILE
+  local RESULT=$(grep -o -P '(?<=Result: )(OK|NOT_OK)$' $LOGFILE | head -1)
+  test "x$RESULT" = "xOK"
 }
 

--- a/qa/common/common.sh
+++ b/qa/common/common.sh
@@ -69,17 +69,17 @@ function gen_policy_cfg {
 cluster-ceph/cluster/*.sls
 # All nodes get the admin keyring
 role-admin/cluster/*.sls
-# Hardware Profile
-profile-*-1/cluster/*.sls
-profile-*-1/stack/default/ceph/minions/*yml
+# Hardware Profile - no OSDs on the last node
+profile-*-1/cluster/*.sls slice=[:-1]
+profile-*-1/stack/default/ceph/minions/*yml slice=[:-1]
 # Common configuration
 config/stack/default/global.yml
 config/stack/default/ceph/cluster.yml
 # Role assignment - master
 role-master/cluster/${SALT_MASTER}*.sls
-# Role assignment - mon (first 3 test nodes)
-role-mon/cluster/*.sls slice=[:3]
-role-mon/stack/default/ceph/minions/*.yml slice=[:3]
+# Role assignment - mon (just one, on the first node)
+role-mon/cluster/*.sls slice=[:1]
+role-mon/stack/default/ceph/minions/*.yml slice=[:1]
 EOF
 }
 

--- a/qa/suites/basic/health-mds.sh
+++ b/qa/suites/basic/health-mds.sh
@@ -29,13 +29,8 @@ gen_policy_cfg_mds
 cat_policy_cfg
 run_stage_2
 run_stage_3
-
-ceph -s | tee /dev/stderr | grep -q 'HEALTH_OK\|HEALTH_WARN'
-if [[ ! $? == 0 ]]; then
-  echo "Ceph cluster is not healthy!"
-  ceph -s
-fi
-
+ceph_health_test
 run_stage_4
+cephfs_mount_and_sanity_test
 
 echo "OK"

--- a/qa/suites/basic/health-mds.sh
+++ b/qa/suites/basic/health-mds.sh
@@ -31,6 +31,7 @@ run_stage_2
 run_stage_3
 ceph_health_test
 run_stage_4
+sleep 10
 cephfs_mount_and_sanity_test
 
 echo "OK"

--- a/qa/suites/basic/health-mds.sh
+++ b/qa/suites/basic/health-mds.sh
@@ -18,10 +18,6 @@
 # - script currently tolerates HEALTH_WARN -> not good. The only HEALTH_WARN
 #   outcome it should tolerate is clock skew. (We will need a special ceph.conf
 #   for two-node clusters.)
-# - In its present form, the test mounts the cephfs on the master node, which
-#   is suboptimal because the master node might be running an MDS daemon.
-#   The test should be refactored to do the mount on a "client" (non-MDS) node
-#   (salt -C 'not I@roles:mds' cmd.run ...)
 
 BASEDIR=$(pwd)
 source $BASEDIR/common/common.sh

--- a/qa/suites/basic/health-mds.sh
+++ b/qa/suites/basic/health-mds.sh
@@ -1,15 +1,15 @@
 #!/bin/bash -ex
 #
-# DeepSea integration test "suites/basic/health-ok.sh"
+# DeepSea integration test "suites/basic/health-mds.sh"
 #
-# This script runs DeepSea stages 0-3 to deploy a Ceph cluster on all the nodes
-# that have at least one external disk drive. After stage 3 completes, the
-# script checks for HEALTH_OK.
+# This script runs DeepSea stages 0-4 to deploy a Ceph cluster with MDS.
+# After stage 4 completes, it mounts the cephfs on the client node,
+# touches a file, and asserts that it exists.
 #
 # The script makes no assumptions beyond those listed in qa/README.
 #
-# On success (HEALTH_OK is reached), the script returns 0. On failure, for
-# whatever reason, the script returns non-zero.
+# On success, the script returns 0. On failure, for whatever reason, the script
+# returns non-zero.
 #
 # The script produces verbose output on stdout, which can be captured for later
 # forensic analysis.
@@ -25,6 +25,7 @@ source $BASEDIR/common/common.sh
 run_stage_0
 run_stage_1
 gen_policy_cfg
+gen_policy_cfg_mds
 cat_policy_cfg
 run_stage_2
 run_stage_3
@@ -34,5 +35,7 @@ if [[ ! $? == 0 ]]; then
   echo "Ceph cluster is not healthy!"
   ceph -s
 fi
+
+run_stage_4
 
 echo "OK"

--- a/qa/suites/basic/health-mds.sh
+++ b/qa/suites/basic/health-mds.sh
@@ -28,7 +28,8 @@ source $BASEDIR/common/common.sh
 
 run_stage_0
 run_stage_1
-gen_policy_cfg
+gen_policy_cfg_base
+gen_policy_cfg_client
 gen_policy_cfg_mds
 cat_policy_cfg
 run_stage_2

--- a/qa/suites/basic/health-mds.sh
+++ b/qa/suites/basic/health-mds.sh
@@ -18,6 +18,10 @@
 # - script currently tolerates HEALTH_WARN -> not good. The only HEALTH_WARN
 #   outcome it should tolerate is clock skew. (We will need a special ceph.conf
 #   for two-node clusters.)
+# - In its present form, the test mounts the cephfs on the master node, which
+#   is suboptimal because the master node might be running an MDS daemon.
+#   The test should be refactored to do the mount on a "client" (non-MDS) node
+#   (salt -C 'not I@roles:mds' cmd.run ...)
 
 BASEDIR=$(pwd)
 source $BASEDIR/common/common.sh

--- a/qa/suites/basic/health-ok.sh
+++ b/qa/suites/basic/health-ok.sh
@@ -28,11 +28,6 @@ gen_policy_cfg
 cat_policy_cfg
 run_stage_2
 run_stage_3
-
-ceph -s | tee /dev/stderr | grep -q 'HEALTH_OK\|HEALTH_WARN'
-if [[ ! $? == 0 ]]; then
-  echo "Ceph cluster is not healthy!"
-  ceph -s
-fi
+ceph_health_test
 
 echo "OK"

--- a/qa/suites/basic/health-ok.sh
+++ b/qa/suites/basic/health-ok.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -ex
 #
-# DeepSea integration test workunit "basic-health-ok.sh"
+# DeepSea integration test "suites/basic/health-ok.sh"
 #
 # This script runs DeepSea stages 0-3 to deploy a Ceph cluster on all the nodes
 # that have at least one external disk drive. After stage 3 completes, the
@@ -35,4 +35,3 @@ if [[ ! $? == 0 ]]; then
 fi 
 
 echo "OK"
-

--- a/qa/suites/basic/health-ok.sh
+++ b/qa/suites/basic/health-ok.sh
@@ -24,7 +24,8 @@ source $BASEDIR/common/common.sh
 
 run_stage_0
 run_stage_1
-gen_policy_cfg
+gen_policy_cfg_base
+gen_policy_cfg_no_client
 cat_policy_cfg
 run_stage_2
 run_stage_3


### PR DESCRIPTION
This PR creates a `suites/basic` hierarchy and moves the existing `basic-health-ok.sh` script into it. It also implements a `suites/basic/health-mds.sh` script for use in CephFS deployment testing.

https://github.com/SUSE/DeepSea/issues/321 was found while implementing this test.