### PR TITLE
add -n, --replacefiles flags to zypper migration

### DIFF
--- a/srv/salt/_modules/packagemanager.py
+++ b/srv/salt/_modules/packagemanager.py
@@ -282,7 +282,7 @@ class Zypper(PackageManager):
             log.info("No updates available.")
 
     def _migrate(self):
-        # There is no dryrun or replacefiles or non-interactive
+        # There is no dryrun
         strategy_flags = ['--auto-agree-with-licenses', '--replacefiles']
         # _NOT_ passing --allow-vendor-change as this should be a user
         # decision and be targeted prior to the upgrade

--- a/srv/salt/_modules/packagemanager.py
+++ b/srv/salt/_modules/packagemanager.py
@@ -283,10 +283,13 @@ class Zypper(PackageManager):
 
     def _migrate(self):
         # There is no dryrun or replacefiles or non-interactive
-        strategy_flags = ['--auto-agree-with-licenses']
+        strategy_flags = ['--auto-agree-with-licenses', '--replacefiles']
+        # _NOT_ passing --allow-vendor-change as this should be a user
+        # decision and be targeted prior to the upgrade
         cmd = []
         cmd.extend(self.base_command)
         cmd.extend(['migration'])
+        cmd.extend(self.zypper_flags)
         cmd.extend(strategy_flags)
         log.debug('Executing {}'.format(cmd))
         proc = Popen(cmd, stdout=PIPE, stderr=PIPE)


### PR DESCRIPTION
Fixes bug in the upgrade_init: migration path.

When upgrading more than one base product, which we do, there is a selection to make, hence passing `-n`

Only difference is the order in which you have to provide the `--non-interactive` switch. in `zypper migration` you have to pass it to the subcommand(migration) instead of zypper.

Intentionally _NOT_ passing the `--allow-vendor-change`.