### PR TITLE
Only warn about a missing profiles

### DIFF
--- a/srv/modules/runners/validate.py
+++ b/srv/modules/runners/validate.py
@@ -648,7 +648,7 @@ class Validate(object):
 	profiles = [ prf  for prf in accum_files if 'profile' in prf ]
 	if not profiles:
 	    message = "There are no files under the profiles directory. Probably an issue with the discovery stage."
-	    self.errors.setdefault('profiles_populated', []).append(message)
+	    self.warnings.setdefault('profiles_populated', []).append(message)
         self._set_pass_status('profiles_populated')
 
     def _lint_yaml_files(self):


### PR DESCRIPTION
Without having to use DEV_ENV, one can now deploy Monitors without being forced to have 'profiles*/' defined.

Follow-up as a request from Martin.