### PR TITLE
Don't allow function exceptions to be passed to jinja

### DIFF
--- a/srv/modules/runners/rescinded.py
+++ b/srv/modules/runners/rescinded.py
@@ -2,7 +2,9 @@
 
 import salt.client
 import pprint
+import logging
 
+log = logging.getLogger(__name__)
 
 def ids(cluster, **kwargs):
     """
@@ -33,5 +35,8 @@ def osds(cluster='ceph'):
     data = local.cmd(search, 'osd.rescinded', [], expr_form="compound")
     ids = []
     for minion in data:
-        ids.extend(data[minion])
+        if type(data[minion]) is list:
+            ids.extend(data[minion])
+        else:
+            log.debug(data[minion])
     return list(set(ids))


### PR DESCRIPTION
If a minion returns a function exception(str) it will be transformed in a list of strings and passed to the jinja template, giving the user something like this:

``` 
- e
- x
- c
- e 
```

Only allow list() to be passed down to jinja and log.debug the remaining results.