### PR TITLE
Fix regression introduced in da73d3e

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,7 @@ copy-files:
 	install -m 644 srv/salt/ceph/configuration/check/*.sls $(DESTDIR)/srv/salt/ceph/configuration/check/
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/configuration/files
 	install -m 644 srv/salt/ceph/configuration/files/*.j2 $(DESTDIR)/srv/salt/ceph/configuration/files/
+	install -m 644 srv/salt/ceph/configuration/files/*.rbd $(DESTDIR)/srv/salt/ceph/configuration/files/
 	install -m 644 srv/salt/ceph/configuration/files/*.rgw $(DESTDIR)/srv/salt/ceph/configuration/files/
 	install -m 644 srv/salt/ceph/configuration/files/ceph.conf.import $(DESTDIR)/srv/salt/ceph/configuration/files/
 	-chown salt:salt $(DESTDIR)/srv/salt/ceph/configuration/files/ceph.conf.import || true

--- a/srv/salt/ceph/configuration/files/ceph.conf.j2
+++ b/srv/salt/ceph/configuration/files/ceph.conf.j2
@@ -12,7 +12,7 @@ filestore_xattr_use_omap = true
 public_network = {{ salt['pillar.get']('public_network') }}
 cluster_network = {{ salt['pillar.get']('cluster_network') }}
 
-{% include "ceph/configuration/files/ceph.conf.rbd"}
+{% include "ceph/configuration/files/ceph.conf.rbd" %}
 
 {% include "ceph/configuration/files/ceph.conf.d/global.conf" ignore missing %}
 


### PR DESCRIPTION
This PR fixes a Jinja syntax error in `srv/salt/ceph/configuration/files/ceph.conf.j2`, and adds the new configuration file to the Makefile.

Fixes regression introduced in da73d3e

Signed-off-by: Ricardo Dias <rdias@suse.com>