### PR TITLE
openattic module implementation for configuring oA

### DIFF
--- a/srv/salt/_modules/openattic.py
+++ b/srv/salt/_modules/openattic.py
@@ -1,0 +1,86 @@
+# -*- coding: utf-8 -*-
+import configobj
+import os
+import salt.utils
+
+from salt.exceptions import CommandExecutionError
+
+
+def _write_config_file(config_file, config):
+    conf_content = ""
+    write_log = set()
+    with salt.utils.fopen(config_file, "r") as fir:
+        for line in fir:
+            sline = line.strip()
+            idx = sline.find('=')
+            if idx != -1 and not sline.startswith('#'):
+                key = sline[:idx].strip()
+                if key in config:
+                    if isinstance(config[key], int):
+                        val_str = "{}".format(config[key])
+                    else:
+                        val_str = '"{}"'.format(config[key])
+                    conf_content += '{}={}\n'.format(key, val_str)
+                    write_log.add(key)
+                    continue
+
+            conf_content += line
+
+    for key, val in config.items():
+        if key not in write_log:
+            if isinstance(val, int):
+                val_str = "{}".format(val)
+            else:
+                val_str = '"{}"'.format(val)
+            conf_content += '{}={}\n'.format(key, val_str)
+
+    try:
+        with salt.utils.fopen(config_file, "w") as fiw:
+            fiw.write(conf_content)
+    except IOError as ex:
+        if ex.errno == 13:
+            raise CommandExecutionError("Permission denied while writting settings to {}.\n"
+                                        "Please check file permissions for user \"openattic\""
+                                        .format(config_file))
+        else:
+            raise CommandExecutionError("Error while writting settings to {}: IOError errno={}"
+                                        .format(config_file, ex.errno))
+
+
+def _select_config_file_path():
+    possible_paths = ("/etc/sysconfig/openattic", "/etc/openattic")
+    for path in possible_paths:
+        if os.access(path, os.F_OK) and os.access(path, os.R_OK | os.W_OK):
+            return path
+    raise CommandExecutionError(
+        "No openATTIC config file found in the following locations: {}"
+        .format(possible_paths))
+
+
+def configure_salt_api(hostname, port, username, sharedsecret):
+    config_file = _select_config_file_path()
+
+    config = configobj.ConfigObj(config_file)
+    if 'SALT_API_HOST' not in config:
+        config['SALT_API_HOST'] = hostname
+    if 'SALT_API_PORT' not in config:
+        config['SALT_API_PORT'] = int(port)
+
+    if 'SALT_API_EAUTH' not in config or config['SALT_API_EAUTH'] == 'auto':
+        config['SALT_API_EAUTH'] = 'sharedsecret'
+
+    config['SALT_API_USERNAME'] = username
+    config['SALT_API_SHARED_SECRET'] = sharedsecret
+
+    _write_config_file(config_file, config)
+
+
+def configure_grafana(hostname):
+    config_file = _select_config_file_path()
+
+    config = configobj.ConfigObj(config_file)
+    if 'GRAFANA_API_HOST' not in config:
+        config['GRAFANA_API_HOST'] = hostname
+
+    _write_config_file(config_file, config)
+

--- a/srv/salt/ceph/openattic/default.sls
+++ b/srv/salt/ceph/openattic/default.sls
@@ -5,17 +5,22 @@ install openattic:
     - pkgs:
       - openattic
 
+configure salt-api:
+  module.run:
+    - name: openattic.configure_salt_api
+    - kwargs:
+      hostname: "{{ salt['pillar.get']('master_minion') }}"
+      port: 8000
+      username: "admin"
+      sharedsecret: "{{ salt['pillar.get']('salt_api_shared_secret') }}"
+
+configure grafana:
+  module.run:
+    - name: openattic.configure_grafana
+    - kwargs:
+      hostname: "{{ salt['pillar.get']('master_minion') }}"
+
 enable openattic-systemd:
   service.running:
     - name: openattic-systemd
     - enable: True
