### PR TITLE
grafana: wait for http api server to come up before adding datasource

### DIFF
--- a/srv/salt/ceph/monitoring/grafana/init.sls
+++ b/srv/salt/ceph/monitoring/grafana/init.sls
@@ -5,6 +5,8 @@ grafana:
 grafana-server:
   service.running:
     - enable: true
+    - require:
+      - pkg: grafana
     - watch:
       - file: /etc/grafana/grafana.ini
 
@@ -22,6 +24,28 @@ grafana-dashboards-ceph:
         [dashboards.json]
         enabled = true
         path = /var/lib/grafana-dashboards-ceph
+
+wait-for-grafana-http:
+  cmd.run:
+    - require:
+      - service: grafana-server
+    - name: |
+         SLEEP_SECONDS=5
+         CURL_CMD="curl -s -H \"Content-Type: application/json\" -XGET http://admin:admin@localhost:3000/api/datasources"
+         i=0
+         eval $CURL_CMD
+         curl_ret=$?
+         until [ $curl_ret -eq 0 ] || [ $i -eq 24 ]; do
+           sleep $SLEEP_SECONDS
+           eval $CURL_CMD
+           curl_ret=$?
+           i=$((i + 1))
+         done;
+         if [ $curl_ret -ne 0 ] ; then
+             echo "ERROR: The grafana http server failed to start after $((i * SLEEP_SECONDS))s"
+         fi
+         test $curl_ret -eq 0
+
 
 add prometheus ds:
   cmd.run:


### PR DESCRIPTION
Signed-off-by: Jan Fajerski <jfajerski@suse.com>

This fixes stage 2 failing on state "add prometheus ds".