### PR TITLE
Move check to conditionals, change variable name

### DIFF
--- a/srv/modules/runners/minions.py
+++ b/srv/modules/runners/minions.py
@@ -20,7 +20,7 @@ def ready(**kwargs):
                  'timeout': None,
                  'search': None,
                  'sleep': 6,
-                 'hardfail': True
+                 'exception': False
                }
     settings.update(kwargs)
 
@@ -64,7 +64,7 @@ def ready(**kwargs):
         if end_time:
             if end_time < time.time():
                 log.warn("Timeout reached")
-                if settings['hardfail']:
+                if settings['exception']:
                     raise RuntimeError("Timeout reached. {} seems to be down.".format(",".join(list(expected - actual))))
                 return False
         time.sleep(settings['sleep'])

--- a/srv/salt/ceph/maintenance/upgrade/master/default.sls
+++ b/srv/salt/ceph/maintenance/upgrade/master/default.sls
@@ -1,10 +1,5 @@
-{% if salt['saltutil.runner']('upgrade.check') and salt['saltutil.runner']('validate.setup') != False %}
-
-pre master readycheck:
-  salt.runner:
-    - name: minions.ready
-    - timeout: {{ salt['pillar.get']('ready_timeout', 300) }}
-    - hardfail: True
+{% set timeout=salt['pillar.get']('minions_ready_timeout', 30) %}
+{% if salt.saltutil.runner('minions.ready', timeout=timeout) and salt['saltutil.runner']('upgrade.check') and salt['saltutil.runner']('validate.setup') %}
 
 {% set notice = salt['saltutil.runner']('advise.salt_upgrade') %}
   

--- a/srv/salt/ceph/maintenance/upgrade/minion/default.sls
+++ b/srv/salt/ceph/maintenance/upgrade/minion/default.sls
@@ -1,8 +1,5 @@
-pre minion readycheck:
-  salt.runner:
-    - name: minions.ready
-    - timeout: {{ salt['pillar.get']('ready_timeout', 300) }}
-    - hardfail: True
+{% set timeout=salt['pillar.get']('minions_ready_timeout', 30) %}
+{% if salt.saltutil.runner('minions.ready', timeout=timeout) %}
 
 update salt:
   salt.state:
@@ -42,6 +39,7 @@ readycheck before processing {{ host }}:
     - name: minions.ready
     - timeout: {{ salt['pillar.get']('ready_timeout', 300) }}
     - hardfail: True
+    - exception: True
 
 upgrading mon on {{ host }}:
   salt.runner:
@@ -89,6 +87,7 @@ readycheck for {{ host }} after processing mons :
     - name: minions.ready
     - timeout: {{ salt['pillar.get']('ready_timeout', 300) }}
     - hardfail: True
+    - exception: True
 
 upgrading {{ host }}:
   salt.runner:
@@ -171,3 +170,10 @@ restart:
     - sls: ceph.updates.restart
 
 {% endif %}
+
+{% else %}
+
+minions not ready:
+  test.nop
+{% endif %}
+


### PR DESCRIPTION
Moving the initial minions.ready to the beginning of the conditional check in the master file allows that step to fail faster.  Otherwise, the other runners must timeout on any minion but succeed and then finally fail on the minions.ready runner.

Salt uses failhard which is not passed from orchestrate to the runner.  The runner must raise an exception to cause the loop to fail in the minions/default.sls.  Jinja does not do dynamic evaluation which is why a conditional is not used.  Orchestrate does not honor return values from other runners.  Avoid using hardfail to prevent confusion.

Be more explicit about the timeout variable by prefixing the full runner name.

Signed-off-by: Eric Jackson <ejackson@suse.com>