### PR TITLE
Add missing report dir/* to spec and Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -371,6 +371,8 @@ copy-files:
 	install -m 644 srv/salt/ceph/maintenance/upgrade/master/*.sls $(DESTDIR)/srv/salt/ceph/maintenance/upgrade/master
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/maintenance/upgrade/minion
 	install -m 644 srv/salt/ceph/maintenance/upgrade/minion/*.sls $(DESTDIR)/srv/salt/ceph/maintenance/upgrade/minion
+	install -d -m 755 $(DESTDIR)/srv/salt/ceph/maintenance/upgrade/report
+	install -m 644 srv/salt/ceph/maintenance/upgrade/report/*.sls $(DESTDIR)/srv/salt/ceph/maintenance/upgrade/report
 	# state files - orchestrate stages
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/stage/all
 	install -m 644 srv/salt/ceph/stage/all/*.sls $(DESTDIR)/srv/salt/ceph/stage/all/

--- a/deepsea.spec
+++ b/deepsea.spec
@@ -232,6 +232,7 @@ systemctl try-restart salt-master > /dev/null 2>&1 || :
 %dir /srv/salt/ceph/maintenance/noout
 %dir /srv/salt/ceph/maintenance/upgrade/master
 %dir /srv/salt/ceph/maintenance/upgrade/minion
+%dir /srv/salt/ceph/maintenance/upgrade/report
 %dir /srv/salt/ceph/upgrade
 %dir /srv/salt/ceph/updates
 %dir /srv/salt/ceph/updates/master
@@ -414,6 +415,7 @@ systemctl try-restart salt-master > /dev/null 2>&1 || :
 %config /srv/salt/ceph/maintenance/upgrade/*.sls
 %config /srv/salt/ceph/maintenance/upgrade/master/*.sls
 %config /srv/salt/ceph/maintenance/upgrade/minion/*.sls
+%config /srv/salt/ceph/maintenance/upgrade/report/*.sls
 %config /srv/salt/ceph/updates/*.sls
 %config /srv/salt/ceph/updates/restart/*.sls
 %config /srv/salt/ceph/updates/master/*.sls


### PR DESCRIPTION
> srv/salt/ceph/maintenance/upgrade/default.sls

``` yml
include:
  - .master
  - .minion
  - .report
```

but we forgot to add it to the deepsea.spec and Makefile