### PR TITLE
Use == instead of is operator in str comp

### DIFF
--- a/srv/modules/runners/proposal.py
+++ b/srv/modules/runners/proposal.py
@@ -109,14 +109,14 @@ def _propose(node, proposal, args):
         dev_par = {}
         format_ = args.get('format')
         if type(v) is dict:
-            assert format_ is 'bluestore'
+            assert format_ == 'bluestore'
             wal, db = v.items()[0]
             dev_par['wal'] = wal
             dev_par['db'] = db
             dev_par['wal_size'] = args.get('wal-size')
             dev_par['db_size'] = args.get('db-size')
         elif type(v) is str:
-            if format_ is 'bluestore':
+            if format_ == 'bluestore':
                 dev_par['wal'] = v
                 dev_par['db'] = v
                 dev_par['wal_size'] = args.get('wal-size')


### PR DESCRIPTION
According to the [pydocs](https://docs.python.org/2/reference/expressions.html#is)

> The operators is and is not test for object identity: x is y is true if and only if x and y are the same object. x is not y yields the inverse truth value. [6]

This caused the proposal. func<_propose> to drop in the else block and define a journal_size although bluestore was defined.