### PR TITLE
Failhard if a minion is missing

### DIFF
--- a/srv/salt/ceph/maintenance/upgrade/master/default.sls
+++ b/srv/salt/ceph/maintenance/upgrade/master/default.sls
@@ -5,6 +5,7 @@ pre master readycheck:
     - name: minions.ready
     - timeout: {{ salt['pillar.get']('ready_timeout', 300) }}
     - hardfail: True
+    - failhard: True
 
 {% set notice = salt['saltutil.runner']('advise.salt_upgrade') %}
   

--- a/srv/salt/ceph/maintenance/upgrade/minion/default.sls
+++ b/srv/salt/ceph/maintenance/upgrade/minion/default.sls
@@ -3,6 +3,7 @@ pre minion readycheck:
     - name: minions.ready
     - timeout: {{ salt['pillar.get']('ready_timeout', 300) }}
     - hardfail: True
+    - failhard: True
 
 update salt:
   salt.state:
@@ -42,6 +43,7 @@ readycheck before processing {{ host }}:
     - name: minions.ready
     - timeout: {{ salt['pillar.get']('ready_timeout', 300) }}
     - hardfail: True
+    - failhard: True
 
 upgrading mon on {{ host }}:
   salt.runner:
@@ -89,6 +91,7 @@ readycheck for {{ host }} after processing mons :
     - name: minions.ready
     - timeout: {{ salt['pillar.get']('ready_timeout', 300) }}
     - hardfail: True
+    - failhard: True
 
 upgrading {{ host }}:
   salt.runner:


### PR DESCRIPTION
During an upgrade we do clusterwide health checks:

* Are all minions up
* Are all services on each minion up
 
checks for service sanity lives in `ceph.processes` which calls the module `cephprocesses.wait`. It's supposed to get the role-minion relationship from the pillar. If a minion is down tough, it's timeout will be handles as a non-blocking(not part of the cluster), hence skipped.
To circumvent this behavior, and overall improve the reliability, wait for minions to be up(for 300seconds).
If all minions fail to reach back to the master -> FAIL(hard).