### PR TITLE
grafana: insist on /var/lib/grafana

### DIFF
--- a/srv/salt/ceph/monitoring/grafana/init.sls
+++ b/srv/salt/ceph/monitoring/grafana/init.sls
@@ -9,6 +9,9 @@ grafana-server:
       - pkg: grafana
     - watch:
       - file: /etc/grafana/grafana.ini
+  file.exists:
+    - name: /var/lib/grafana
+    - failhard: True
 
 grafana-dashboards-ceph:
   pkg.installed:


### PR DESCRIPTION
The grafana-server.service will fail to start if this directory doesn't exist.
It's supposed to be created by the grafana RPM, but we had a case where it
wasn't getting created and we were failing farther down, in the "curl" command.

Signed-off-by: Nathan Cutler <ncutler@suse.com>