### PR TITLE
Giving up on salt state, calling systemctl directly

### DIFF
--- a/srv/salt/ceph/rescind/rgw/default.sls
+++ b/srv/salt/ceph/rescind/rgw/default.sls
@@ -4,10 +4,10 @@ rgw nop:
 
 {% if 'master' not in salt['pillar.get']('roles') and
       'rgw' not in salt['pillar.get']('roles') %}
+
 stop ceph-radosgw:
-  service.dead:
-    - name: ceph-radosgw@rgw.*
-    - enable: False
+  cmd.run:
+    - name: 'systemctl stop ceph-radosgw@rgw*'
     - onlyif: "test -f /usr/bin/radosgw"
 
 # Need conditional check if all rgw configurations are unassigned


### PR DESCRIPTION
I suspect the problem has to do with the globbing of the service name and that Salt is transforming the string along the way.  Settling for what works.

Signed-off-by: Eric Jackson <ejackson@suse.com>