### PR TITLE
Refrain from creating a demo RBD image

### DIFF
--- a/srv/salt/ceph/pool/default.sls
+++ b/srv/salt/ceph/pool/default.sls
@@ -8,9 +8,3 @@ wait:
         'status': "HEALTH_ERR"
     - fire_event: True
 
-demo image:
-  cmd.run:
-    - name: "rbd -p rbd create demo --size=1024"
-    - unless: "rbd -p rbd ls | grep -q demo$"
-    - fire_event: True
-


### PR DESCRIPTION
The rbd pool is longer created as of https://github.com/ceph/ceph/pull/15894 - so don't create a demo image in it, either.

Signed-off-by: Nathan Cutler <ncutler@suse.com>