-
-/etc/sysconfig/openattic:
-  file.append:
-    - text: |
-        SALT_API_HOST="{{ salt['pillar.get']('master_minion') }}"
-        SALT_API_PORT=8000
-        SALT_API_EAUTH="sharedsecret"
-        SALT_API_USERNAME="admin"
-        SALT_API_SHARED_SECRET="{{ salt['pillar.get']('salt_api_shared_secret') }}"
-        GRAFANA_API_HOST="{{ salt['pillar.get']('master_minion') }}"

--- a/tests/unit/_modules/test_openattic.py
+++ b/tests/unit/_modules/test_openattic.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+import configobj
+
+from pyfakefs import fake_filesystem_unittest
+from mock import MagicMock, patch, mock
+
+from srv.salt._modules import openattic
+from salt.exceptions import CommandExecutionError
+
+
+class TestOpenatticModule(fake_filesystem_unittest.TestCase):
+    def setUp(self):
+        self.setUpPyfakefs()
+
+    def test_configure_salt_api(self):
+        config_file = "/etc/sysconfig/openattic"
+        self.fs.CreateFile(config_file, contents="")
+        openattic.configure_salt_api("salt.localhost", 9000, "admin", "mysharedsecret")
+        config = configobj.ConfigObj(config_file)
+        self.assertEqual(config['SALT_API_HOST'], "salt.localhost")
+        self.assertEqual(config['SALT_API_PORT'], "9000")
+        self.assertEqual(config['SALT_API_USERNAME'], "admin")
+        self.assertEqual(config['SALT_API_EAUTH'], "sharedsecret")
+        self.assertEqual(config['SALT_API_SHARED_SECRET'], "mysharedsecret")
+        self.fs.RemoveFile(config_file)
+
+    def test_configure_grafana(self):
+        config_file = "/etc/sysconfig/openattic"
+        self.fs.CreateFile(config_file, contents="")
+        openattic.configure_grafana("grafana.localhost")
+        config = configobj.ConfigObj(config_file)
+        self.assertEqual(config['GRAFANA_API_HOST'], "grafana.localhost")
+        self.fs.RemoveFile(config_file)
+
+    def test_no_config_file(self):
+        config_file = "/etc/sysconfig/openattic"
+        with self.assertRaises(CommandExecutionError) as ctx:
+            openattic.configure_grafana("grafana.localhost")
+        self.assertEqual(str(ctx.exception),
+                         "No openATTIC config file found in the following locations: "
+                         "('/etc/sysconfig/openattic', '/etc/openattic')")
+
+    def test_salt_api_upgrade(self):
+        config_file = "/etc/sysconfig/openattic"
+        self.fs.CreateFile(config_file,
+                           contents="SALT_API_HOST=mysalt.localhost\n"
+                                    "SALT_API_PORT=8000\n"
+                                    "SALT_API_EAUTH=auto\n"
+                                    "SALT_API_USERNAME=myuser\n"
+                                    "SALT_API_PASSWORD=mypassword\n")
+        openattic.configure_salt_api("salt.localhost", 9000, "admin", "mysharedsecret")
+        config = configobj.ConfigObj(config_file)
+        self.assertEqual(config['SALT_API_HOST'], "mysalt.localhost")
+        self.assertEqual(config['SALT_API_PORT'], "8000")
+        self.assertEqual(config['SALT_API_USERNAME'], "admin")
+        self.assertEqual(config['SALT_API_EAUTH'], "sharedsecret")
+        self.assertEqual(config['SALT_API_SHARED_SECRET'], "mysharedsecret")
+        self.fs.RemoveFile(config_file)

--- a/tox.ini
+++ b/tox.ini
@@ -12,13 +12,14 @@ deps =
     salt
 
 [testenv:py27]
-commands =  py.test --tb=line -v --junitxml=junit-{envname}.xml
+commands =  py.test --tb=line -v --junitxml=junit-{envname}.xml {posargs}
 deps =
     {[base]deps}
     mock
     pyfakefs
     pytest
     salttesting
+    configobj
 
 [testenv:lint]
 commands = pylint --rcfile=.pylintrc --jobs=5 srv/ etc/


### PR DESCRIPTION
This PR implements an openattic salt module to make it easy for DeepSea to configure the salt-api and grafana settings in the openATTIC configuration file.

Signed-off-by: Ricardo Dias <rdias@suse.com>