### PR TITLE
igw: do not fail Stage 4 if command not recognized

### DIFF
--- a/srv/salt/ceph/igw/config/default.sls
+++ b/srv/salt/ceph/igw/config/default.sls
@@ -12,7 +12,7 @@ demo pool:
 
 demo pool enable application:
   cmd.run:
-    - name: "ceph osd pool application enable iscsi-images rbd"
+    - name: "ceph osd pool application enable iscsi-images rbd || :"
     - fire_event: True
 
 demo image:

--- a/srv/salt/ceph/mds/pools/default.sls
+++ b/srv/salt/ceph/mds/pools/default.sls
@@ -14,12 +14,20 @@ cephfs data:
       - "rados lspools | grep -q cephfs_data"
       - "ceph fs ls | grep -q ^name"
 
+cephfs data pool enable application:
+  cmd.run:
+    - name: "ceph osd pool application enable cephfs cephfs_data || :"
+
 cephfs metadata:
   cmd.run:
     - name: "ceph osd pool create cephfs_metadata 128"
     - unless:
       - "rados lspools | grep -q cephfs_metadata"
       - "ceph fs ls | grep -q ^name"
+
+cephfs metadata pool enable application:
+  cmd.run:
+    - name: "ceph osd pool application enable cephfs cephfs_metadata || :"
 
 cephfs:
   cmd.run:


### PR DESCRIPTION
"ceph osd pool application enable" is a very new command, added quite late
in the luminous development cycle.

There are two basic scenarios in which this command might get run:

1. installation of recent luminous cluster - command should simply succeed
2. upgrade of an older cluster to luminous - command might not be recognized

Each of these has two subscenarios:

a. iscsi-image pool exists
b. iscsi-image pool does not exist (unlikely, but theoretically possible)

Provided the command is recognized, "ceph osd pool application enable" is of
course idempotent. The problem arises when the command is not recognized by the
MON we are talking to. In that case, Stage 4 currently fails, which is not a
satisfactory outcome for such a trivial error.

By using "onlyif", we try to handle all these scenarios, but it might happen
(during a cluster upgrade) that this command runs before the command is
recognized. In that case, Stage 4 will complete without error, but the cluster
might end up that the iscsi-images pool does not get assigned to an
application. This should be taken care of in the upgrade code.

Fixes: #504