### PR TITLE
Disable upgrade if MON/OSD are on the same node (temporarily)

### DIFF
--- a/srv/modules/runners/upgrade.py
+++ b/srv/modules/runners/upgrade.py
@@ -1,0 +1,42 @@
+import salt.client
+import salt.utils.error
+
+class UpgradeValidation(object):
+    """
+    Due to the current situation you have to upgrade
+    all monitos before ceph allows you to start any OSD
+    Our current implementation of maintenance upgrades
+    triggers this behavior if you happen to have
+    Monitors and Storage roles assigned on the same node
+    (And more then one monitor)
+    To avoid this, before actually providing a proper solution,
+    we stop users to execute the upgade in the first place.
+    """
+
+    def __init__(self, cluster='ceph'):
+        local = salt.client.LocalClient()
+        search = "I@cluster:{}".format(cluster)
+
+        self.pillar_data = local.cmd(search , 'pillar.items', [], expr_form="compound")
+        self.grains_data = local.cmd(search , 'grains.items', [], expr_form="compound")
+
+    def colocated_services(self):
+        pillar_data = self.pillar_data
+        for host in pillar_data.keys():
+            if 'roles' in pillar_data[host]:
+                if 'storage' in pillar_data[host]['roles']\
+                    and 'mon' in pillar_data[host]['roles']:
+                    msg = """
+                         ************** PLEASE READ ***************
+                         We currently do not support upgrading when
+                         you have a monitor and a storage role
+                         assigned on the same node.
+                         ******************************************"""
+                    return False, msg
+        return True, ""
+
+def check():
+      uvo = UpgradeValidation()
+      ret, msg = uvo.colocated_services()
+      print msg
+      return ret

--- a/srv/salt/ceph/maintenance/upgrade/master/default.sls
+++ b/srv/salt/ceph/maintenance/upgrade/master/default.sls
@@ -1,12 +1,4 @@
-{% if salt['saltutil.runner']('validate.setup') == False %}
-
-validate failed:
-  salt.state:
-    - name: just.exit
-    - tgt: {{ salt['pillar.get']('master_minion') }}
-    - failhard: True
-
-{% endif %}
+{% if salt['saltutil.runner']('upgrade.check') or salt['saltutil.runner']('validate.setup') != False %}
 
 {% set notice =  salt['saltutil.runner']('advise.salt_upgrade') %}
 
@@ -34,4 +26,12 @@ reboot master:
     - tgt: {{ salt['pillar.get']('master_minion') }}
     - sls: ceph.updates.restart
 
+{% else %}
 
+validate failed:
+  salt.state:
+    - name: just.exit
+    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - failhard: True
+
+{% endif %}


### PR DESCRIPTION
   Due to the current situation you have to upgrade    
    all monitos before ceph allows you to start any OSD                 
    Our current implementation of maintenance upgrades                  
    triggers this behavior if you happen to have                        
    Monitors and Storage roles assigned on the same node                
    (And more then one monitor)  
    To avoid this, before actually providing a proper solution,         
    we stop users to execute the upgade in the first place.