### PR TITLE
cephfs: don't create pools in case there is a cephfs instance

### DIFF
--- a/srv/salt/ceph/mds/pools/default.sls
+++ b/srv/salt/ceph/mds/pools/default.sls
@@ -10,12 +10,16 @@ prevent empty rendering:
 cephfs data:
   cmd.run:
     - name: "ceph osd pool create cephfs_data 128"
-    - unless: "rados lspools | grep -q cephfs_data"
+    - unless:
+      - "rados lspools | grep -q cephfs_data"
+      - "ceph fs ls | grep -q ^name"
 
 cephfs metadata:
   cmd.run:
     - name: "ceph osd pool create cephfs_metadata 128"
-    - unless: "rados lspools | grep -q cephfs_metadata"
+    - unless:
+      - "rados lspools | grep -q cephfs_metadata"
+      - "ceph fs ls | grep -q ^name"
 
 cephfs:
   cmd.run:


### PR DESCRIPTION
This should avoid creating cephfs_data and cephfs_metadata pools in case
a cephfs instance was created using different pool names.

Signed-off-by: Jan Fajerski <jfajerski@suse.com>