### PR TITLE
ganesha: RGW exports should export a user bucket instead of "/"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -319,6 +319,8 @@ copy-files:
 	# state files - rgw
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/rgw
 	install -m 644 srv/salt/ceph/rgw/*.sls $(DESTDIR)/srv/salt/ceph/rgw/
+	install -d -m 755 $(DESTDIR)/srv/salt/ceph/rgw/buckets
+	install -m 644 srv/salt/ceph/rgw/buckets/*.sls $(DESTDIR)/srv/salt/ceph/rgw/buckets/
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/rgw/key
 	install -m 644 srv/salt/ceph/rgw/key/*.sls $(DESTDIR)/srv/salt/ceph/rgw/key/
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/rgw/auth

--- a/deepsea.spec
+++ b/deepsea.spec
@@ -197,6 +197,7 @@ systemctl try-restart salt-master > /dev/null 2>&1 || :
 %dir /srv/salt/ceph/rgw/files
 %dir /srv/salt/ceph/rgw/key
 %dir /srv/salt/ceph/rgw/auth
+%dir /srv/salt/ceph/rgw/buckets
 %dir /srv/salt/ceph/rgw/keyring
 %dir /srv/salt/ceph/rgw/restart
 %dir /srv/salt/ceph/rgw/users
@@ -369,6 +370,7 @@ systemctl try-restart salt-master > /dev/null 2>&1 || :
 %config /srv/salt/ceph/rgw/files/*.j2
 %config /srv/salt/ceph/rgw/key/*.sls
 %config /srv/salt/ceph/rgw/auth/*.sls
+%config /srv/salt/ceph/rgw/buckets/*.sls
 %config /srv/salt/ceph/rgw/keyring/*.sls
 %config /srv/salt/ceph/rgw/restart/*.sls
 %config /srv/salt/ceph/rgw/users/*.sls

--- a/srv/salt/_modules/rgw.py
+++ b/srv/salt/_modules/rgw.py
@@ -5,6 +5,10 @@ import logging
 from subprocess import call, Popen, PIPE
 import os
 import json
+import boto
+import boto.s3.connection
+import boto.exception
+
 
 log = logging.getLogger(__name__)
 
@@ -104,9 +108,24 @@ def add_users(pathname="/srv/salt/ceph/rgw/cache"):
                 log.info("stderr: {}".format(line))
 
             proc.wait()
-        
-        
-        
+
+
+def create_bucket(**kwargs):
+    s3conn = boto.connect_s3(
+        aws_access_key_id=kwargs['access_key'],
+        aws_secret_access_key=kwargs['secret_key'],
+        host=kwargs['host'],
+        is_secure=kwargs['ssl'],
+        port=kwargs['port'],
+        calling_format=boto.s3.connection.OrdinaryCallingFormat(),
+    )
+    try:
+        s3conn.create_bucket(kwargs['bucket_name'])
+    except boto.exception.S3CreateError:
+        return False
+    return True
+
+
 def _key(user, field, pathname):
     """
     Read the filename and return the key value.  

--- a/srv/salt/ceph/ganesha/files/ganesha.conf.j2
+++ b/srv/salt/ceph/ganesha/files/ganesha.conf.j2
@@ -30,9 +30,13 @@ EXPORT
 {
 	Export_ID={{ loop.index + 1 }};
 
-	Path = "/";
+	# exporting {{ user }}-demo bucket
+	Path = "{{ user }}-demo";
+	
+	# You can also export the root path / inplace of bucket name
+	# Path = "/"
 
-	Pseudo = "/{{ user }}";
+	Pseudo = "/{{ user }}/{{ user }}-demo";
 
 	Access_Type = RW;
 

--- a/srv/salt/ceph/ganesha/files/gold.conf.j2
+++ b/srv/salt/ceph/ganesha/files/gold.conf.j2
@@ -6,9 +6,13 @@ EXPORT
 {
 	Export_ID={{ loop.index + 1 }};
 
-	Path = "/";
+	# exporting {{ user }}-demo bucket
+	Path = "{{ user }}-demo";
+	
+	# You can also export the root path / inplace of bucket name
+	# Path = "/"
 
-	Pseudo = "/{{ user }}";
+	Pseudo = "/{{ user }}/{{ user }}-demo";
 
 	Access_Type = RW;
 

--- a/srv/salt/ceph/ganesha/files/silver-common.conf.j2
+++ b/srv/salt/ceph/ganesha/files/silver-common.conf.j2
@@ -6,9 +6,13 @@ EXPORT
 {
 	Export_ID={{ loop.index }};
 
-	Path = "/";
+	# exporting {{ user }}-demo bucket
+	Path = "{{ user }}-demo";
+	
+	# You can also export the root path / inplace of bucket name
+	# Path = "/"
 
-	Pseudo = "/{{ user }}";
+	Pseudo = "/{{ user }}/{{ user }}-demo";
 
 	Access_Type = RO;
 

--- a/srv/salt/ceph/ganesha/files/silver.conf.j2
+++ b/srv/salt/ceph/ganesha/files/silver.conf.j2
@@ -6,9 +6,13 @@ EXPORT
 {
 	Export_ID={{ loop.index }};
 
-	Path = "/";
+	# exporting {{ user }}-demo bucket
+	Path = "{{ user }}-demo";
+	
+	# You can also export the root path / inplace of bucket name
+	# Path = "/"
 
-	Pseudo = "/{{ user }}";
+	Pseudo = "/{{ user }}/{{ user }}-demo";
 
 	Access_Type = RW;
 

--- a/srv/salt/ceph/packages/common/default.sls
+++ b/srv/salt/ceph/packages/common/default.sls
@@ -8,6 +8,7 @@ stage prep dependencies suse:
       - lsscsi
       - pciutils
       - gptfdisk
+      - python-boto
     - fire_event: True
 
 {% elif os == 'Ubuntu' %}
@@ -18,6 +19,7 @@ stage prep dependencies ubuntu:
       - lsscsi
       - pciutils
       - gdisk
+      - python-boto
     - fire_event: True
 
 {% else %}

--- a/srv/salt/ceph/rgw/buckets/default.sls
+++ b/srv/salt/ceph/rgw/buckets/default.sls
@@ -1,0 +1,18 @@
+
+install rgw:
+  pkg.installed:
+    - pkgs:
+      - python-boto
+
+{% for user in salt['rgw.users']('rgw') %}
+create demo bucket:
+  module.run:
+    - name: rgw.create_bucket
+    - kwargs:
+        'bucket_name': {{ user }}-demo
+        'host': {{ salt['pillar.get']('rgw_host') }}
+        'access_key': {{ salt['rgw.access_key'](user) }}
+        'secret_key': {{ salt['rgw.secret_key'](user) }}
+        'ssl': {{ salt['pillar.get']('rgw_ssl') }}
+        'port': {{ salt['pillar.get']('rgw_port') }}
+{% endfor %}

--- a/srv/salt/ceph/rgw/buckets/init.sls
+++ b/srv/salt/ceph/rgw/buckets/init.sls
@@ -1,0 +1,4 @@
+
+
+include:
+  - .{{ salt['pillar.get']('rgw_buckets', 'default') }}

--- a/srv/salt/ceph/rgw/users/default.sls
+++ b/srv/salt/ceph/rgw/users/default.sls
@@ -1,7 +1,9 @@
 
 install rgw:
   pkg.installed:
-    - name: ceph-radosgw
+    - pkgs:
+      - ceph-radosgw
+      - python-boto
 
 add users:
   module.run:

--- a/srv/salt/ceph/stage/radosgw/default.sls
+++ b/srv/salt/ceph/stage/radosgw/default.sls
@@ -21,3 +21,15 @@ rgw users:
 
 {% endfor %}
 {% endif %}
+
+{% set endpoint = salt.saltutil.runner('ui_rgw.endpoints')[0] %}
+rgw demo buckets:
+  salt.state:
+    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt_type: compound
+    - sls: ceph.rgw.buckets
+    - pillar:
+        'rgw_host': {{ endpoint['host'] }}
+        'rgw_port': {{ endpoint['port'] }}
+        'rgw_ssl': {{ endpoint['ssl'] }}
+


### PR DESCRIPTION
Currently NFS-Ganesha exports using RGW backend are being configured to export the `/` path. This poses some limitations to what the user can do when mounting such export. For instance, it cannot create a file, only directories.

This PR changes the RGW based exports configuration to export a bucket `demo` that is created for every RGW user configured by DeepSea.