### PR TITLE
mds: daemon keyring only needs 'allow mds'

### DIFF
--- a/srv/salt/ceph/mds/files/keyring.j2
+++ b/srv/salt/ceph/mds/files/keyring.j2
@@ -1,6 +1,6 @@
 [{{ client }}]
         key = {{ secret }}
-        caps mds = "allow *"
+        caps mds = "allow"
         caps mon = "allow profile mds"
         caps osd = "allow rwx"
 


### PR DESCRIPTION
Otherwise it would allow the mds keyring can be used to change mds
config options. This should be reserved for the admin keyring.
This commit aligns with what ceph-deploy does.

Signed-off-by: Jan Fajerski <jfajerski@suse.com>