### PR TITLE
Add PyCharm project files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,5 +97,8 @@ ENV/
 # VS Code project files
 .vscode
 
+# PyCharm project files
+.idea
+
 # tox output
 junit*.xml


### PR DESCRIPTION
This PR adds the PyCharm project files to .gitignore

Signed-off-by: Ricardo Marques <rimarques@suse.com>