### PR TITLE
Added automatic configuration of openATTIC

### DIFF
--- a/srv/modules/runners/sharedsecret.py
+++ b/srv/modules/runners/sharedsecret.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+import os
+
+
+def show():
+    '''
+    This function reads the contents of the sharedsecret.conf file and parses the secret key.
+    This file has the following structure:
+
+    ``sharedsecret: <secret_key>``
+
+    Returns:
+        str: the secret key used by salt-api sharedsecret eauth
+
+    '''
+    filename = '/etc/salt/master.d/sharedsecret.conf'
+    if not os.path.exists(filename):
+        return None
+    with open(filename, 'r') as fhandler:
+        line = fhandler.readline()
+        idx = line.find(':')
+        if idx == -1:
+            return None
+        return line[idx+2:]

--- a/srv/salt/ceph/openattic/default.sls
+++ b/srv/salt/ceph/openattic/default.sls
@@ -9,3 +9,12 @@ enable openattic-systemd:
   service.running:
     - name: openattic-systemd
     - enable: True
+
+/etc/sysconfig/openattic:
+  file.append:
+    - text: |
+        SALT_API_HOST="{{ salt['pillar.get']('master_minion') }}"
+        SALT_API_PORT=8000
+        SALT_API_EAUTH="sharedsecret"
+        SALT_API_USERNAME="admin"
+        SALT_API_SHARED_SECRET="{{ salt['pillar.get']('salt_api_shared_secret') }}"

--- a/srv/salt/ceph/openattic/default.sls
+++ b/srv/salt/ceph/openattic/default.sls
@@ -18,3 +18,4 @@ enable openattic-systemd:
         SALT_API_EAUTH="sharedsecret"
         SALT_API_USERNAME="admin"
         SALT_API_SHARED_SECRET="{{ salt['pillar.get']('salt_api_shared_secret') }}"
+        GRAFANA_API_HOST="{{ salt['pillar.get']('master_minion') }}"

--- a/srv/salt/ceph/stage/openattic/default.sls
+++ b/srv/salt/ceph/stage/openattic/default.sls
@@ -1,30 +1,32 @@
 
 openattic nop:
-  test.nop
+    test.nop
 
 {% if salt.saltutil.runner('select.minions', cluster='ceph', roles='openattic') %}
 
 openattic auth:
-  salt.state:
-    - tgt: {{ salt['pillar.get']('master_minion') }}
-    - sls: ceph.openattic.auth
+    salt.state:
+        - tgt: {{ salt['pillar.get']('master_minion') }}
+        - sls: ceph.openattic.auth
 
 openattic:
-  salt.state:
-    - tgt: "I@roles:openattic"
-    - tgt_type: compound
-    - sls: ceph.openattic
+    salt.state:
+        - tgt: "I@roles:openattic"
+        - tgt_type: compound
+        - sls: ceph.openattic
+        - pillar:
+            'salt_api_shared_secret': {{ salt.saltutil.runner('sharedsecret.show') }}
 
 openattic keyring:
-  salt.state:
-    - tgt: "I@roles:openattic"
-    - tgt_type: compound
-    - sls: ceph.openattic.keyring
+    salt.state:
+        - tgt: "I@roles:openattic"
+        - tgt_type: compound
+        - sls: ceph.openattic.keyring
 
 openattic oaconfig:
-  salt.state:
-    - tgt: "I@roles:openattic"
-    - tgt_type: compound
-    - sls: ceph.openattic.oaconfig
+    salt.state:
+        - tgt: "I@roles:openattic"
+        - tgt_type: compound
+        - sls: ceph.openattic.oaconfig
 
 {% endif %}

--- a/tests/unit/runners/test_sharedsecret.py
+++ b/tests/unit/runners/test_sharedsecret.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+'''
+Unit tests for the sharedsecret salt runner
+'''
+from pyfakefs import fake_filesystem
+from mock import patch
+from srv.modules.runners import sharedsecret
+
+
+fs = fake_filesystem.FakeFilesystem()
+f_os = fake_filesystem.FakeOsModule(fs)
+f_open = fake_filesystem.FakeFileOpen(fs)
+
+
+class TestSharedSecret(object):
+
+    @patch('os.path.exists', new=f_os.path.exists)
+    def test_no_sharedsecret_file(self):
+        assert sharedsecret.show() is None
+
+    @patch('os.path.exists', new=f_os.path.exists)
+    @patch('__builtin__.open', new=f_open)
+    def test_valid_sharedsecret_file(self):
+        fs.CreateFile('/etc/salt/master.d/sharedsecret.conf',
+                      contents='sharedsecret: my-precious-key')
+        key = sharedsecret.show()
+        fs.RemoveFile('/etc/salt/master.d/sharedsecret.conf')
+        assert key == 'my-precious-key'
+
+    @patch('os.path.exists', new=f_os.path.exists)
+    @patch('__builtin__.open', new=f_open)
+    def test_invalid_sharedsecret_file(self):
+        fs.CreateFile('/etc/salt/master.d/sharedsecret.conf',
+                      contents='sharedsecret = my-precious-key')
+        key = sharedsecret.show()
+        fs.RemoveFile('/etc/salt/master.d/sharedsecret.conf')
+        assert key is None


### PR DESCRIPTION
This PRs adds to the openattic installation the automatic configuration of the salt-api credentials and the configuration of the grafana hostname.