### PR TITLE
Add Prometheus exporter for Ceph RGW user bandwidth stats

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -333,6 +333,8 @@ copy-files:
 	install -m 644 srv/salt/ceph/rescind/rgw/*.sls $(DESTDIR)/srv/salt/ceph/rescind/rgw/
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/rescind/rgw/keyring
 	install -m 644 srv/salt/ceph/rescind/rgw/keyring/*.sls $(DESTDIR)/srv/salt/ceph/rescind/rgw/keyring/
+	install -d -m 755 $(DESTDIR)/srv/salt/ceph/rescind/rgw/monitoring
+	install -m 644 srv/salt/ceph/rescind/rgw/monitoring/*.sls $(DESTDIR)/srv/salt/ceph/rescind/rgw/monitoring/
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/rescind/storage
 	install -m 644 srv/salt/ceph/rescind/storage/*.sls $(DESTDIR)/srv/salt/ceph/rescind/storage/
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/rescind/storage/keyring

--- a/srv/salt/ceph/monitoring/grafana/files/ceph-rgw-users.json
+++ b/srv/salt/ceph/monitoring/grafana/files/ceph-rgw-users.json
@@ -1,0 +1,331 @@
+{
+  "overwrite": false,
+  "dashboard": {
+    "__requires": [
+      {
+        "type": "grafana",
+        "id": "grafana",
+        "name": "Grafana",
+        "version": "3.1.1"
+      },
+      {
+        "type": "panel",
+        "id": "graph",
+        "name": "Graph",
+        "version": ""
+      },
+      {
+        "type": "datasource",
+        "id": "prometheus",
+        "name": "Prometheus",
+        "version": "1.0.0"
+      }
+    ],
+    "annotations": {
+      "list": []
+    },
+    "description": "Ceph Object Gateway status.",
+    "editable": false,
+    "gnetId": null,
+    "graphTooltip": 0,
+    "hideControls": false,
+    "id": null,
+    "links": [],
+    "refresh": false,
+    "rows": [
+      {
+        "collapse": false,
+        "height": 253,
+        "panels": [
+          {
+            "aliasColors": {},
+            "bars": false,
+            "datasource": "Prometheus",
+            "decimals": null,
+            "fill": 1,
+            "id": 1,
+            "legend": {
+              "alignAsTable": false,
+              "avg": false,
+              "current": false,
+              "hideEmpty": false,
+              "hideZero": false,
+              "max": false,
+              "min": false,
+              "rightSide": false,
+              "show": true,
+              "sideWidth": null,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "null as zero",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "span": 12,
+            "stack": false,
+            "steppedLine": true,
+            "targets": [
+              {
+                "expr": "ceph_rgw_user_usage_ops_total{owner='$owner',bucket='$bucket',category='$category'}",
+                "hide": false,
+                "interval": "$interval",
+                "intervalFactor": 1,
+                "legendFormat": "Operations",
+                "metric": "",
+                "refId": "A",
+                "step": 3600
+              },
+              {
+                "expr": "ceph_rgw_user_usage_successful_ops_total{owner='$owner',bucket='$bucket',category='$category'}",
+                "interval": "$interval",
+                "intervalFactor": 1,
+                "legendFormat": "Successful operations",
+                "metric": "",
+                "refId": "B",
+                "step": 3600
+              },
+              {
+                "expr": "ceph_rgw_user_usage_sent_bytes_total{owner='$owner',bucket='$bucket',category='$category'}",
+                "interval": "$interval",
+                "intervalFactor": 1,
+                "legendFormat": "Sent",
+                "metric": "",
+                "refId": "C",
+                "step": 3600
+              },
+              {
+                "expr": "ceph_rgw_user_usage_received_bytes_total{owner='$owner',bucket='$bucket',category='$category'}",
+                "interval": "$interval",
+                "intervalFactor": 1,
+                "legendFormat": "Received",
+                "metric": "",
+                "refId": "D",
+                "step": 3600
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Bandwidth usage - $category",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          }
+        ],
+        "repeat": null,
+        "repeatIteration": null,
+        "repeatRowId": null,
+        "showTitle": true,
+        "title": "Owner: $owner",
+        "titleSize": "h6"
+      }
+    ],
+    "schemaVersion": 14,
+    "style": "dark",
+    "tags": [
+      "ceph",
+      "rgw"
+    ],
+    "templating": {
+      "list": [
+        {
+          "auto": true,
+          "auto_count": 10,
+          "auto_min": "1m",
+          "current": {
+            "text": "1h",
+            "value": "1h"
+          },
+          "hide": 0,
+          "label": "Interval",
+          "name": "interval",
+          "options": [
+            {
+              "selected": false,
+              "text": "auto",
+              "value": "$__auto_interval"
+            },
+            {
+              "selected": false,
+              "text": "1m",
+              "value": "1m"
+            },
+            {
+              "selected": false,
+              "text": "10m",
+              "value": "10m"
+            },
+            {
+              "selected": false,
+              "text": "30m",
+              "value": "30m"
+            },
+            {
+              "selected": true,
+              "text": "1h",
+              "value": "1h"
+            },
+            {
+              "selected": false,
+              "text": "6h",
+              "value": "6h"
+            },
+            {
+              "selected": false,
+              "text": "12h",
+              "value": "12h"
+            },
+            {
+              "selected": false,
+              "text": "1d",
+              "value": "1d"
+            },
+            {
+              "selected": false,
+              "text": "7d",
+              "value": "7d"
+            },
+            {
+              "selected": false,
+              "text": "14d",
+              "value": "14d"
+            },
+            {
+              "selected": false,
+              "text": "30d",
+              "value": "30d"
+            }
+          ],
+          "query": "1m,10m,30m,1h,6h,12h,1d,7d,14d,30d",
+          "refresh": 2,
+          "type": "interval"
+        },
+        {
+          "allValue": null,
+          "current": {},
+          "datasource": "Prometheus",
+          "hide": 0,
+          "includeAll": false,
+          "label": "Username",
+          "multi": false,
+          "name": "owner",
+          "options": [],
+          "query": "label_values(ceph_rgw_user_usage_ops_total, owner)",
+          "refresh": 1,
+          "regex": "",
+          "sort": 1,
+          "tagValuesQuery": "",
+          "tags": [],
+          "tagsQuery": "",
+          "type": "query",
+          "useTags": false
+        },
+        {
+          "allValue": null,
+          "current": {},
+          "datasource": "Prometheus",
+          "hide": 0,
+          "includeAll": false,
+          "label": "Bucket",
+          "multi": false,
+          "name": "bucket",
+          "options": [],
+          "query": "label_values(ceph_rgw_user_usage_ops_total{owner='$owner'}, bucket)",
+          "refresh": 1,
+          "regex": "",
+          "sort": 1,
+          "tagValuesQuery": "",
+          "tags": [],
+          "tagsQuery": "",
+          "type": "query",
+          "useTags": false
+        },
+        {
+          "allValue": null,
+          "current": {},
+          "datasource": "Prometheus",
+          "hide": 0,
+          "includeAll": false,
+          "label": "Category",
+          "multi": false,
+          "name": "category",
+          "options": [],
+          "query": "label_values(ceph_rgw_user_usage_ops_total, category)",
+          "refresh": 1,
+          "regex": "",
+          "sort": 1,
+          "tagValuesQuery": "",
+          "tags": [],
+          "tagsQuery": "",
+          "type": "query",
+          "useTags": false
+        }
+      ]
+    },
+    "time": {
+      "from": "now-24h",
+      "to": "now"
+    },
+    "timepicker": {
+      "refresh_intervals": [
+        "5s",
+        "10s",
+        "30s",
+        "1m",
+        "5m",
+        "15m",
+        "30m",
+        "1h",
+        "2h",
+        "1d"
+      ],
+      "time_options": [
+        "5m",
+        "15m",
+        "1h",
+        "6h",
+        "12h",
+        "24h",
+        "2d",
+        "7d",
+        "30d"
+      ]
+    },
+    "timezone": "browser",
+    "title": "Ceph - Object Gateway users",
+    "version": 0
+  }
+}

--- a/srv/salt/ceph/monitoring/grafana/init.sls
+++ b/srv/salt/ceph/monitoring/grafana/init.sls
@@ -73,3 +73,10 @@ add rbd dashboard:
         curl -s -H "Content-Type: application/json" \
           -XPOST http://admin:admin@localhost:3000/api/dashboards/db \
           -d @/srv/salt/ceph/monitoring/grafana/files/ceph-rbd.json
+
+add rgw-users dashboard:
+  cmd.run:
+    - name: |
+        curl -s -H "Content-Type: application/json" \
+          -XPOST http://admin:admin@localhost:3000/api/dashboards/db \
+          -d @/srv/salt/ceph/monitoring/grafana/files/ceph-rgw-users.json

--- a/srv/salt/ceph/monitoring/prometheus/exporters/ceph_rgw_exporter.sls
+++ b/srv/salt/ceph/monitoring/prometheus/exporters/ceph_rgw_exporter.sls
@@ -1,0 +1,47 @@
+{% if 'rgw' in salt['pillar.get']('roles') %}
+install_packages:
+  pkg.installed:
+    - name: python-pip
+
+install_pip_packages:
+  pip.installed:
+    - name: prometheus-client
+    - require:
+      - pkg: python-pip
+
+install_rgw_exporter:
+  file.managed:
+    - name: /var/lib/prometheus/node-exporter/ceph_rgw.py
+    - user: prometheus
+    - group: prometheus
+    - mode: 755
+    - source: salt://ceph/monitoring/prometheus/exporters/files/ceph_rgw.py
+    - makedirs: True
+
+create_rgw_exporter_service_unit:
+  file.managed:
+    - name: /usr/lib/systemd/system/prometheus-ceph_rgw_exporter.service
+    - mode: 644
+    - contents: |
+        [Unit]
+        Description=Prometheus exporter for Ceph Object Gateway metrics
+
+        [Service]
+        Restart=always
+        ExecStart=/var/lib/prometheus/node-exporter/ceph_rgw.py
+        ExecReload=/bin/kill -HUP $MAINPID
+        TimeoutStopSec=20s
+        SendSIGKILL=no
+
+        [Install]
+        WantedBy=multi-user.target
+
+start_rgw_exporter_service:
+  module.run:
+    - name: service.systemctl_reload
+    - onchanges:
+      - file: create_rgw_exporter_service_unit
+  service.running:
+    - name: prometheus-ceph_rgw_exporter
+    - enable: True
+{% endif %}

--- a/srv/salt/ceph/monitoring/prometheus/exporters/ceph_rgw_exporter.sls
+++ b/srv/salt/ceph/monitoring/prometheus/exporters/ceph_rgw_exporter.sls
@@ -1,13 +1,7 @@
 {% if 'rgw' in salt['pillar.get']('roles') %}
-install_packages:
+install_package:
   pkg.installed:
-    - name: python-pip
-
-install_pip_packages:
-  pip.installed:
-    - name: prometheus-client
-    - require:
-      - pkg: python-pip
+    - name: python-prometheus-client
 
 install_rgw_exporter:
   file.managed:

--- a/srv/salt/ceph/monitoring/prometheus/exporters/files/ceph_rgw.py
+++ b/srv/salt/ceph/monitoring/prometheus/exporters/files/ceph_rgw.py
@@ -1,0 +1,102 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+import argparse
+import json
+import prometheus_client
+import socket
+import subprocess
+import sys
+import syslog
+import time
+
+class CephRgwCollector(object):
+    def _request_data(self):
+        try:
+            out = subprocess.check_output(['radosgw-admin', 'usage', 'show',
+                '--show-log-sum=false'])
+            return json.loads(out.decode())
+        except Exception as e:
+            syslog.syslog(syslog.LOG_ERR, str(e))
+            return {}
+
+    def _init_metrics(self):
+        self._metrics = {
+            'ops': prometheus_client.core.CounterMetricFamily(
+                'ceph_rgw_user_usage_ops_total',
+                'Number of operations',
+                labels=["bucket", "owner", "category"]),
+            'successful_ops': prometheus_client.core.CounterMetricFamily(
+                'ceph_rgw_user_usage_successful_ops_total',
+                'Number of successful operations',
+                labels=["bucket", "owner", "category"]),
+            'bytes_sent': prometheus_client.core.CounterMetricFamily(
+                'ceph_rgw_user_usage_sent_bytes_total',
+                'Number of bytes sent by the RADOS Gateway',
+                labels=["bucket", "owner", "category"]),
+            'bytes_received': prometheus_client.core.CounterMetricFamily(
+                'ceph_rgw_user_usage_received_bytes_total',
+                'Number of bytes received by the RADOS Gateway',
+                labels=["bucket", "owner", "category"])
+        }
+
+    def _add_metrics(self, bucket_name, bucket_owner, category):
+        self._metrics['ops'].add_metric([
+            bucket_name, bucket_owner,
+            category['category']], category['ops'])
+        self._metrics['successful_ops'].add_metric([
+            bucket_name, bucket_owner,
+            category['category']], category['successful_ops'])
+        self._metrics['bytes_sent'].add_metric([
+            bucket_name, bucket_owner,
+            category['category']], category['bytes_sent'])
+        self._metrics['bytes_received'].add_metric([
+            bucket_name, bucket_owner,
+            category['category']], category['bytes_received'])
+
+    def collect(self):
+        data = self._request_data()
+        self._init_metrics()
+        if 'entries' in data:
+            for entry in data['entries']:
+                for bucket in entry['buckets']:
+                    for category in bucket['categories']:
+                        self._add_metrics(
+                            bucket['bucket'],
+                            bucket['owner'],
+                            category)
+        for metric in self._metrics.values():
+            yield metric
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '-p', '--port',
+        metavar='port',
+        required=False,
+        type=int,
+        help='Listen locally to this port',
+        default=9156)
+    return parser.parse_args()
+
+def main():
+    try:
+        args = parse_args()
+        # Register collector and start HTTP server.
+        prometheus_client.REGISTRY.register(CephRgwCollector())
+        prometheus_client.start_http_server(args.port)
+        # Print message to STDOUT and syslog.
+        message = 'Listening on http://{}:{}\n'.format(socket.getfqdn(),
+            args.port)
+        sys.stdout.write(message)
+        syslog.syslog(syslog.LOG_INFO, message)
+        while True:
+            time.sleep(1)
+    except KeyboardInterrupt:
+        exit(0)
+    except Exception as e:
+        syslog.syslog(syslog.LOG_ERR, str(e))
+        exit(1)
+
+if __name__ == "__main__":
+    main()

--- a/srv/salt/ceph/monitoring/prometheus/files/prometheus.yml.j2
+++ b/srv/salt/ceph/monitoring/prometheus/files/prometheus.yml.j2
@@ -12,10 +12,16 @@ global:
 scrape_configs:
   # The job name is added as a label `job=<job_name>` to any timeseries scraped from this config.
   - job_name: 'ceph-exporter'
-
     static_configs:
       - targets: ['{{ salt['pillar.get']('master_minion') }}:9128']
 
   - job_name: 'node-exporter'
     file_sd_configs:
       - files: [ '/etc/prometheus/ses_nodes/*.yml' ]
+
+  - job_name: 'ceph-rgw-exporter'
+    static_configs:
+      - targets:
+        {% for fqdn in salt.saltutil.runner('select.minions', cluster='ceph', roles='rgw') -%}
+        - '{{ fqdn }}:9156'
+        {% endfor -%}

--- a/srv/salt/ceph/monitoring/prometheus/init.sls
+++ b/srv/salt/ceph/monitoring/prometheus/init.sls
@@ -3,8 +3,7 @@ golang-github-prometheus-prometheus:
     - fire_event: True
 
 /etc/prometheus/prometheus.yml:
-  file:
-    - managed
+  file.managed:
     - source: salt://ceph/monitoring/prometheus/files/prometheus.yml.j2
     - template: jinja
     - user: root
@@ -17,3 +16,6 @@ start prometheus:
   service.running:
     - name: prometheus
     - enable: True
+    - restart: True
+    - watch:
+      - file: /etc/prometheus/prometheus.yml

--- a/srv/salt/ceph/rescind/rgw/default.sls
+++ b/srv/salt/ceph/rescind/rgw/default.sls
@@ -17,4 +17,5 @@ uninstall ceph-radosgw:
 
 include:
 - .keyring
+- .monitoring
 {% endif %}

--- a/srv/salt/ceph/rescind/rgw/monitoring/default.sls
+++ b/srv/salt/ceph/rescind/rgw/monitoring/default.sls
@@ -1,0 +1,22 @@
+
+stop_rgw_exporter_service:
+  service.dead:
+    - name: prometheus-ceph_rgw_exporter
+    - enable: False
+
+remove_rgw_exporter_service_unit:
+  file.absent:
+   - name: /usr/lib/systemd/system/prometheus-ceph_rgw_exporter.service
+
+remove_rgw_exporter:
+  file.absent:
+    - name: /var/lib/prometheus/node-exporter/ceph_rgw.py
+
+uninstall_pip_packages:
+  pip.removed:
+    - name: prometheus-client
+    - onlyif: "test -f /usr/bin/pip"
+
+uninstall_packages:
+  pkg.removed:
+    - name: python-pip

--- a/srv/salt/ceph/rescind/rgw/monitoring/default.sls
+++ b/srv/salt/ceph/rescind/rgw/monitoring/default.sls
@@ -12,11 +12,8 @@ remove_rgw_exporter:
   file.absent:
     - name: /var/lib/prometheus/node-exporter/ceph_rgw.py
 
-uninstall_pip_packages:
-  pip.removed:
-    - name: prometheus-client
-    - onlyif: "test -f /usr/bin/pip"
-
-uninstall_packages:
+{% if 'python-prometheus-client' in salt['pkg.list_pkgs']() %}
+uninstall_package:
   pkg.removed:
-    - name: python-pip
+    - name: python-prometheus-client
+{% endif %}

--- a/srv/salt/ceph/rescind/rgw/monitoring/init.sls
+++ b/srv/salt/ceph/rescind/rgw/monitoring/init.sls
@@ -1,0 +1,4 @@
+
+
+include:
+  - .{{ salt['pillar.get']('rescind_rgw_monitoring', 'default') }}

--- a/srv/salt/ceph/stage/deploy/default.sls
+++ b/srv/salt/ceph/stage/deploy/default.sls
@@ -93,6 +93,12 @@ setup ceph exporter:
     - tgt_type: compound
     - sls: ceph.monitoring.prometheus.exporters.ceph_exporter
 
+setup ceph rgw exporter:
+  salt.state:
+    - tgt: 'I@roles:rgw and I@cluster:ceph'
+    - tgt_type: compound
+    - sls: ceph.monitoring.prometheus.exporters.ceph_rgw_exporter
+
 setup rbd exporter:
   salt.state:
     - tgt: {{ salt['pillar.get']('master_minion') }}


### PR DESCRIPTION
* Implement a Prometheus exporter for RGW statistics. The exporter is running on port 9156 by default. Additional RGW stats can be retrieved by this exporter in future, e.g. bucket stats.
* Add systemd service unit to manage Prometheus Ceph RGW exporter. The command 'systemctl daemon-reload' is executed via service.systemctl_reload after the service unit has been installed.
* Add Grafana 'Ceph - Object Gateway users' dashboard
* The Prometheus exporter is based on Python. The required Python package prometheus_client is installed via [python-prometheus-client](https://build.suse.de/package/show/SUSE:SLE-12-SP3:Update:Products:SES5/python-prometheus-client).
* The systemd unit and Prometheus exporter will be deinstaller on the minions when the RGW role is removed.
* Restart prometheus if /etc/prometheus/prometheus.yml has been changed

Open issues:
* Should we always install the Grafana 'Ceph - Object Gateway users' dashboard, or only if there is at least one RGW role?

This PR is related to https://tracker.openattic.org/browse/OP-2214.

Signed-off-by: Volker Theile <vtheile@suse.com>