### PR TITLE
wip: rgw: add examples for deploying rgw with ssl

### DIFF
--- a/srv/pillar/ceph/rgw-ssl.sls.example
+++ b/srv/pillar/ceph/rgw-ssl.sls.example
@@ -1,0 +1,9 @@
+rgw_configurations:
+  rgw:
+    users:
+      - { uid: "admin", name: "Admin", email: "admin@demo.nil", system: True }
+  # when using only RGW& not ganesha ssl will have all the users of rgw already,
+  # but to be consistent we define atleast one user
+  rgw-ssl:
+    users:
+      - { uid: "admin", name: "Admin", email: "admin@demo.nil", system: True }

--- a/srv/salt/ceph/configuration/files/ceph.conf.rgw-ssl
+++ b/srv/salt/ceph/configuration/files/ceph.conf.rgw-ssl
@@ -1,0 +1,3 @@
+[ client.{{ client }} ]
+rgw frontends = "civetweb port=443s ssl_certificate=/etc/ceph/rgw.pem"
+rgw dns name = {{ grains['fqdn'] }}

--- a/srv/salt/ceph/rgw/cert/default.sls
+++ b/srv/salt/ceph/rgw/cert/default.sls
@@ -1,0 +1,5 @@
+# Create a cert in pem format and copy this to /srv/salt/ceph/rgw/cert/rgw.pem
+deploy the rgw.pem file:
+  file.managed:
+    - name: /etc/ceph/rgw.pem
+    - source: salt://ceph/rgw/cert/rgw.pem

--- a/srv/salt/ceph/rgw/cert/init.sls
+++ b/srv/salt/ceph/rgw/cert/init.sls
@@ -1,0 +1,4 @@
+
+
+include:
+  - .{{ salt['pillar.get']('rgw_cert', 'default') }}

--- a/srv/salt/ceph/rgw/default-ssl.sls
+++ b/srv/salt/ceph/rgw/default-ssl.sls
@@ -1,0 +1,22 @@
+
+# change the init.sls to default-ssl  to use this file
+include:
+  - .keyring
+  - .cert
+
+install rgw:
+  pkg.installed:
+    - name: ceph-radosgw
+
+{% for role in salt['pillar.get']('rgw_configurations', [ 'rgw' ]) %}
+start {{ role }}:
+  service.running:
+    - name: ceph-radosgw@{{ role + "." + grains['host'] }}
+    - enable: True
+
+restart {{ role }}:
+  module.run:
+    - name: service.restart
+    - m_name: ceph-radosgw@{{ role + "." + grains['host'] }}
+
+{% endfor %}

--- a/srv/salt/ceph/rgw/files/rgw-ssl.j2
+++ b/srv/salt/ceph/rgw/files/rgw-ssl.j2
@@ -1,0 +1,5 @@
+[{{ client }}]
+        key = {{ secret }}
+        caps mon = "allow rwx"
+        caps osd = "allow rwx"
+        caps mgr = "allow r"


### PR DESCRIPTION
use rgw_configurations to create a role rgw-ssl alongside rgw, and have
an easier helper function that would copy certificates in pem format in
salt://ceph/rgw/cert/rgw.pem to the rgw nodes

Signed-off-by: Abhishek Lekshmanan <abhishek@suse.com>