### PR TITLE
allow mgr full permissions for admin keyring

### DIFF
--- a/srv/salt/ceph/admin/files/keyring.j2
+++ b/srv/salt/ceph/admin/files/keyring.j2
@@ -3,3 +3,4 @@
 	caps mds = "allow *"
 	caps mon = "allow *"
 	caps osd = "allow *"
+	caps mgr = "allow *"


### PR DESCRIPTION
This otherwise causes various ceph pg related commands to fail like
`ceph pg dump`

Fixes: http://tracker.ceph.com/issues/20296

Signed-off-by: Abhishek Lekshmanan <abhishek@suse.com>
Reported-by: Patrick Nawracay <pnawracay@suse.com>