### PR TITLE
iscsi: handle iscsi configure when no demo rbd image exists

### DIFF
--- a/srv/salt/ceph/igw/files/lrbd.conf.j2
+++ b/srv/salt/ceph/igw/files/lrbd.conf.j2
@@ -1,3 +1,4 @@
+{% if salt['cmd.run']('rados lspools | grep -q "^rbd$"') and salt['cmd.run']('rbd --pool rbd ls | grep -q "^demo$"') %}
 {
     "auth": [
         {
@@ -53,3 +54,11 @@
         }  
     ]
 }
+{% else %}
+{
+  "auth": [],
+  "targets": [],
+  "portals": [],
+  "pools": []
+}
+{% endif %}

--- a/srv/salt/ceph/igw/import/default.sls
+++ b/srv/salt/ceph/igw/import/default.sls
@@ -19,4 +19,4 @@ configure:
     - shell: /bin/bash
     - require:
       - file: /tmp/lrbd.conf
-
+    - unless: 'cat /tmp/lrbd.conf | grep -q "\"pools\": \[\]$"'

--- a/srv/salt/ceph/stage/configure/default.sls
+++ b/srv/salt/ceph/stage/configure/default.sls
@@ -42,13 +42,6 @@ refresh_pillar2:
 
 {% endfor %}
 
-igw config:
-  salt.state:
-    - tgt: {{ salt['pillar.get']('master_minion') }}
-    - tgt_type: compound
-    - sls: ceph.igw.config
-    - failhard: True
-
 setup monitoring:
   salt.state:
     - tgt: {{ salt['pillar.get']('master_minion') }}

--- a/srv/salt/ceph/stage/iscsi/default.sls
+++ b/srv/salt/ceph/stage/iscsi/default.sls
@@ -1,5 +1,11 @@
 {% if salt.saltutil.runner('select.minions', cluster='ceph', roles='igw') %}
 
+igw config:
+  salt.state:
+    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt_type: compound
+    - sls: ceph.igw.config
+
 auth:
   salt.state:
     - tgt: {{ salt['pillar.get']('master_minion') }}


### PR DESCRIPTION
This PR addresses the issue of configuring an iSCSI target when no RBD demo image was created.

This PR is related to #401 

Signed-off-by: Ricardo Dias <rdias@suse.com>