### PR TITLE
qa: implement basic NFS-Ganesha integration test

### DIFF
--- a/qa/common/json.sh
+++ b/qa/common/json.sh
@@ -9,7 +9,7 @@ function json_total_nodes {
 
 function _json_nodes_of_role_x {
   local ROLE=$1
-  salt --static --out json "$SALT_MASTER" test.ping | jq '. | length'
+  salt --static --out json -C "I@roles:$ROLE" test.ping | jq '. | length'
 }
 
 function json_storage_nodes {

--- a/qa/common/nfs-ganesha.sh
+++ b/qa/common/nfs-ganesha.sh
@@ -1,0 +1,105 @@
+#
+# This file is part of the DeepSea integration test suite
+#
+
+function _nfs_ganesha_node {
+  _first_x_node ganesha
+}
+
+function nfs_ganesha_no_root_squash {
+  local GANESHAJ2=/srv/salt/ceph/ganesha/files/ganesha.conf.j2
+  sed -i '/Access_Type = RW;/a \\tSquash = No_root_squash;' $GANESHAJ2
+}
+
+#
+# Since we don't seem to be using NFSv4, the effect of this option is unclear
+#
+function nfs_ganesha_no_grace_period {
+  local GANESHAJ2=/srv/salt/ceph/ganesha/files/ganesha.conf.j2
+  cat <<EOF >>$GANESHAJ2
+NFSv4 {Graceless = True}
+EOF
+}
+
+function nfs_ganesha_debug_log {
+  local GANESHANODE=$(_nfs_ganesha_node)
+  local TESTSCRIPT=/tmp/test-nfs-ganesha.sh
+  cat <<EOF > $TESTSCRIPT
+set -ex
+trap 'echo "Result: NOT_OK"' ERR
+echo "nfs-ganesha debug log script running as $(whoami) on $(hostname --fqdn)"
+sed -i 's/NIV_EVENT/NIV_DEBUG/g' /etc/sysconfig/nfs-ganesha
+cat /etc/sysconfig/nfs-ganesha
+rm -rf /var/log/ganesha/ganesha.log
+systemctl restart nfs-ganesha.service
+systemctl is-active nfs-ganesha.service
+echo "Result: OK"
+EOF
+  _run_test_script_on_node $TESTSCRIPT $GANESHANODE
+}
+
+function nfs_ganesha_cat_config_file {
+  salt -C 'I@roles:ganesha' cmd.run 'cat /etc/ganesha/ganesha.conf'
+}
+
+function nfs_ganesha_showmount_loop {
+  local TESTSCRIPT=/tmp/test-nfs-ganesha.sh
+  salt -C 'I@roles:ganesha' cmd.run "while true ; do showmount -e $GANESHANODE | tee /tmp/showmount.log || true ; grep -q 'Timed out' /tmp/showmount.log || break ; done"
+}
+
+function nfs_ganesha_mount {
+  #
+  # creates a directory /root/mnt and mounts NFS-Ganesha export in it
+  #
+  local ASUSER=$1
+  local CLIENTNODE=$(_client_node)
+  local GANESHANODE=$(_nfs_ganesha_node)
+  local TESTSCRIPT=/tmp/test-nfs-ganesha.sh
+  salt "$CLIENTNODE" pillar.get roles
+  salt "$CLIENTNODE" pkg.install nfs-client # FIXME: only works on SUSE
+  cat <<EOF > $TESTSCRIPT
+set -ex
+trap 'echo "Result: NOT_OK"' ERR
+echo "nfs-ganesha mount test script running as $(whoami) on $(hostname --fqdn)"
+test ! -e /root/mnt
+mkdir /root/mnt
+test -d /root/mnt
+# ************************************************
+# mount the NFS export - this is prone to timeout!
+# ************************************************
+# NOTE: NFSv4 does not work with root, even when /etc/ganesha/ganesha.conf
+# contains "Squash = No_root_squash;" line
+#mount -t nfs -o nfsvers=4 ${GANESHANODE}:/ /root/mnt
+mount -t nfs ${GANESHANODE}:/ /root/mnt
+echo "Result: OK"
+EOF
+  # FIXME: assert no MDS running on $CLIENTNODE
+  _run_test_script_on_node $TESTSCRIPT $CLIENTNODE $ASUSER
+}
+
+function nfs_ganesha_touch_a_file {
+  #
+  # touches a file, asserts that it exists, unmounts /root/mnt
+  #
+  local ASUSER=$1
+  local CLIENTNODE=$(_client_node)
+  local TESTSCRIPT=/tmp/test-nfs-ganesha.sh
+  local MOUNTPOINT=/root/mnt
+  local PSEUDO="/cephfs"
+  local MOUNTPATH=$MOUNTPOINT
+  if [ -z "$ASUSER" ] ; then
+      MOUNTPATH=$MOUNTPOINT$PSEUDO
+  fi
+  local TOUCHFILE=$MOUNTPATH/bubba
+  cat <<EOF > $TESTSCRIPT
+set -ex
+trap 'echo "Result: NOT_OK"' ERR
+echo "nfs-ganesha touch-a-file test script running as $(whoami) on $(hostname --fqdn)"
+ls -lR $MOUNTPOINT
+touch $TOUCHFILE
+test -f $TOUCHFILE
+umount $MOUNTPATH
+echo "Result: OK"
+EOF
+  _run_test_script_on_node $TESTSCRIPT $CLIENTNODE $ASUSER
+}

--- a/qa/suites/basic/health-mds.sh
+++ b/qa/suites/basic/health-mds.sh
@@ -14,10 +14,6 @@
 # The script produces verbose output on stdout, which can be captured for later
 # forensic analysis.
 #
-# FIXME:
-# - script currently tolerates HEALTH_WARN -> not good. The only HEALTH_WARN
-#   outcome it should tolerate is clock skew. (We will need a special ceph.conf
-#   for two-node clusters.)
 
 set -ex
 BASEDIR=$(pwd)

--- a/qa/suites/basic/health-nfs-ganesha.sh
+++ b/qa/suites/basic/health-nfs-ganesha.sh
@@ -1,0 +1,42 @@
+#!/bin/bash -ex
+#
+# DeepSea integration test "suites/basic/health-nfs-ganesha.sh"
+#
+# This script runs DeepSea stages 0-4 to deploy a Ceph cluster with MDS and
+# NFS-Ganesha.  After stage 4 completes, it mounts the NFS-Ganesha on the
+# client node, touches a file, and asserts that it exists.
+#
+# The script makes no assumptions beyond those listed in qa/README.
+#
+# On success, the script returns 0. On failure, for whatever reason, the script
+# returns non-zero.
+#
+# The script produces verbose output on stdout, which can be captured for later
+# forensic analysis.
+#
+
+BASEDIR=$(pwd)
+source $BASEDIR/common/common.sh
+source $BASEDIR/common/nfs-ganesha.sh
+
+#nfs_ganesha_no_grace_period
+run_stage_0
+run_stage_1
+policy_cfg_base
+policy_cfg_client
+policy_cfg_mds
+policy_cfg_nfs_ganesha
+cat_policy_cfg
+run_stage_2
+ceph_conf
+run_stage_3
+nfs_ganesha_no_root_squash
+run_stage_4
+ceph_health_test
+nfs_ganesha_cat_config_file
+nfs_ganesha_debug_log
+nfs_ganesha_showmount_loop
+nfs_ganesha_mount
+nfs_ganesha_touch_a_file
+
+echo "OK"

--- a/qa/suites/basic/health-ok.sh
+++ b/qa/suites/basic/health-ok.sh
@@ -14,10 +14,6 @@
 # The script produces verbose output on stdout, which can be captured for later
 # forensic analysis.
 #
-# FIXME:
-# - script currently tolerates HEALTH_WARN -> not good. The only HEALTH_WARN
-#   outcome it should tolerate is clock skew. (We will need a special ceph.conf
-#   for two-node clusters.)
 
 set -ex
 BASEDIR=$(pwd)


### PR DESCRIPTION
This PR adds a minimalistic `suites/basic/health-nfs-ganesha.sh` script to the integration test suite. It:

* adds a ganesha role
* configures NFS-ganesha for "No_root_squash" and "NIV_DEBUG"
* runs Stages 0-4
* works around buggy behavior (first attempt to communicate with the NFS server times out about half the time)
* mounts the NFS export as root
* touches a file
* unmounts the export
