### PR TITLE
Add role-mgr, to deploy ceph-mgr instances

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,6 +140,19 @@ copy-files:
 	install -m 644 srv/salt/ceph/mds/files/*.j2 $(DESTDIR)/srv/salt/ceph/mds/files/
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/mds/restart
 	install -m 644 srv/salt/ceph/mds/restart/*.sls $(DESTDIR)/srv/salt/ceph/mds/restart
+	# state files - mgr
+	install -d -m 755 $(DESTDIR)/srv/salt/ceph/mgr
+	install -m 644 srv/salt/ceph/mgr/*.sls $(DESTDIR)/srv/salt/ceph/mgr/
+	install -d -m 755 $(DESTDIR)/srv/salt/ceph/mgr/key
+	install -m 644 srv/salt/ceph/mgr/key/*.sls $(DESTDIR)/srv/salt/ceph/mgr/key/
+	install -d -m 755 $(DESTDIR)/srv/salt/ceph/mgr/auth
+	install -m 644 srv/salt/ceph/mgr/auth/*.sls $(DESTDIR)/srv/salt/ceph/mgr/auth/
+	install -d -m 755 $(DESTDIR)/srv/salt/ceph/mgr/keyring
+	install -m 644 srv/salt/ceph/mgr/keyring/*.sls $(DESTDIR)/srv/salt/ceph/mgr/keyring/
+	install -d -m 755 $(DESTDIR)/srv/salt/ceph/mgr/files
+	install -m 644 srv/salt/ceph/mgr/files/*.j2 $(DESTDIR)/srv/salt/ceph/mgr/files/
+	install -d -m 755 $(DESTDIR)/srv/salt/ceph/mgr/restart
+	install -m 644 srv/salt/ceph/mgr/restart/*.sls $(DESTDIR)/srv/salt/ceph/mgr/restart
 	# state files - salt-api
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/salt-api
 	install -m 644 srv/salt/ceph/salt-api/*.sls $(DESTDIR)/srv/salt/ceph/salt-api
@@ -283,6 +296,10 @@ copy-files:
 	install -m 644 srv/salt/ceph/rescind/mds/*.sls $(DESTDIR)/srv/salt/ceph/rescind/mds/
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/rescind/mds/keyring
 	install -m 644 srv/salt/ceph/rescind/mds/keyring/*.sls $(DESTDIR)/srv/salt/ceph/rescind/mds/keyring/
+	install -d -m 755 $(DESTDIR)/srv/salt/ceph/rescind/mgr
+	install -m 644 srv/salt/ceph/rescind/mgr/*.sls $(DESTDIR)/srv/salt/ceph/rescind/mgr/
+	install -d -m 755 $(DESTDIR)/srv/salt/ceph/rescind/mgr/keyring
+	install -m 644 srv/salt/ceph/rescind/mgr/keyring/*.sls $(DESTDIR)/srv/salt/ceph/rescind/mgr/keyring/
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/rescind/mon
 	install -m 644 srv/salt/ceph/rescind/mon/*.sls $(DESTDIR)/srv/salt/ceph/rescind/mon/
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/rescind/admin
@@ -314,6 +331,9 @@ copy-files:
 	# state files - restart - mon
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/restart/mon
 	install -m 644 srv/salt/ceph/restart/mon/*.sls $(DESTDIR)/srv/salt/ceph/restart/mon
+	# state files - restart - mgr
+	install -d -m 755 $(DESTDIR)/srv/salt/ceph/restart/mgr
+	install -m 644 srv/salt/ceph/restart/mgr/*.sls $(DESTDIR)/srv/salt/ceph/restart/mgr
 	# state files - restart - osd
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/restart/osd
 	install -m 644 srv/salt/ceph/restart/osd/*.sls $(DESTDIR)/srv/salt/ceph/restart/osd
@@ -443,6 +463,7 @@ copy-files:
 	install -d -m 700 $(DESTDIR)/srv/salt/ceph/ganesha/cache
 	install -d -m 700 $(DESTDIR)/srv/salt/ceph/igw/cache
 	install -d -m 700 $(DESTDIR)/srv/salt/ceph/mds/cache
+	install -d -m 700 $(DESTDIR)/srv/salt/ceph/mgr/cache
 	install -d -m 700 $(DESTDIR)/srv/salt/ceph/mon/cache
 	install -d -m 700 $(DESTDIR)/srv/salt/ceph/openattic/cache
 	install -d -m 700 $(DESTDIR)/srv/salt/ceph/osd/cache
@@ -455,6 +476,7 @@ copy-files:
 	-chown salt:salt $(DESTDIR)/srv/salt/ceph/ganesha/cache || true
 	-chown salt:salt $(DESTDIR)/srv/salt/ceph/igw/cache || true
 	-chown salt:salt $(DESTDIR)/srv/salt/ceph/mds/cache || true
+	-chown salt:salt $(DESTDIR)/srv/salt/ceph/mgr/cache || true
 	-chown salt:salt $(DESTDIR)/srv/salt/ceph/mon/cache || true
 	-chown salt:salt $(DESTDIR)/srv/salt/ceph/openattic/cache || true
 	-chown salt:salt $(DESTDIR)/srv/salt/ceph/osd/cache || true

--- a/deepsea.spec
+++ b/deepsea.spec
@@ -121,6 +121,13 @@ systemctl try-restart salt-master > /dev/null 2>&1 || :
 %dir /srv/salt/ceph/mds/keyring
 %dir /srv/salt/ceph/mds/pools
 %dir /srv/salt/ceph/mds/restart
+%dir /srv/salt/ceph/mgr
+%dir %attr(0700, salt, salt) /srv/salt/ceph/mgr/cache
+%dir /srv/salt/ceph/mgr/files
+%dir /srv/salt/ceph/mgr/key
+%dir /srv/salt/ceph/mgr/auth
+%dir /srv/salt/ceph/mgr/keyring
+%dir /srv/salt/ceph/mgr/restart
 %dir /srv/salt/ceph/migrate
 %dir /srv/salt/ceph/migrate/nodes
 %dir /srv/salt/ceph/migrate/osds
@@ -190,6 +197,8 @@ systemctl try-restart salt-master > /dev/null 2>&1 || :
 %dir /srv/salt/ceph/rescind/mds-nfs
 %dir /srv/salt/ceph/rescind/mds
 %dir /srv/salt/ceph/rescind/mds/keyring
+%dir /srv/salt/ceph/rescind/mgr
+%dir /srv/salt/ceph/rescind/mgr/keyring
 %dir /srv/salt/ceph/rescind/mon
 %dir /srv/salt/ceph/rescind/rgw-nfs
 %dir /srv/salt/ceph/rescind/rgw
@@ -202,6 +211,7 @@ systemctl try-restart salt-master > /dev/null 2>&1 || :
 %dir /srv/salt/ceph/restart
 %dir /srv/salt/ceph/restart/osd
 %dir /srv/salt/ceph/restart/mon
+%dir /srv/salt/ceph/restart/mgr
 %dir /srv/salt/ceph/restart/rgw
 %dir /srv/salt/ceph/restart/igw
 %dir /srv/salt/ceph/restart/mds
@@ -309,6 +319,12 @@ systemctl try-restart salt-master > /dev/null 2>&1 || :
 %config /srv/salt/ceph/mds/keyring/*.sls
 %config /srv/salt/ceph/mds/pools/*.sls
 %config /srv/salt/ceph/mds/restart/*.sls
+%config /srv/salt/ceph/mgr/*.sls
+%config /srv/salt/ceph/mgr/files/*.j2
+%config /srv/salt/ceph/mgr/key/*.sls
+%config /srv/salt/ceph/mgr/auth/*.sls
+%config /srv/salt/ceph/mgr/keyring/*.sls
+%config /srv/salt/ceph/mgr/restart/*.sls
 %config /srv/salt/ceph/migrate/nodes/*.sls
 %config /srv/salt/ceph/migrate/osds/*.sls
 %config /srv/salt/ceph/mines/*.sls
@@ -369,6 +385,8 @@ systemctl try-restart salt-master > /dev/null 2>&1 || :
 %config /srv/salt/ceph/rescind/mds-nfs/*.sls
 %config /srv/salt/ceph/rescind/mds/*.sls
 %config /srv/salt/ceph/rescind/mds/keyring/*.sls
+%config /srv/salt/ceph/rescind/mgr/*.sls
+%config /srv/salt/ceph/rescind/mgr/keyring/*.sls
 %config /srv/salt/ceph/rescind/mon/*.sls
 %config /srv/salt/ceph/rescind/rgw-nfs/*.sls
 %config /srv/salt/ceph/rescind/rgw/*.sls
@@ -382,6 +400,7 @@ systemctl try-restart salt-master > /dev/null 2>&1 || :
 %config /srv/salt/ceph/restart/*.sls
 %config /srv/salt/ceph/restart/osd/*.sls
 %config /srv/salt/ceph/restart/mon/*.sls
+%config /srv/salt/ceph/restart/mgr/*.sls
 %config /srv/salt/ceph/restart/mds/*.sls
 %config /srv/salt/ceph/restart/rgw/*.sls
 %config /srv/salt/ceph/restart/igw/*.sls

--- a/doc/examples/policy.cfg-generic
+++ b/doc/examples/policy.cfg-generic
@@ -9,5 +9,6 @@ config/stack/default/ceph/cluster.yml
 # Role assignment
 role-master/cluster/*.sls slice=[2:3]
 role-mon/cluster/*.sls slice=[3:6]
+role-mgr/cluster/*.sls slice=[3:6]
 role-igw/cluster/*.sls slice=[6:9]
 role-mon/stack/default/ceph/minions/*.yml slice=[3:6]

--- a/doc/examples/policy.cfg-regex
+++ b/doc/examples/policy.cfg-regex
@@ -11,4 +11,5 @@ config/stack/default/ceph/cluster.yml
 role-master/cluster/admin.subdomainA.sls 
 role-igw/cluster/*.sls re=.*2[4-6]\.subdomainX\.sls$
 role-mon/cluster/mon*.sls re=.*1[135]\.subdomainX\.sls$
+role-mgr/cluster/mon*.sls re=.*1[135]\.subdomainX\.sls$
 role-mon/stack/default/ceph/minions/*.yml re=.*1[135]\.subdomainX\.yml$

--- a/doc/examples/policy.cfg-rolebased
+++ b/doc/examples/policy.cfg-rolebased
@@ -10,6 +10,9 @@ role-admin/cluster/admin*.sls
 role-mon/stack/default/ceph/minions/mon*.yml
 role-mon/cluster/mon*.sls
 
+# MGR (mgrs are usually colocated with mons)
+role-mgr/cluster/mon*.sls
+
 # MDS
 role-mds/cluster/mds*.sls
 

--- a/qa/common/common.sh
+++ b/qa/common/common.sh
@@ -129,6 +129,7 @@ role-master/cluster/${SALT_MASTER}*.sls
 role-admin/cluster/*.sls
 # Role assignment - mon
 role-mon/cluster/*.sls slice=[:1]
+role-mgr/cluster/*.sls slice=[:1]
 role-mon/stack/default/ceph/minions/*.yml slice=[:1]
 EOF
 }

--- a/srv/modules/runners/orderednodes.py
+++ b/srv/modules/runners/orderednodes.py
@@ -19,14 +19,14 @@ def _preserve_order_sorted(seq):
 def unique(cluster='ceph', exclude=[]):
     """ 
     Assembling a list of nodes.
-    Ordered(MON, OSD, MDS, RGW, IGW)  
+    Ordered(MON, MGR, OSD, MDS, RGW, IGW)
     """ 
     all_clients = []
 
     client = salt.client.LocalClient(__opts__['conf_file'])
 
     cluster_assignment = "I@cluster:{}".format(cluster)
-    roles = ['mon', 'storage', 'mds', 'rgw', 'igw', 'ganesha']
+    roles = ['mon', 'mgr', 'storage', 'mds', 'rgw', 'igw', 'ganesha']
     # Adding an exclude param here to allow skipping of individual
     # roles. 
     # Usecase: If an admin wants to have manual control over the upgrade

--- a/srv/modules/runners/populate.py
+++ b/srv/modules/runners/populate.py
@@ -523,7 +523,7 @@ class CephRoles(object):
         Create role named directories and create corresponding yaml files
         for every server.
         """
-        roles = [ 'admin', 'mon', 'mds', 'igw', 'openattic' ]
+        roles = [ 'admin', 'mon', 'mds', 'mgr', 'igw', 'openattic' ]
         roles += self._rgw_configurations()
         roles += self._ganesha_configurations()
         self.available_roles.extend(roles)

--- a/srv/modules/runners/validate.py
+++ b/srv/modules/runners/validate.py
@@ -266,6 +266,23 @@ class Validate(object):
         else:
             self.passed['monitors'] = "valid"
 
+    def mgrs(self):
+        """
+        At least three nodes should have the mgr role
+        """
+        # TODO: Only make this mandatory for Ceph >= Luminous
+        mgrs = []
+        for node in self.data.keys():
+            if ('roles' in self.data[node] and
+                'mgr' in self.data[node]['roles']):
+                mgrs.append(node)
+
+        if (not self.in_dev_env and len(mgrs) < 3) or (self.in_dev_env and len(mgrs) < 1):
+            msg = "Too few mgrs {}".format(",".join(mgrs))
+            self.errors['mgrs'] = [ msg ]
+        else:
+            self.passed['mgrs'] = "valid"
+
     def storage(self):
         """
         At least four nodes must have the storage role.  All storage nodes
@@ -791,6 +808,7 @@ def pillar(cluster = None, printer=None, **kwargs):
     v.cluster_network()
     v.cluster_interface()
     v.monitors()
+    v.mgrs()
     v.storage()
     v.ganesha()
     v.master_role()

--- a/srv/salt/_modules/keyring.py
+++ b/srv/salt/_modules/keyring.py
@@ -39,6 +39,9 @@ def file(component, name=None):
     if component == "mds":
         return "/srv/salt/ceph/mds/cache/" + name + ".keyring"
 
+    if component == "mgr":
+        return "/srv/salt/ceph/mgr/cache/" + name + ".keyring"
+
     if component == "rgw":
         return "/srv/salt/ceph/rgw/cache/" + name + ".keyring"
 

--- a/srv/salt/ceph/mgr/auth/default.sls
+++ b/srv/salt/ceph/mgr/auth/default.sls
@@ -1,0 +1,16 @@
+
+prevent empty rendering:
+  test.nop:
+    - name: skip
+
+{% for host in salt.saltutil.runner('select.minions', cluster='ceph', roles='mgr', host=True) %}
+{% set client = "mgr." + host %}
+{% set keyring_file = salt['keyring.file']('mgr', host)  %}
+
+auth {{ keyring_file }}:
+  cmd.run:
+    - name: "ceph auth add {{ client }} -i {{ keyring_file }}"
+
+{% endfor %}
+
+

--- a/srv/salt/ceph/mgr/auth/init.sls
+++ b/srv/salt/ceph/mgr/auth/init.sls
@@ -1,0 +1,4 @@
+
+
+include:
+  - .{{ salt['pillar.get']('mgr_auth', 'default') }}

--- a/srv/salt/ceph/mgr/default.sls
+++ b/srv/salt/ceph/mgr/default.sls
@@ -1,0 +1,10 @@
+
+include:
+  - .keyring
+
+start mgr:
+  service.running:
+    - name: ceph-mgr@{{ grains['host'] }}
+    - enable: True
+
+

--- a/srv/salt/ceph/mgr/files/keyring.j2
+++ b/srv/salt/ceph/mgr/files/keyring.j2
@@ -1,0 +1,6 @@
+[{{ client }}]
+        key = {{ secret }}
+        caps mon = "allow profile mgr"
+        caps osd = "allow *"
+        caps mds = "allow *"
+

--- a/srv/salt/ceph/mgr/init.sls
+++ b/srv/salt/ceph/mgr/init.sls
@@ -1,0 +1,4 @@
+
+
+include:
+  - .{{ salt['pillar.get']('mgr_init', 'default') }}

--- a/srv/salt/ceph/mgr/key/default.sls
+++ b/srv/salt/ceph/mgr/key/default.sls
@@ -1,0 +1,25 @@
+
+prevent empty rendering:
+  test.nop:
+    - name: skip
+
+{% for host in salt.saltutil.runner('select.minions', cluster='ceph', roles='mgr', host=True) %}
+{% set client = "mgr." + host %}
+{% set keyring_file = salt['keyring.file']('mgr', host)  %}
+{{ keyring_file}}:
+  file.managed:
+    - source:
+      - salt://ceph/mgr/files/keyring.j2
+    - template: jinja
+    - user: salt
+    - group: salt
+    - mode: 600
+    - makedirs: True
+    - context:
+      client: {{ client }}
+      secret: {{ salt['keyring.secret'](keyring_file) }}
+    - fire_event: True
+
+{% endfor %}
+
+

--- a/srv/salt/ceph/mgr/key/init.sls
+++ b/srv/salt/ceph/mgr/key/init.sls
@@ -1,0 +1,4 @@
+
+
+include:
+  - .{{ salt['pillar.get']('mgr_key', 'default') }}

--- a/srv/salt/ceph/mgr/keyring/default.sls
+++ b/srv/salt/ceph/mgr/keyring/default.sls
@@ -1,0 +1,13 @@
+
+
+/var/lib/ceph/mgr/ceph-{{ grains['host'] }}/keyring:
+  file.managed:
+    - source:
+      - salt://ceph/mgr/cache/{{ grains['host'] }}.keyring
+    - template: jinja
+    - user: ceph
+    - group: ceph
+    - mode: 600
+    - makedirs: True
+    - fire_event: True
+

--- a/srv/salt/ceph/mgr/keyring/init.sls
+++ b/srv/salt/ceph/mgr/keyring/init.sls
@@ -1,0 +1,4 @@
+
+
+include:
+  - .{{ salt['pillar.get']('mgr_keyring', 'default') }}

--- a/srv/salt/ceph/mgr/restart/default.sls
+++ b/srv/salt/ceph/mgr/restart/default.sls
@@ -1,0 +1,5 @@
+restart:
+  cmd.run:
+    - name: "systemctl restart ceph-mgr@{{ grains['host'] }}.service"
+    - unless: "systemctl is-failed ceph-mgr@{{ grains['host'] }}.service"
+    - fire_event: True

--- a/srv/salt/ceph/mgr/restart/init.sls
+++ b/srv/salt/ceph/mgr/restart/init.sls
@@ -1,0 +1,4 @@
+
+include:
+  - .{{ salt['pillar.get']('mgr_restart_init', 'default') }}
+

--- a/srv/salt/ceph/rescind/mgr/default.sls
+++ b/srv/salt/ceph/rescind/mgr/default.sls
@@ -1,0 +1,13 @@
+
+mgr nop:
+  test.nop
+
+{% if 'mgr' not in salt['pillar.get']('roles') %}
+stop mgr {{ grains['host'] }}:
+  service.dead:
+    - name: ceph-mgr@{{ grains['host'] }}
+    - enable: False
+
+include:
+- .keyring
+{% endif %}

--- a/srv/salt/ceph/rescind/mgr/init.sls
+++ b/srv/salt/ceph/rescind/mgr/init.sls
@@ -1,0 +1,4 @@
+
+
+include:
+  - .{{ salt['pillar.get']('rescind_mgr', 'default') }}

--- a/srv/salt/ceph/rescind/mgr/keyring/default.sls
+++ b/srv/salt/ceph/rescind/mgr/keyring/default.sls
@@ -1,0 +1,5 @@
+
+/var/lib/ceph/mgr/ceph-{{ grains['host'] }}/keyring:
+  file.absent
+
+

--- a/srv/salt/ceph/rescind/mgr/keyring/init.sls
+++ b/srv/salt/ceph/rescind/mgr/keyring/init.sls
@@ -1,0 +1,4 @@
+
+
+include:
+  - .{{ salt['pillar.get']('rescind_mgr_keyring', 'default') }}

--- a/srv/salt/ceph/restart/default.sls
+++ b/srv/salt/ceph/restart/default.sls
@@ -1,5 +1,6 @@
 include:
   - .mon
+  - .mgr
   - .osd
   - .rgw
   - .mds

--- a/srv/salt/ceph/restart/mgr/default.sls
+++ b/srv/salt/ceph/restart/mgr/default.sls
@@ -1,0 +1,16 @@
+{% set master = salt['pillar.get']('master_minion') %}
+{% for host in salt.saltutil.runner('select.minions', cluster='ceph', roles='mgr') %}
+
+    wait until {{ host }} with role mgr can be restarted:
+      salt.state:
+        - tgt: {{ master }}
+        - sls: ceph.wait
+
+    restarting mgr on {{ host }}:
+      salt.state:
+        - tgt: {{ host }}
+        - tgt_type: compound
+        - sls: ceph.mgr.restart
+        - failhard: True
+
+{% endfor %}

--- a/srv/salt/ceph/restart/mgr/init.sls
+++ b/srv/salt/ceph/restart/mgr/init.sls
@@ -1,0 +1,2 @@
+include:
+  - .{{ salt['pillar.get']('mgr_restart_method', 'default') }}

--- a/srv/salt/ceph/stage/configure/default.sls
+++ b/srv/salt/ceph/stage/configure/default.sls
@@ -32,7 +32,7 @@ refresh_pillar2:
     - require: 
       - salt: post configuration
 
-{% for role in [ 'admin', 'mon', 'osd', 'igw', 'mds', 'rgw', 'ganesha', 'openattic'] %}
+{% for role in [ 'admin', 'mon', 'mgr', 'osd', 'igw', 'mds', 'rgw', 'ganesha', 'openattic'] %}
 {{ role }} key:
   salt.state:
     - tgt: {{ salt['pillar.get']('master_minion') }}

--- a/srv/salt/ceph/stage/deploy/default.sls
+++ b/srv/salt/ceph/stage/deploy/default.sls
@@ -61,11 +61,30 @@ admin:
     - tgt_type: compound
     - sls: ceph.admin
 
+mgr keyrings:
+  salt.state:
+    - tgt: 'I@roles:mgr and I@cluster:ceph'
+    - tgt_type: compound
+    - sls: ceph.mgr.keyring
+    - failhard: True
+
 monitors:
   salt.state:
     - tgt: 'I@roles:mon and I@cluster:ceph'
     - tgt_type: compound
     - sls: ceph.mon
+    - failhard: True
+
+mgr auth:
+  salt.state:
+    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - sls: ceph.mgr.auth
+
+mgrs:
+  salt.state:
+    - tgt: 'I@roles:mgr and I@cluster:ceph'
+    - tgt_type: compound
+    - sls: ceph.mgr
     - failhard: True
 
 setup ceph exporter:


### PR DESCRIPTION
PROBLEMS:
- Error EINVAL: entity mgr.ses4-2 exists but key does not match
(when run over an existing cluster with auto-deployed mgrs)

TODO:
- remove
- rescind
- only mandatory on Luminous+

ALSO:
- add mgr support to engulfer

Fixes: https://github.com/SUSE/DeepSea/issues/183
Signed-off-by: Tim Serong <tserong@suse.com>