### PR TITLE
build/ops: require python-netaddr unconditionally

### DIFF
--- a/deepsea.spec
+++ b/deepsea.spec
@@ -33,9 +33,7 @@ Requires:       salt-master
 Requires:       salt-minion
 Requires:       salt-api
 Requires:       python-ipaddress
-%if 0%{?sle_version} == 120200 && 0%{?is_opensuse} == 1
 Requires:       python-netaddr
-%endif
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 BuildArch:      noarch
 


### PR DESCRIPTION
python-netaddr is part of the POOL repo in both SLE-12-SP2 and SLE-12-SP3, so
there's no danger.

Signed-off-by: Nathan Cutler <ncutler@suse.com>