### PR TITLE
populate: get existing cluster's fsid from ceph.conf

### DIFF
--- a/srv/salt/_modules/cephinspector.py
+++ b/srv/salt/_modules/cephinspector.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 # vim: ts=8 et sw=4 sts=4
 
-import rados
-
 import os
 import socket
 from subprocess import Popen, PIPE
@@ -46,11 +44,6 @@ def get_ceph_disks_yml(**kwargs):
 		_append_to_ceph_disk(ceph_disks, path, p['journal_dev'])
 
     return ceph_disks
-
-def get_cluster_fsid():
-    cluster=rados.Rados(conffile="/etc/ceph/ceph.conf")
-    cluster.connect()
-    return cluster.get_fsid()
 
 def _extract_key(filename):
     # This is pretty similar to keyring.secret()...


### PR DESCRIPTION
This removes the need to talk via librados to a running cluster on
the master_minion node, which might not yet be set up to talk to
the existing cluster at the time of import.

Signed-off-by: Tim Serong <tserong@suse.com>