### PR TITLE
Added "mds" caps to openATTIC keyring.

### DIFF
--- a/srv/salt/ceph/openattic/files/keyring.j2
+++ b/srv/salt/ceph/openattic/files/keyring.j2
@@ -2,4 +2,5 @@
 	key = {{ secret }}
 	caps mon = "allow *"
 	caps osd = "allow *"
+	caps mds = "allow *"
         caps mgr = "allow r"


### PR DESCRIPTION
This is necessary in order for openATTIC to access CephFS mounts.

Signed-off-by: Ricardo Dias <rdias@suse.com>