### PR TITLE
rgw: conf: set `rgw_dns_name` as the fqdn

### DIFF
--- a/srv/salt/ceph/configuration/files/ceph.conf.rgw
+++ b/srv/salt/ceph/configuration/files/ceph.conf.rgw
@@ -1,3 +1,3 @@
 [ client.{{ client }} ]
 rgw frontends = "civetweb port=80"
-rgw dns name = {{ grains['host'] }}
+rgw dns name = {{ grains['fqdn'] }}


### PR DESCRIPTION
In RGW we do a suffix validation of the hostname, and in current case
the default DeepSea deployment sets the hostname as the short hostname
which would fail the default GET request at `/` and possibly a few other
tests that may depend on absoulte/subdomin/host style calling formats.
The reason for a suffix validation is that hostname is a part of the s3
signature and this needs to be extracted from the request

Fixes: https://github.com/SUSE/DeepSea/issues/341
Reported-by: Nathan Cutler <ncutler@suse.com>
Signed-off-by: Abhishek Lekshmanan <abhishek@suse.com>