### PR TITLE
osd.py: run partprobe on the newly created partition

### DIFF
--- a/srv/salt/_modules/osd.py
+++ b/srv/salt/_modules/osd.py
@@ -767,7 +767,7 @@ class OSDPartitions(object):
             else:
                 cmd = "/usr/sbin/sgdisk -N {} -t {}:{} {}".format(number, number, self.osd.types[partition_type], device)
             _run(cmd)
-            partprobe_cmd = "/usr/sbin/partprobe {}".format(device)
+            partprobe_cmd = "/usr/sbin/partprobe {}{}".format(device, number)
             _run(partprobe_cmd)
             # Seems odd to wipe a just created partition ; however, ghost
             # filesystems on reused disks seem to be an issue


### PR DESCRIPTION
If only run on the device there is a chance that partprobe returns with
success, but dd after does not find the partition (on the second
partition created on a device). If partprobe is run on the created
partition everything works.

Signed-off-by: Jan Fajerski <jfajerski@suse.com>