### PR TITLE
cephinspector: skip "disks" with no partitions

### DIFF
--- a/srv/salt/_modules/cephinspector.py
+++ b/srv/salt/_modules/cephinspector.py
@@ -38,6 +38,9 @@ def get_ceph_disks_yml(**kwargs):
     # [ { 'path': '/dev/foo', 'partitions': [ {...}, ... ], ... }, ... ]
     # The partitions list has all the goodies.
     for part_dict in out_list:
+        if not part_dict.has_key("partitions"):
+            # This can happen if we encounter a CD/DVD (/dev/sr0)
+            continue
 	path = part_dict['path']
 	for p in part_dict['partitions']:
 	    if p['type'] == 'data':


### PR DESCRIPTION
When ceph-disk encounters /dev/sr0, that's included in its output, but the
dict for that device has no "partitions" key, which results in a traceback
(KeyError: 'partitions') a couple of lines later.  That traceback then lands
in the generated YAML file (yuck).

In general, we need a good way of dealing with failures like this from
cephinspector so that we don't accidentally do Stupid Things[TM] later :-/

Signed-off-by: Tim Serong <tserong@suse.com>