### PR TITLE
qa: make 1- and 2-node clusters reach HEALTH_OK

### DIFF
--- a/qa/README
+++ b/qa/README
@@ -2,7 +2,18 @@ DeepSea integration test suite
 ==============================
 
 The DeepSea integration suite residing in qa/ consists of a number of
-executable files (bash scripts), all of which make the following assumptions:
+executable files (bash scripts), which can be classified as follows:
+
+qa/common/ -> scripts that are sourced by the test scripts
+qa/suites/ -> test scripts
+
+The test scripts are designed to be run from the qa/ directory. Please
+study carefully this README and the comments at the top of the test script
+before trying to run any of the test scripts.
+
+
+Assumptions made by all test scripts
+------------------------------------
 
 1. there are at least two test nodes (VMs or physical machines) that are
    running the same OS (e.g. Leap 42.3) and can see eachother over the network. 
@@ -16,5 +27,15 @@ executable files (bash scripts), all of which make the following assumptions:
 5. the DeepSea code under test has already been installed (git clone ; make
    install) on the master node
 6. the integration test script (this script) is run from the qa/ subdirectory
-   of the DeepSea repo clone
+   of the DeepSea repo clone.
+
+
+The following section is WIP - do not use!
+------------------------------------------
+
+7. a file called 'deepsea-qa-cluster-layout' (working name) has optionally been
+   created inside the same directory where the DeepSea repo was cloned. If it
+   exists, this file is expected to contain data points describing the cluster
+   layout (e.g. which nodes are storage nodes, which are client nodes, etc.).
+   If it is not present, the test script will try to do without it.
 

--- a/qa/README
+++ b/qa/README
@@ -10,7 +10,7 @@ executable files (bash scripts), all of which make the following assumptions:
    a. one node is configured as both a master and a minion
    b. the remaining nodes are configured as minions only
    c. the master can "salt '*' test.ping" all the minions
