### PR TITLE
Fixes removal of openATTIC packages

### DIFF
--- a/srv/salt/ceph/rescind/openattic/default.sls
+++ b/srv/salt/ceph/rescind/openattic/default.sls
@@ -25,8 +25,6 @@ uninstall openattic:
   pkg.removed:
     - pkgs:
       - openattic
-      - openattic-base
-      - openattic-pgsql
 
 {% for service in salt['pillar.get']('openattic_configurations:stop_services', []) %}
 {% if salt['service.available'](service) %}


### PR DESCRIPTION
Starting with version 3.2.0, openATTIC consists only of a single `openattic` RPM package that obsoletes/replaces all other RPM subpackages (see https://tracker.openattic.org/browse/OP-2342 for details).

Remove `openattic-base` and `openattic-pgsql` from the list of packages to remove.

The upstream [PR#241](https://bitbucket.org/openattic/openattic/pull-requests/241/packaging-consolidate-subpackages-into-a/diff) has been merged and will be released in openATTIC 3.2.0,
which will also be included in the next SES5 Milestone 7 release.

Signed-off-by: Lenz Grimmer <lgrimmer@suse.com>