### PR TITLE
qa: add a test that deploys a cluster capable of running ceph_test_librbd

### DIFF
--- a/qa/common/common.sh
+++ b/qa/common/common.sh
@@ -4,6 +4,7 @@
 
 BASEDIR=$(pwd)
 source $BASEDIR/common/json.sh
+source $BASEDIR/common/rbd.sh
 
 SALT_MASTER=$(cat /srv/pillar/ceph/master_minion.sls | \
              sed 's/.*master_minion:[[:blank:]]*\(\w\+\)[[:blank:]]*/\1/' | \
@@ -102,6 +103,13 @@ EOF
     echo "Three or more storage nodes; not adjusting ceph.conf"
     # TODO: look up default value of "mon pg warn min per osd"
   fi
+}
+
+function ceph_conf_mon_allow_pool_delete {
+    echo "Adjusting ceph.conf to allow pool deletes"
+    cat <<EOF >> /srv/salt/ceph/configuration/files/ceph.conf.d/global.conf
+mon allow pool delete = true
+EOF
 }
 
 #

--- a/qa/common/rbd.sh
+++ b/qa/common/rbd.sh
@@ -1,0 +1,26 @@
+#
+# This file is part of the DeepSea integration test suite
+#
+
+function ceph_conf_upstream_rbd_default_features {
+  #
+  # by removing this line, we ensure that there will be no "rbd default
+  # features" setting in ceph.conf, so the default value will be used
+  #
+  sed -i '/^rbd default features =/d' \
+      /srv/salt/ceph/configuration/files/ceph.conf.rbd
+}
+
+function ceph_test_librbd_can_be_run {
+  local TESTSCRIPT=/tmp/rbd_api_test.sh
+  local CLIENTNODE=$(_client_node)
+  cat << 'EOF' > $TESTSCRIPT
+set -ex
+trap 'echo "Result: NOT_OK"' ERR
+rpm -V ceph-test
+type ceph_test_librbd
+echo "Result: OK"
+EOF
+  _run_test_script_on_node $TESTSCRIPT $CLIENTNODE
+  echo "You can now run ceph_test_librbd on the client node"
+}

--- a/qa/suites/ceph-test/librbd.sh
+++ b/qa/suites/ceph-test/librbd.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+#
+# DeepSea integration test "suites/ceph-test/librbd.sh"
+#
+# This script deploys a basic cluster and tests that ceph_test_librbd can be
+# run on the client node. That means it's probably only useful if you execute
+# that command yourself (manually or via CI tooling) after this script runs.
+#
+# The script makes the following assumption beyond those listed in qa/README:
+# - the ceph-test RPM is installed on the client node
+#
+# On success (script thinks ceph_test_librbd can be run), the script returns 0.
+# On failure, for whatever reason, the script returns non-zero.
+#
+# The script produces verbose output on stdout, which can be captured for later
+# forensic analysis.
+#
+
+set -ex
+BASEDIR=$(pwd)
+source $BASEDIR/common/common.sh
+
+install_deps
+run_stage_0
+run_stage_1
+policy_cfg_base
+policy_cfg_client
+cat_policy_cfg
+run_stage_2
+ceph_conf
+ceph_conf_mon_allow_pool_delete
+ceph_conf_upstream_rbd_default_features
+run_stage_3
+ceph_health_test
+ceph_test_librbd_can_be_run


### PR DESCRIPTION
At first I intended for this test to *run* ceph_test_librbd but that didn't work out because that executable produces quite a lot of output and Salt chokes on it. (The only way I know of to run the test script on the client node being `cmd.run`.)

```
2017-06-29T09:02:00.575 INFO:teuthology.orchestra.run.target147135132188.stderr:+ salt target147135132188.teuthology cmd.r
un 'sh /tmp/rbd_api_test.sh'
2017-06-29T09:07:16.693 INFO:teuthology.orchestra.run.target147135132188.stderr:ERROR: Minions returned with non-zero exit
 code
2017-06-29T09:07:16.694 INFO:teuthology.orchestra.run.target147135132188.stdout:target147135132188.teuthology:
2017-06-29T09:07:16.695 INFO:teuthology.orchestra.run.target147135132188.stdout:    VALUE_TRIMMED
```

To get around that bogosity, I removed the `ceph_test_librbd` invocation from this script and I'm invoking it via teuthology :-/