-3. the nodes have at least one external drive (>= 30GB) for OSD
+3. the nodes have at least one external drive (>= 10GB) for OSD
 4. the package repos have already been set up so DeepSea can install the RPMs
    it needs
 5. the DeepSea code under test has already been installed (git clone ; make

--- a/qa/common/common.sh
+++ b/qa/common/common.sh
@@ -62,7 +62,7 @@ function run_stage_5 {
   _run_stage 5 "$@"
 }
 
-function gen_policy_cfg_base {
+function policy_cfg_base {
   cat <<EOF > /srv/pillar/ceph/proposals/policy.cfg
 # Cluster assignment
 cluster-ceph/cluster/*.sls
@@ -79,7 +79,7 @@ role-mon/stack/default/ceph/minions/*.yml slice=[:1]
 EOF
 }
 
-function gen_policy_cfg_no_client {
+function policy_cfg_no_client {
   cat <<EOF >> /srv/pillar/ceph/proposals/policy.cfg
 # Hardware Profile
 profile-*-1/cluster/*.sls
@@ -87,7 +87,7 @@ profile-*-1/stack/default/ceph/minions/*yml
 EOF
 }
 
-function gen_policy_cfg_client {
+function policy_cfg_client {
   cat <<EOF >> /srv/pillar/ceph/proposals/policy.cfg
 # Hardware Profile
 profile-*-1/cluster/*.sls slice=[:-1]
@@ -95,7 +95,7 @@ profile-*-1/stack/default/ceph/minions/*yml slice=[:-1]
 EOF
 }
 
-function gen_policy_cfg_mds {
+function policy_cfg_mds {
   cat <<EOF >> /srv/pillar/ceph/proposals/policy.cfg
 # Role assignment - mds
 role-mds/cluster/*.sls slice=[:-1]

--- a/qa/common/json.sh
+++ b/qa/common/json.sh
@@ -1,0 +1,18 @@
+#
+# This file is part of the DeepSea integration test suite
+#
+
+function json_total_nodes {
+  # total number of nodes in the cluster
+  salt --static --out json '*' test.ping | jq '. | length'
+}
+
+function _json_nodes_of_role_x {
+  local ROLE=$1
+  salt --static --out json "$SALT_MASTER" test.ping | jq '. | length'
+}
+
+function json_storage_nodes {
+  # number of storage nodes in the cluster
+  _json_nodes_of_role_x storage
+}

--- a/qa/suites/basic/health-mds.sh
+++ b/qa/suites/basic/health-mds.sh
@@ -23,7 +23,6 @@ set -ex
 BASEDIR=$(pwd)
 source $BASEDIR/common/common.sh
 
-ceph_conf
 run_stage_0
 run_stage_1
 policy_cfg_base
@@ -31,6 +30,7 @@ policy_cfg_client
 policy_cfg_mds
 cat_policy_cfg
 run_stage_2
+ceph_conf
 run_stage_3
 run_stage_4
 ceph_health_test

--- a/qa/suites/basic/health-mds.sh
+++ b/qa/suites/basic/health-mds.sh
@@ -32,6 +32,6 @@ policy_cfg_mds
 cat_policy_cfg
 run_stage_2
 run_stage_3
-ceph_health_test
 run_stage_4
+ceph_health_test
 cephfs_mount_and_sanity_test

--- a/qa/suites/basic/health-mds.sh
+++ b/qa/suites/basic/health-mds.sh
@@ -34,5 +34,4 @@ run_stage_2
 run_stage_3
 ceph_health_test
 run_stage_4
-sleep 10
 cephfs_mount_and_sanity_test

--- a/qa/suites/basic/health-mds.sh
+++ b/qa/suites/basic/health-mds.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -ex
+#!/bin/bash
 #
 # DeepSea integration test "suites/basic/health-mds.sh"
 #
@@ -19,9 +19,11 @@
 #   outcome it should tolerate is clock skew. (We will need a special ceph.conf
 #   for two-node clusters.)
 
+set -ex
 BASEDIR=$(pwd)
 source $BASEDIR/common/common.sh
 
+ceph_conf
 run_stage_0
 run_stage_1
 policy_cfg_base
@@ -34,5 +36,3 @@ ceph_health_test
 run_stage_4
 sleep 10
 cephfs_mount_and_sanity_test
-
-echo "OK"

--- a/qa/suites/basic/health-mds.sh
+++ b/qa/suites/basic/health-mds.sh
@@ -24,9 +24,9 @@ source $BASEDIR/common/common.sh
 
 run_stage_0
 run_stage_1
-gen_policy_cfg_base
-gen_policy_cfg_client
-gen_policy_cfg_mds
+policy_cfg_base
+policy_cfg_client
+policy_cfg_mds
 cat_policy_cfg
 run_stage_2
 run_stage_3

--- a/qa/suites/basic/health-ok.sh
+++ b/qa/suites/basic/health-ok.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -ex
+#!/bin/bash
 #
 # DeepSea integration test "suites/basic/health-ok.sh"
 #
@@ -19,6 +19,7 @@
 #   outcome it should tolerate is clock skew. (We will need a special ceph.conf
 #   for two-node clusters.)
 
+set -ex
 BASEDIR=$(pwd)
 source $BASEDIR/common/common.sh
 
@@ -28,7 +29,6 @@ policy_cfg_base
 policy_cfg_no_client
 cat_policy_cfg
 run_stage_2
+ceph_conf
 run_stage_3
 ceph_health_test
-
-echo "OK"

--- a/qa/suites/basic/health-ok.sh
+++ b/qa/suites/basic/health-ok.sh
@@ -24,8 +24,8 @@ source $BASEDIR/common/common.sh
 
 run_stage_0
 run_stage_1
-gen_policy_cfg_base
-gen_policy_cfg_no_client
+policy_cfg_base
+policy_cfg_no_client
 cat_policy_cfg
 run_stage_2
 run_stage_3


### PR DESCRIPTION
For the time being we're introducing a `qa/.config` (which must be populated for each run) to tell the integration testing script how many storage nodes there are. If the number is less than three, then the necessary ceph.conf knobs are twiddled to ensure the cluster reaches HEALTH_OK.

No longer tolerate HEALTH_WARN.

Use "wait.until status=HEALTH_OK" to give the cluster some time to reach HEALTH_OK. The timeout seems to be five minutes. Don't know could that be extended, but it seems to reach HEALTH_OK pretty quick, so perhaps 5 minutes is enough.