### PR TITLE
Add ability to import existing clusters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,8 @@ copy-files:
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/configuration/files
 	install -m 644 srv/salt/ceph/configuration/files/*.j2 $(DESTDIR)/srv/salt/ceph/configuration/files/
 	install -m 644 srv/salt/ceph/configuration/files/*.rgw $(DESTDIR)/srv/salt/ceph/configuration/files/
+	install -m 644 srv/salt/ceph/configuration/files/ceph.conf.import $(DESTDIR)/srv/salt/ceph/configuration/files/
+	-chown salt:salt $(DESTDIR)/srv/salt/ceph/configuration/files/ceph.conf.import || true
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/configuration/files/ceph.conf.d
 	install -m 644 srv/salt/ceph/configuration/files/ceph.conf.d/README $(DESTDIR)/srv/salt/ceph/configuration/files/ceph.conf.d
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/events
@@ -417,6 +419,28 @@ copy-files:
 	ln -sf deploy		$(DESTDIR)/srv/salt/ceph/stage/3
 	ln -sf services		$(DESTDIR)/srv/salt/ceph/stage/4
 	ln -sf removal		$(DESTDIR)/srv/salt/ceph/stage/5
+
+	# cache directories
+	install -d -m 700 $(DESTDIR)/srv/salt/ceph/admin/cache
+	install -d -m 700 $(DESTDIR)/srv/salt/ceph/ganesha/cache
+	install -d -m 700 $(DESTDIR)/srv/salt/ceph/igw/cache
+	install -d -m 700 $(DESTDIR)/srv/salt/ceph/mds/cache
+	install -d -m 700 $(DESTDIR)/srv/salt/ceph/mon/cache
+	install -d -m 700 $(DESTDIR)/srv/salt/ceph/openattic/cache
+	install -d -m 700 $(DESTDIR)/srv/salt/ceph/osd/cache
+	install -d -m 700 $(DESTDIR)/srv/salt/ceph/rgw/cache
+	# At runtime, these need to be owned by salt:salt.  This won't work
+	# in a buildroot on OBS, hence the leading '-' to ignore failures
+	# and '|| true' to suppress some error output, but will work fine
+	# in development when root runs `make install`.
+	-chown salt:salt $(DESTDIR)/srv/salt/ceph/admin/cache || true
+	-chown salt:salt $(DESTDIR)/srv/salt/ceph/ganesha/cache || true
+	-chown salt:salt $(DESTDIR)/srv/salt/ceph/igw/cache || true
+	-chown salt:salt $(DESTDIR)/srv/salt/ceph/mds/cache || true
+	-chown salt:salt $(DESTDIR)/srv/salt/ceph/mon/cache || true
+	-chown salt:salt $(DESTDIR)/srv/salt/ceph/openattic/cache || true
+	-chown salt:salt $(DESTDIR)/srv/salt/ceph/osd/cache || true
+	-chown salt:salt $(DESTDIR)/srv/salt/ceph/rgw/cache || true
 
 install: copy-files
 	sed -i '/^master_minion:/s!_REPLACE_ME_!'`hostname -f`'!' /srv/pillar/ceph/master_minion.sls

--- a/deepsea.spec
+++ b/deepsea.spec
@@ -76,6 +76,7 @@ systemctl try-restart salt-master > /dev/null 2>&1 || :
 %dir /srv/salt/_modules
 %dir %attr(0755, salt, salt) /srv/salt/ceph
 %dir /srv/salt/ceph/admin
+%dir %attr(0700, salt, salt) /srv/salt/ceph/admin/cache
 %dir /srv/salt/ceph/admin/files
 %dir /srv/salt/ceph/admin/key
 %dir /srv/salt/ceph/benchmarks
@@ -92,6 +93,7 @@ systemctl try-restart salt-master > /dev/null 2>&1 || :
 %dir /srv/salt/ceph/events
 %dir /srv/salt/ceph/ganesha
 %dir /srv/salt/ceph/ganesha/auth
+%dir %attr(0700, salt, salt) /srv/salt/ceph/ganesha/cache
 %dir /srv/salt/ceph/ganesha/config
 %dir /srv/salt/ceph/ganesha/configure
 %dir /srv/salt/ceph/ganesha/files
@@ -101,6 +103,7 @@ systemctl try-restart salt-master > /dev/null 2>&1 || :
 %dir /srv/salt/ceph/ganesha/restart
 %dir /srv/salt/ceph/ganesha/service
 %dir /srv/salt/ceph/igw
+%dir %attr(0700, salt, salt) /srv/salt/ceph/igw/cache
 %dir /srv/salt/ceph/igw/config
 %dir /srv/salt/ceph/igw/files
 %dir /srv/salt/ceph/igw/import
@@ -111,6 +114,7 @@ systemctl try-restart salt-master > /dev/null 2>&1 || :
 %dir /srv/salt/ceph/igw/sysconfig
 %dir /srv/salt/ceph/iperf
 %dir /srv/salt/ceph/mds
+%dir %attr(0700, salt, salt) /srv/salt/ceph/mds/cache
 %dir /srv/salt/ceph/mds/files
 %dir /srv/salt/ceph/mds/key
 %dir /srv/salt/ceph/mds/auth
@@ -120,6 +124,7 @@ systemctl try-restart salt-master > /dev/null 2>&1 || :
 %dir /srv/salt/ceph/mines
 %dir /srv/salt/ceph/mines/files
 %dir /srv/salt/ceph/mon
+%dir %attr(0700, salt, salt) /srv/salt/ceph/mon/cache
 %dir /srv/salt/ceph/mon/files
 %dir /srv/salt/ceph/mon/key
 %dir /srv/salt/ceph/mon/restart
@@ -133,11 +138,13 @@ systemctl try-restart salt-master > /dev/null 2>&1 || :
 %dir /srv/salt/ceph/noout/unset
 %dir /srv/salt/ceph/openattic
 %dir /srv/salt/ceph/openattic/auth
+%dir %attr(0700, salt, salt) /srv/salt/ceph/openattic/cache
 %dir /srv/salt/ceph/openattic/files
 %dir /srv/salt/ceph/openattic/key
 %dir /srv/salt/ceph/openattic/keyring
 %dir /srv/salt/ceph/openattic/oaconfig
 %dir /srv/salt/ceph/osd
+%dir %attr(0700, salt, salt) /srv/salt/ceph/osd/cache
 %dir /srv/salt/ceph/osd/files
 %dir /srv/salt/ceph/osd/key
 %dir /srv/salt/ceph/osd/auth
@@ -194,6 +201,7 @@ systemctl try-restart salt-master > /dev/null 2>&1 || :
 %dir /srv/salt/ceph/restart/mds
 %dir /srv/salt/ceph/restart/ganesha
 %dir /srv/salt/ceph/rgw
+%dir %attr(0700, salt, salt) /srv/salt/ceph/rgw/cache
 %dir /srv/salt/ceph/rgw/files
 %dir /srv/salt/ceph/rgw/key
 %dir /srv/salt/ceph/rgw/auth
@@ -259,6 +267,7 @@ systemctl try-restart salt-master > /dev/null 2>&1 || :
 %config /srv/salt/ceph/configuration/*.sls
 %config /srv/salt/ceph/configuration/check/*.sls
 %config /srv/salt/ceph/configuration/files/ceph.conf*
+%config(noreplace) %attr(-, salt, salt) /srv/salt/ceph/configuration/files/ceph.conf.import
 /srv/salt/ceph/configuration/files/ceph.conf.d/README
 /srv/salt/ceph/diagnose/README.md
 %config /srv/salt/ceph/diagnose/*.sls

--- a/srv/salt/_modules/cephinspector.py
+++ b/srv/salt/_modules/cephinspector.py
@@ -1,0 +1,170 @@
+# -*- coding: utf-8 -*-
+# vim: ts=8 et sw=4 sts=4
+
+import os
+import socket
+from subprocess import Popen, PIPE
+import json
+import psutil
+
+def _get_listening_ipaddr(proc_name):
+    """
+    Search for the first instance of proc_name and return the first instance of a
+    listening IP address.  If proc_name or a listening IP are not found, return None.
+    """
+    proc_listening_ip = None
+
+    for proc in psutil.process_iter():
+	# Note that depending on psutil version, there are slight api differences, hence the
+	# try/except blocks below.
+	try:
+	    name = proc.name()
+	except:
+	    name = proc.name
+	if name == proc_name:
+	    try:
+		conns = proc.get_connections(kind="inet")
+	    except:
+		conns = proc.connections(kind="inet")
+	    for con in conns:
+		if con.status == "LISTEN":
+		    proc_listening_ip = con.laddr[0]
+
+    return proc_listening_ip
+
+def get_minion_public_network():
+    """
+    Returns the listening IP of the ceph-mon process encountered first on the system.
+    If ceph-mon is not running/listening, returns None.
+    """
+    return _get_listening_ipaddr("ceph-mon")
+
+def get_minion_cluster_network():
+    """
+    Returns the listening IP of the ceph-osd process encountered first on the system.
+    If ceph-osd is not running/listening, returns None.
+    """
+    return _get_listening_ipaddr("ceph-osd")
+
+def _get_disk_id(partition):
+    """
+    Return the disk id of a partition/device, or an empty string if not available.
+    """
+    disk_id_cmd = Popen("find -L /dev/disk/by-id -samefile " + partition + " \( -name ata* -o -name nvme* \)", stdout=PIPE, stderr=PIPE, shell=True)
+    out, err = disk_id_cmd.communicate()
+
+    # We should only ever have one entry that we return.
+    return out.rstrip()
+
+def _append_to_ceph_disk(ceph_disks, partition, journal_dev):
+    """
+    Populate ceph_disks dictionary with data and journal partitions.
+    """
+
+    # We don't care about the trailing number on journal_dev.
+    journal_dev = journal_dev.rstrip("1234567890")
+    # For nvme journal, strip the trailing 'p' as well.
+    if "nvme" in journal_dev:
+        journal_dev = journal_dev[:-1]
+
+    # Try to obtain disk id's for data partition (device) and journal partition.
+    partition_id = _get_disk_id(partition)
+    journal_dev_id = _get_disk_id(journal_dev)
+
+    partition = partition_id if partition_id else partition
+    journal_dev = journal_dev_id if journal_dev_id else journal_dev
+
+    try:
+	ceph_disks["ceph"]["storage"]["osds"][partition]
+    except KeyError, e:
+	ceph_disks["ceph"]["storage"]["osds"][partition] = {}
+    finally:
+	ceph_disks["ceph"]["storage"]["osds"][partition]["format"] = "filestore"
+	ceph_disks["ceph"]["storage"]["osds"][partition]["journal"] = journal_dev
+
+def get_ceph_disks_yml(**kwargs):
+    """
+    Generates yml representation of Ceph filestores on a given node.
+    Returns something like: {"ceph": {"storage": {"osds": {"/dev/foo":
+							    {"format": "filestore",
+							     "journal": "/dev/bar"}}}}}
+    """
+    ceph_disk_list = Popen("ceph-disk list --format=json", stdout=PIPE, stderr=PIPE, shell=True)
+    out, err = ceph_disk_list.communicate()
+    ceph_disks = {"ceph":
+		  {"storage":
+		   {"osds": {} }}}
+
+    # Failed `ceph-disk list`
+    if err: return None
+
+    out_list = json.loads(out)
+    # [ { 'path': '/dev/foo', 'partitions': [ {...}, ... ], ... }, ... ]
+    # The partitions list has all the goodies.
+    for part_dict in out_list:
+        if not part_dict.has_key("partitions"):
+            # This can happen if we encounter a CD/DVD (/dev/sr0)
+            continue
+	path = part_dict['path']
+	for p in part_dict['partitions']:
+	    if p['type'] == 'data':
+		_append_to_ceph_disk(ceph_disks, path, p['journal_dev'])
+
+    return ceph_disks
+
+def inspect(**kwargs):
+    # This will *ONLY* work on a cluster named "ceph".  It won't help with
+    # clusters with other names.
+
+    # deliberately only looking for things ceph-deploy can deploy
+    # TODO: do we need more than this?
+    ceph_services = ['ceph-mon', 'ceph-osd', 'ceph-mds', 'ceph-radosgw']
+
+    #
+    # running_services will be something like:
+    #
+    # {
+    #   'ceph-mon': [ 'hostname' ],
+    #   'ceph-osd': [ '0', '1', '2', ... ]
+    # }
+    #
+    running_services = {}
+    for rs in __salt__['service.get_running']():
+        instance = rs.split('@')
+        if len(instance) == 2 and instance[0] in ceph_services:
+            if not running_services.has_key(instance[0]):
+                running_services[instance[0]] = []
+            running_services[instance[0]].append(instance[1])
+
+    ceph_conf = None
+    try:
+        with open("/etc/ceph/ceph.conf", "r") as conf:
+            ceph_conf = conf.read()
+    except:
+        pass
+
+    return {
+        "running_services": running_services,
+        "ceph_conf": ceph_conf,
+        "has_admin_keyring": os.path.isfile("/etc/ceph/ceph.client.admin.keyring")
+    }
+
+def get_keyring(**kwargs):
+    """
+    Retrieve a keyring via `ceph auth get`.  Pass key=NAME_OF_KEY,
+    e.g.: use key=client.admin to get the client admin key.
+
+    Returns either the complete keyring (suitable for use in a ceph keyring
+    file), or None if the key does not exist, or cannot be obtained.
+
+    This needs to be run on a minion with a suitable ceph.conf and client
+    admin keyring, in order for `ceph auth get` to be able to talk to the
+    cluster.
+    """
+    if not "key" in kwargs:
+        return None
+
+    cmd = Popen("ceph auth get " + kwargs["key"], stdout=PIPE, stderr=PIPE, shell=True)
+    out, err = cmd.communicate()
+
+    return out if out else None

--- a/srv/salt/_modules/keyring.py
+++ b/srv/salt/_modules/keyring.py
@@ -9,6 +9,9 @@ def secret(filename):
     """
     Read the filename and return the key value.  If it does not exist,
     generate one.
+
+    Note that if used on a file that contains multiple keys, this will
+    always return the first key.
     """
     if os.path.exists(filename):
         with open(filename, 'r') as keyring:

--- a/srv/salt/ceph/configuration/default-import.sls
+++ b/srv/salt/ceph/configuration/default-import.sls
@@ -1,0 +1,16 @@
+
+
+/etc/ceph/ceph.conf:
+  file:
+    - managed
+    - source:
+        - salt://ceph/configuration/files/ceph.conf.import
+    - user: root
+    - group: root
+    - mode: 644
+    - makedirs: True
+    - fire_event: True
+
+
+
+

--- a/srv/salt/ceph/configuration/files/ceph.conf.import
+++ b/srv/salt/ceph/configuration/files/ceph.conf.import
@@ -1,0 +1,2 @@
+# When DeepSea imports an existing cluster, the imported ceph.conf
+# will replace this file.


### PR DESCRIPTION
Here's the idea:

- Install DeepSea on some node (your salt master).
- Install salt-minion on every existing ceph node
- Hook up the minions to the masters as usual.
- Run `salt-run populate.engulf_existing_cluster`.  This will:
  1) Distribute all the needed Salt and DeepSea modules to all the
     minions.
  2) Inspect the running Ceph cluster and populate
     /srv/pillar/ceph/proposals with a layout of the cluster (ie.
     roles, hardware profiles, policy.cfg).
  3) Verify and save ceph.conf to DeepSea's internal directory
     structure.
  4) Save the various admin, mon, osd, mds and rgw keyrings to
     DeepSea's internal directory structure.
  5) Detect cluster and write out cluster fsid, internal and cluster
     networks to DeepSea's internal directory structure.

Signed-off-by: Tim Serong <tserong@suse.com>
Signed-off-by: Karol Mroz <kmroz@suse.de>