### PR TITLE
device/partition comparison in db branch

### DIFF
--- a/srv/salt/_modules/osd.py
+++ b/srv/salt/_modules/osd.py
@@ -740,7 +740,7 @@ class OSDPartitions(object):
 
             if self.osd.db:
                 if self.osd.db_size:
-                    if self.osd.wal == self.osd.device:
+                    if self.osd.db == self.osd.device:
                         log.warn("DB size is unsupported for same device of {}".format(self.osd.device))
                     else:
                         log.warn("Setting wal to same device {} as db".format(self.osd.db))


### PR DESCRIPTION
In the branch where  _either_ a db or a wal is defined.

Only a db is defined and the db_size is set although the __db__ equals the data device.

probably a copy&paste mistake.
     