### PR TITLE
mon keyring: append admin key

### DIFF
--- a/srv/salt/ceph/mon/files/keyring.j2
+++ b/srv/salt/ceph/mon/files/keyring.j2
@@ -1,9 +1,3 @@
 [mon.]
         key = {{ mon_secret }}
         caps mon = "allow *"
-[client.admin]
-	key = {{ admin_secret }}
-	caps mds = "allow *"
-	caps mon = "allow *"
-	caps osd = "allow *"
-	caps mgr = "allow profile mds"

--- a/srv/salt/ceph/mon/key/default.sls
+++ b/srv/salt/ceph/mon/key/default.sls
@@ -1,10 +1,8 @@
 
-{% set admin_keyring = "/srv/salt/ceph/admin/cache/ceph.client.admin.keyring" %}
-
 {% set keyring_file = "/srv/salt/ceph/mon/cache/mon.keyring" %}
-{{ keyring_file}}:
+{{ keyring_file }}:
   file.managed:
-    - source: 
+    - source:
       - salt://ceph/mon/files/keyring.j2
     - template: jinja
     - user: salt
@@ -13,8 +11,9 @@
     - makedirs: True
     - context:
       mon_secret: {{ salt['keyring.secret'](keyring_file) }}
-      admin_secret: {{ salt['keyring.secret'](admin_keyring) }}
     - fire_event: True
 
-
-
+{{ keyring_file }} append admin keyring:
+  file.append:
+    - name: {{ keyring_file }}
+    - source: salt://ceph/admin/cache/ceph.client.admin.keyring


### PR DESCRIPTION
Instead of maintaining the admin caps twice, rather append the admin key
to the mon keyring from its source.

Signed-off-by: Jan Fajerski <jfajerski@suse.com>