### PR TITLE
remove leading and trailing whitespace

### DIFF
--- a/srv/modules/runners/push.py
+++ b/srv/modules/runners/push.py
@@ -284,7 +284,7 @@ class PillarData(object):
             for line in policy:
                 # strip comments from the end of the line
                 line = re.sub('\s+#.*$', '', line)
-                line = line.rstrip()
+                line = line.strip()
                 if (line.startswith('#') or not line):
                     log.debug("Ignoring '{}'".format(line))
                     continue

--- a/tests/unit/runners/test_push.py
+++ b/tests/unit/runners/test_push.py
@@ -33,6 +33,10 @@ fs.CreateFile('policy.cfg_ml_commented',
                         'cluster-ceph/cluster/*.sls \t# with a comment'))
 fs.CreateFile('policy.cfg_leading_whitespace',
               contents=(' cluster-ceph/cluster/*.sls'))
+fs.CreateFile('policy.cfg_trailing_whitespace',
+              contents=('cluster-ceph/cluster/*.sls '))
+fs.CreateFile('policy.cfg_trailing_and_leading_whitespace',
+              contents=(' cluster-ceph/cluster/*.sls '))
 
 f_glob = fake_glob.FakeGlobModule(fs)
 f_os = fake_fs.FakeOsModule(fs)
@@ -85,4 +89,10 @@ class TestPush():
         assert len(organized.keys()) == len(nodes)
 
         organized = p_d.organize('policy.cfg_leading_whitespace')
+        assert len(organized.keys()) == len(nodes)
+
+        organized = p_d.organize('policy.cfg_trailing_whitespace')
+        assert len(organized.keys()) == len(nodes)
+
+        organized = p_d.organize('policy.cfg_trailing_and_leading_whitespace')
         assert len(organized.keys()) == len(nodes)

--- a/tests/unit/runners/test_push.py
+++ b/tests/unit/runners/test_push.py
@@ -31,6 +31,8 @@ fs.CreateFile('policy.cfg_commented2',
 fs.CreateFile('policy.cfg_ml_commented',
               contents=('# a line comment\n'
                         'cluster-ceph/cluster/*.sls \t# with a comment'))
+fs.CreateFile('policy.cfg_leading_whitespace',
+              contents=(' cluster-ceph/cluster/*.sls'))
 
 f_glob = fake_glob.FakeGlobModule(fs)
 f_os = fake_fs.FakeOsModule(fs)
@@ -80,4 +82,7 @@ class TestPush():
         assert len(organized.keys()) == len(nodes)
 
         organized = p_d.organize('policy.cfg_ml_commented')
+        assert len(organized.keys()) == len(nodes)
+
+        organized = p_d.organize('policy.cfg_leading_whitespace')
         assert len(organized.keys()) == len(nodes)

--- a/tests/unit/runners/test_push.py
+++ b/tests/unit/runners/test_push.py
@@ -37,6 +37,10 @@ fs.CreateFile('policy.cfg_trailing_whitespace',
               contents=('cluster-ceph/cluster/*.sls '))
 fs.CreateFile('policy.cfg_trailing_and_leading_whitespace',
               contents=(' cluster-ceph/cluster/*.sls '))
+fs.CreateFile('policy.cfg_trailing_and_leading_whitespace_and_leading_comment',
+              contents=(' #cluster-ceph/cluster/*.sls '))
+fs.CreateFile('policy.cfg_trailing_and_leading_whitespace_and_trailing_comment',
+              contents=(' cluster-ceph/cluster/*.sls #'))
 
 f_glob = fake_glob.FakeGlobModule(fs)
 f_os = fake_fs.FakeOsModule(fs)
@@ -95,4 +99,10 @@ class TestPush():
         assert len(organized.keys()) == len(nodes)
 
         organized = p_d.organize('policy.cfg_trailing_and_leading_whitespace')
+        assert len(organized.keys()) == len(nodes)
+
+        organized = p_d.organize('policy.cfg_trailing_and_leading_whitespace_and_leading_comment')
+        assert len(organized.keys()) == 0
+
+        organized = p_d.organize('policy.cfg_trailing_and_leading_whitespace_and_trailing_comment')
         assert len(organized.keys()) == len(nodes)


### PR DESCRIPTION
strip: 

> Return a copy of the string with the leading and trailing characters removed. The chars argument is a string specifying the set of characters to be removed. If omitted or None, the chars argument defaults to removing whitespace. The chars argument is not a prefix or suffix; rather, all combinations of its values are stripped:

as opposed to rstrip:

> Return a copy of the string with trailing characters removed. The chars argument is a string specifying the set of characters to be removed. If omitted or None, the chars argument defaults to removing whitespace. The chars argument is not a suffix; rather, all combinations of its values are stripped: