### PR TITLE
rpm: fix upgrade path when moving to sharedsecret eauth

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ copy-files:
 	install -m 644 etc/salt/master.d/output.conf $(DESTDIR)/etc/salt/master.d/
 	install -m 600 etc/salt/master.d/eauth.conf $(DESTDIR)/etc/salt/master.d/
 	install -m 644 etc/salt/master.d/salt-api.conf $(DESTDIR)/etc/salt/master.d/
+	install -m 600 srv/salt/ceph/salt-api/files/sharedsecret.conf.j2 $(DESTDIR)/etc/salt/master.d/sharedsecret.conf
 	# docs
 	install -d -m 755 $(DESTDIR)$(DOCDIR)/deepsea
 	install -m 644 LICENSE $(DESTDIR)$(DOCDIR)/deepsea/
@@ -493,7 +494,6 @@ copy-files:
 	-chown salt:salt $(DESTDIR)/srv/salt/ceph/rgw/cache || true
 
 install: copy-files
-	install -m 600 srv/salt/ceph/salt-api/files/sharedsecret.conf.j2 $(DESTDIR)/etc/salt/master.d/sharedsecret.conf
 	sed -i '/^sharedsecret: /s!{{ shared_secret }}!'`cat /proc/sys/kernel/random/uuid`'!' $(DESTDIR)/etc/salt/master.d/sharedsecret.conf
 	chown salt:salt $(DESTDIR)/etc/salt/master.d/*
 	sed -i '/^master_minion:/s!_REPLACE_ME_!'`hostname -f`'!' /srv/pillar/ceph/master_minion.sls

--- a/deepsea.spec
+++ b/deepsea.spec
@@ -50,15 +50,15 @@ A collection of Salt files providing a deployment of Ceph as a series of stages.
 
 %install
 make DESTDIR=%{buildroot} DOCDIR=%{_docdir} copy-files
-install -m 600 srv/salt/ceph/salt-api/files/sharedsecret.conf.j2 %{buildroot}/etc/salt/master.d/sharedsecret.conf
 
 %post
 if [ $1 -eq 1 ] ; then
   # Initialize to most likely value
   sed -i '/^master_minion:/s!_REPLACE_ME_!'`hostname -f`'!' /srv/pillar/ceph/master_minion.sls
-  sed -i '/^sharedsecret: /s!{{ shared_secret }}!'`cat /proc/sys/kernel/random/uuid`'!' /etc/salt/master.d/sharedsecret.conf
-  chown salt:salt /etc/salt/master.d/sharedsecret.conf
 fi
+# Initialize the shared secret key
+sed -i '/^sharedsecret: /s!{{ shared_secret }}!'`cat /proc/sys/kernel/random/uuid`'!' /etc/salt/master.d/sharedsecret.conf
+chown salt:salt /etc/salt/master.d/sharedsecret.conf
 # Restart salt-master if it's running, so it picks up
 # the config changes in /etc/salt/master.d/modules.conf
 systemctl try-restart salt-master > /dev/null 2>&1 || :


### PR DESCRIPTION
Fixes: #443

Signed-off-by: Ricardo Dias <rdias@suse.com>