### PR TITLE
 qa: don't fail on missing global.conf

### DIFF
--- a/qa/common/common.sh
+++ b/qa/common/common.sh
@@ -189,7 +189,7 @@ function salt_cmd_run_lsblk {
 }
 
 function cat_global_conf {
-  cat /srv/salt/ceph/configuration/files/ceph.conf.d/global.conf
+  cat /srv/salt/ceph/configuration/files/ceph.conf.d/global.conf || true
 }
 
 function cat_ceph_conf {


### PR DESCRIPTION
If enough storage nodes are present no ceph.conf adjustment is
necessary.

Signed-off-by: Jan Fajerski <jfajerski@suse.com>