### PR TITLE
ceph_tgt support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -525,6 +525,8 @@ copy-files:
 install: copy-files
 	sed -i '/^sharedsecret: /s!{{ shared_secret }}!'`cat /proc/sys/kernel/random/uuid`'!' $(DESTDIR)/etc/salt/master.d/sharedsecret.conf
 	chown salt:salt $(DESTDIR)/etc/salt/master.d/*
+	sed -i '/^master_minion:/s!_REPLACE_ME_!'`hostname -f`'!' /srv/pillar/ceph/master_minion.sls
+	echo "ceph_tgt: '*'" > /srv/pillar/ceph/ceph_tgt.sls
 	chown -R salt /srv/pillar/ceph
 	systemctl restart salt-master
 	sed -i '/^master_minion:/s!_REPLACE_ME_!'`cat /etc/salt/minion_id`'!' /srv/pillar/ceph/master_minion.sls

--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,7 @@ copy-files:
 	install -m 644 srv/pillar/ceph/benchmarks/templates/*.j2 $(DESTDIR)/srv/pillar/ceph/benchmarks/templates/
 	install -m 644 srv/pillar/ceph/init.sls $(DESTDIR)/srv/pillar/ceph/
 	install -m 644 srv/pillar/ceph/master_minion.sls $(DESTDIR)/srv/pillar/ceph/
+	install -m 644 srv/pillar/ceph/ceph_tgt.sls $(DESTDIR)/srv/pillar/ceph/
 	install -d -m 755 $(DESTDIR)/srv/pillar/ceph/stack
 	install -m 644 srv/pillar/ceph/stack/stack.cfg $(DESTDIR)/srv/pillar/ceph/stack/stack.cfg
 	install -m 644 srv/pillar/top.sls $(DESTDIR)/srv/pillar/

--- a/deepsea.spec
+++ b/deepsea.spec
@@ -304,6 +304,7 @@ systemctl try-restart salt-api > /dev/null 2>&1 || :
 %config %attr(-, salt, salt) /srv/pillar/ceph/benchmarks/fio/*.yml
 %config %attr(-, salt, salt) /srv/pillar/ceph/benchmarks/templates/*.j2
 %config(noreplace) %attr(-, salt, salt) /srv/pillar/ceph/master_minion.sls
+%config(noreplace) %attr(-, salt, salt) /srv/pillar/ceph/ceph_tgt.sls
 %config %attr(-, salt, salt) /srv/pillar/ceph/stack/stack.cfg
 %config /srv/salt/_modules/*.py*
 %config /srv/salt/ceph/admin/*.sls

--- a/deepsea.spec
+++ b/deepsea.spec
@@ -294,6 +294,7 @@ systemctl try-restart salt-api > /dev/null 2>&1 || :
 %dir /srv/salt/ceph/warning/noout
 %dir /srv/salt/ceph/processes
 %{_mandir}/man7/deepsea.commands.7.gz
+%{_mandir}/man7/deepsea.ceph_tgt.7.gz
 %config(noreplace) %attr(-, salt, salt) /etc/salt/master.d/*.conf
 %config /srv/modules/runners/*.py*
 %config %attr(-, salt, salt) /srv/pillar/top.sls

--- a/man/deepsea.ceph_tgt.7
+++ b/man/deepsea.ceph_tgt.7
@@ -1,0 +1,56 @@
+.TH deepsea 7
+.SH NAME
+deepsea ceph_tgt
+.SH DESCRIPTION
+For compatibility with other Salt solutions,
+.B DeepSea
+uses
+.I ceph_tgt,
+which constrains the targeting of Salt minions.
+By default DeepSea targets by grain using 'G@deepsea'. For more information on salt targeting see https://docs.saltstack.com/en/latest/topics/targeting/
+.SH METHODS
+Either reconfigure 
+.I ceph_tgt
+to use any valid Salt target or apply grains to the desired minions.  For example, 
+.PP
+.RS 4
+ceph_tgt: '*'
+.RE
+.PP
+will target all Salt minions.  Likewise,
+.PP
+.RS 4
+ceph_tgt: 'ses*'
+.RE
+.PP
+will only target minions that begin with 
+.B ses.
+.PP
+Alternatively, apply a grain to each minion and use the default ceph_tgt of
+.B G@deepsea:*.
+For example,
+.PP
+.RS 4
+salt -L node1.domain,node2.domain grains.append deepsea default
+salt -S 10.0.0.0/24 grains.append deepsea default
+.RE
+.PP
+will target the minions node1.domain and node2.domain in addition to all minions in the subnet 10.0.0.0/24.  Grain selection works well in environments where Salt is installed on minions that follow no simple pattern.
+.PP
+To remove a grain completely from a minion, run
+.PP
+.RS 4
+salt 'xyz.domain' grains.delval deepsea destructive=True
+.RE
+.PP
+For more information on Salt grains see https://docs.saltstack.com/en/latest/topics/grains/
+
+.SH FILES
+The file for 
+.I ceph_tgt
+is /srv/pillar/ceph/ceph_tgt.sls.
+.SH AUTHORS
+Eric Jackson <ejackson@suse.com>
+.RS
+.RE
+Jan Fajerski <jfajerski@suse.com>

--- a/srv/modules/runners/ceph_tgt.py
+++ b/srv/modules/runners/ceph_tgt.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+
+import salt.client
+import sys
+import os
+import logging
+
+log = logging.getLogger(__name__)
+
+class CephTgt(object):
+    """
+    """
+
+    def __init__(self, **kwargs):
+        """
+        """
+        self.local = salt.client.LocalClient()
+        self.ceph_tgt = self._query()
+        self.matches = self._matches()
+       
+
+    def _query(self):
+        """
+        """
+        # When search matches no minions, salt prints to stdout.  
+        # Suppress stdout.
+        _stdout = sys.stdout
+        sys.stdout = open(os.devnull, 'w')
+
+        ret = self.local.cmd('*' , 'saltutil.pillar_refresh')
+        minions = self.local.cmd('*' , 'pillar.get', [ 'ceph_tgt' ], 
+                            expr_form="compound")
+        sys.stdout = _stdout
+        for minion in minions:
+            if minions[minion]:
+                return minions[minion]
+           
+        
+        log.error("ceph_tgt is not set")
+        return []
+
+    def _matches(self):
+        """
+        """
+        if self.ceph_tgt:
+            # When search matches no minions, salt prints to stdout.  
+            # Suppress stdout.
+            _stdout = sys.stdout
+            sys.stdout = open(os.devnull, 'w')
+            matches = self.local.cmd(self.ceph_tgt , 'pillar.get', [ 'id' ], 
+                                expr_form="compound")
+            sys.stdout = _stdout
+            return matches.keys()
+        return []
+
+def show(**kwargs):
+    """
+    """
+    target = CephTgt()
+    return target.ceph_tgt
+
+def matches(**kwargs):
+    target = CephTgt()
+    return target.matches

--- a/srv/modules/runners/configure.py
+++ b/srv/modules/runners/configure.py
@@ -5,6 +5,7 @@ import ipaddress
 import pprint
 import yaml
 import os
+import ceph_tgt
 from os.path import dirname
 
 
@@ -71,7 +72,10 @@ class ClusterAssignment(object):
         """
         Query the cluster assignment and remove unassigned
         """
-        self.minions = local.cmd('*' , 'pillar.get', [ 'cluster' ])
+        target = ceph_tgt.CephTgt()
+        search = target.ceph_tgt
+
+        self.minions = local.cmd(search , 'pillar.get', [ 'cluster' ])
 
         self.names = dict(self._clusters())
         if 'unassigned' in self.names:

--- a/srv/modules/runners/configure.py
+++ b/srv/modules/runners/configure.py
@@ -75,7 +75,7 @@ class ClusterAssignment(object):
         target = ceph_tgt.CephTgt()
         search = target.ceph_tgt
 
-        self.minions = local.cmd(search , 'pillar.get', [ 'cluster' ])
+        self.minions = local.cmd(search , 'pillar.get', [ 'cluster' ], expr_form="compound")
 
         self.names = dict(self._clusters())
         if 'unassigned' in self.names:

--- a/srv/modules/runners/net.py
+++ b/srv/modules/runners/net.py
@@ -3,6 +3,7 @@
 import logging
 import re
 import salt.client
+import ceph_tgt
 
 from netaddr import IPNetwork, IPAddress
 
@@ -82,7 +83,9 @@ def ping(cluster = None, exclude = None, **kwargs):
             if 'public_network' in networks[host]:
                 addresses.extend(_address(total[host], networks[host]['public_network']))
     else:
-        search = "*"
+        target = ceph_tgt.CephTgt()
+        search = target.ceph_tgt
+
         if exclude_string:
             search += " and not ( " + exclude_string + " )"
             log.debug( "ping: search {} ".format(search))

--- a/srv/modules/runners/populate.py
+++ b/srv/modules/runners/populate.py
@@ -489,7 +489,7 @@ class CephRoles(object):
 
         local = salt.client.LocalClient()
 
-        _rgws = local.cmd(self.search , 'pillar.get', [ 'rgw_configurations' ])
+        _rgws = local.cmd(self.search , 'pillar.get', [ 'rgw_configurations' ], expr_form="compound")
         for node in _rgws.keys():
             # Check the first one
             if _rgws[node]:
@@ -504,7 +504,7 @@ class CephRoles(object):
         """
         local = salt.client.LocalClient()
 
-        _ganeshas = local.cmd(self.search , 'pillar.get', [ 'ganesha_configurations' ])
+        _ganeshas = local.cmd(self.search , 'pillar.get', [ 'ganesha_configurations' ], expr_form="compound")
         for node in _ganeshas.keys():
             # Check the first one
             if _ganeshas[node]:
@@ -654,7 +654,7 @@ class CephRoles(object):
         networks = {}
         local = salt.client.LocalClient()
 
-        interfaces = local.cmd(self.search, 'network.interfaces')
+        interfaces = local.cmd(self.search, 'network.interfaces', [], expr_form="compound")
 
         for minion in interfaces.keys():
             for nic in interfaces[minion]:
@@ -745,9 +745,9 @@ class CephCluster(object):
         search = target.ceph_tgt
 
         local = salt.client.LocalClient()
-        self.minions = local.cmd(search , 'grains.get', [ 'id' ])
+        self.minions = local.cmd(search , 'grains.get', [ 'id' ], expr_form="compound")
 
-        _rgws = local.cmd(search , 'pillar.get', [ 'rgw_configurations' ])
+        _rgws = local.cmd(search , 'pillar.get', [ 'rgw_configurations' ], expr_form="compound")
         for node in _rgws.keys():
             self.rgw_configurations = _rgws[node]
             # Just need first
@@ -909,7 +909,7 @@ def _get_existing_cluster_network(addrs, public_network=None):
     minion_networks = []
 
     # Grab network interfaces from salt.
-    minion_network_interfaces = local.cmd(search, "network.interfaces")
+    minion_network_interfaces = local.cmd(search, "network.interfaces", [], expr_form="compound")
     # Remove lo.
     for entry in minion_network_interfaces:
 	try:

--- a/srv/modules/runners/proposal.py
+++ b/srv/modules/runners/proposal.py
@@ -12,6 +12,7 @@ from os.path import isdir, isfile
 import os
 from sys import exit
 import logging
+import ceph_tgt
 
 log = logging.getLogger(__name__)
 
@@ -84,6 +85,8 @@ List of recognized parameters and their defaults:
                     gibibytes (G), tebibytes (T), or pebibytes (P).
 '''
 
+target = ceph_tgt.CephTgt()
+
 std_args = {
     'leftovers': False,
     'standalone': False,
@@ -93,7 +96,7 @@ std_args = {
     'ssd-spinner': False,
     'ratio': 5,
     'db-ratio': 5,
-    'target': '*',
+    'target': target.ceph_tgt,
     'data': 0,
     'journal': 0,
     'wal': 0,
@@ -162,8 +165,11 @@ def _choose_proposal(node, proposal, args):
             return _propose(node, proposal[conf], args)
     # if no flags a present propose what is there
     for conf in confs:
-        if proposal[conf]:
-            return _propose(node, proposal[conf], args)
+        if conf in proposal:
+            if proposal[conf]:
+                return _propose(node, proposal[conf], args)
+        else:
+            log.error("Verify that targeted minions have proposal.generate")
 
 
 def help():

--- a/srv/modules/runners/validate.py
+++ b/srv/modules/runners/validate.py
@@ -742,6 +742,28 @@ class Validate(object):
             files = glob.glob(line)
         return files
 
+    def ceph_tgt(self):
+        """
+        Verify ceph_tgt if set
+        """
+        local = salt.client.LocalClient()
+        present = False
+        for node in self.data.keys():
+            if 'ceph_tgt' in self.data[node]:
+                present = True
+                data = local.cmd(self.data[node]['ceph_tgt'] , 
+                                 'test.ping', [''], expr_form="compound")
+                break
+        if present:
+            if data:
+                self.passed['ceph_tgt'] = "valid"
+            else:
+                msg = "Invalid compound match: {}".format(self.data[node]['ceph_tgt'])
+                self.errors['ceph_tgt'] = [ msg ]
+        else:
+            self.passed['ceph_tgt'] = "valid"
+
+
     def report(self):
         self.printer.add(self.name, self.passed, self.errors, self.warnings)
         self.printer.print_result()
@@ -871,6 +893,7 @@ def setup(**kwargs):
     v = Validate("setup", pillar_data, [], printer)
     v.master_minion()
     v.ceph_version()
+    v.ceph_tgt()
     v.report()
 
     if v.errors:

--- a/srv/modules/runners/validate.py
+++ b/srv/modules/runners/validate.py
@@ -10,6 +10,7 @@ import yaml
 import os
 import re
 import sys
+import ceph_tgt
 from subprocess import call, Popen, PIPE
 from os.path import dirname
 import glob
@@ -99,7 +100,9 @@ class ClusterAssignment(object):
         """
         Query the cluster assignment and remove unassigned
         """
-        self.minions = local.cmd('*' , 'pillar.get', [ 'cluster' ])
+        target = ceph_tgt.CephTgt()
+        search = target.ceph_tgt
+        self.minions = local.cmd(search , 'pillar.get', [ 'cluster' ])
 
         self.names = dict(self._clusters())
         if 'unassigned' in self.names:
@@ -155,7 +158,7 @@ class Validate(object):
         self.passed = OrderedDict()
         self.errors = OrderedDict()
         self.warnings = OrderedDict()
-        self._minion_check()
+        #self._minion_check()
 
     def __dev_env(self):
         if 'DEV_ENV' in os.environ:
@@ -619,6 +622,8 @@ class Validate(object):
         """
         Verify that the master minion setting is a minion
         """
+        data = None
+        node = None
         local = salt.client.LocalClient()
         for node in self.data.keys():
             data = local.cmd(self.data[node]['master_minion'] , 'pillar.get', [ 'master_minion' ], expr_form="glob")
@@ -626,7 +631,10 @@ class Validate(object):
         if data:
             self.passed['master_minion'] = "valid"
         else:
-            msg = "Could not find minion {}. Check /srv/pillar/ceph/master_minion.sls".format(self.data[node]['master_minion'])
+            if node:
+                msg = "Could not find minion {}. Check /srv/pillar/ceph/master_minion.sls".format(self.data[node]['master_minion'])
+            else:
+                msg = "Missing pillar data"
             self.errors['master_minion'] = [ msg ]
 
 
@@ -635,8 +643,10 @@ class Validate(object):
         Scan all minions for ceph versions in their repos.
         """
         JEWEL_VERSION="10.2"
+        target = ceph_tgt.CephTgt()
+        search = target.ceph_tgt
         local = salt.client.LocalClient()
-        contents = local.cmd('*' , 'cmd.shell', [ '/usr/bin/zypper info ceph' ], expr_form="glob")
+        contents = local.cmd(search , 'cmd.shell', [ '/usr/bin/zypper info ceph' ], expr_form="glob")
 
         for minion in contents.keys():
             m = re.search(r'Version: (\S+)', contents[minion])
@@ -742,27 +752,19 @@ class Validate(object):
             files = glob.glob(line)
         return files
 
-    def ceph_tgt(self):
+    def ceph_tgt(self, target):
         """
-        Verify ceph_tgt if set
+        Verify ceph_tgt is set
         """
-        local = salt.client.LocalClient()
-        present = False
-        for node in self.data.keys():
-            if 'ceph_tgt' in self.data[node]:
-                present = True
-                data = local.cmd(self.data[node]['ceph_tgt'] , 
-                                 'test.ping', [''], expr_form="compound")
-                break
-        if present:
-            if data:
+        if target.ceph_tgt:
+            if target.matches:
                 self.passed['ceph_tgt'] = "valid"
             else:
-                msg = "Invalid compound match: {}".format(self.data[node]['ceph_tgt'])
+                msg = "No minions matched for {} - check /srv/pillar/ceph/ceph_tgt.sls".format(target.ceph_tgt)
                 self.errors['ceph_tgt'] = [ msg ]
         else:
-            self.passed['ceph_tgt'] = "valid"
-
+            msg = "ceph_tgt not defined - check /srv/pillar/ceph/ceph_tgt.sls"
+            self.errors['ceph_tgt'] = [ msg ]
 
     def report(self):
         self.printer.add(self.name, self.passed, self.errors, self.warnings)
@@ -799,7 +801,8 @@ def discovery(cluster=None, printer=None, **kwargs):
     local = salt.client.LocalClient()
 
     # Restrict search to this cluster
-    search = "*"
+    target = ceph_tgt.CephTgt()
+    search = target.ceph_tgt
     if 'cluster' in __pillar__:
         if __pillar__['cluster']:
             search = "I@cluster:{}".format(cluster)
@@ -868,9 +871,11 @@ def deploy(**kwargs):
     """
     Verify that Stage 4, Services can succeed.
     """
+    target = ceph_tgt.CephTgt()
+    search = target.ceph_tgt
     local = salt.client.LocalClient()
-    pillar_data = local.cmd('*', 'pillar.items', [], expr_form="glob")
-    grains_data = local.cmd('*', 'grains.items', [], expr_form="compound")
+    pillar_data = local.cmd(search, 'pillar.items', [], expr_form="glob")
+    grains_data = local.cmd(search, 'grains.items', [], expr_form="compound")
     printer = get_printer(**kwargs)
 
     v = Validate("deploy", pillar_data, grains_data, printer)
@@ -886,14 +891,17 @@ def setup(**kwargs):
     """
     Check that initial files prior to any stage are correct
     """
+    target = ceph_tgt.CephTgt()
+    search = target.ceph_tgt
     local = salt.client.LocalClient()
-    pillar_data = local.cmd('*' , 'pillar.items', [], expr_form="glob")
+
+    pillar_data = local.cmd(search , 'pillar.items', [], expr_form="glob")
     printer = get_printer(**kwargs)
 
     v = Validate("setup", pillar_data, [], printer)
+    v.ceph_tgt(target)
     v.master_minion()
     v.ceph_version()
-    v.ceph_tgt()
     v.report()
 
     if v.errors:

--- a/srv/modules/runners/validate.py
+++ b/srv/modules/runners/validate.py
@@ -646,7 +646,7 @@ class Validate(object):
         target = ceph_tgt.CephTgt()
         search = target.ceph_tgt
         local = salt.client.LocalClient()
-        contents = local.cmd(search , 'cmd.shell', [ '/usr/bin/zypper info ceph' ], expr_form="glob")
+        contents = local.cmd(search , 'cmd.shell', [ '/usr/bin/zypper info ceph' ], expr_form="compound")
 
         for minion in contents.keys():
             m = re.search(r'Version: (\S+)', contents[minion])
@@ -874,7 +874,7 @@ def deploy(**kwargs):
     target = ceph_tgt.CephTgt()
     search = target.ceph_tgt
     local = salt.client.LocalClient()
-    pillar_data = local.cmd(search, 'pillar.items', [], expr_form="glob")
+    pillar_data = local.cmd(search, 'pillar.items', [], expr_form="compound")
     grains_data = local.cmd(search, 'grains.items', [], expr_form="compound")
     printer = get_printer(**kwargs)
 
@@ -895,7 +895,7 @@ def setup(**kwargs):
     search = target.ceph_tgt
     local = salt.client.LocalClient()
 
-    pillar_data = local.cmd(search , 'pillar.items', [], expr_form="glob")
+    pillar_data = local.cmd(search , 'pillar.items', [], expr_form="compound")
     printer = get_printer(**kwargs)
 
     v = Validate("setup", pillar_data, [], printer)

--- a/srv/modules/runners/validate.py
+++ b/srv/modules/runners/validate.py
@@ -813,6 +813,7 @@ def discovery(cluster=None, printer=None, **kwargs):
     printer = get_printer(**kwargs)
     v = Validate(cluster, data=pillar_data, printer=printer)
 
+    v.ceph_tgt(target)
     v._lint_yaml_files()
     if not v.in_dev_env:
         v._profiles_populated()
@@ -886,6 +887,13 @@ def deploy(**kwargs):
         return False
 
     return True
+
+def prep(**kwargs):
+    """
+    Enough users seem to skip around.  Verify that the basics are still
+    correct for Stage 1.
+    """
+    setup(**kwargs)
 
 def setup(**kwargs):
     """

--- a/srv/pillar/ceph/ceph_tgt.sls
+++ b/srv/pillar/ceph/ceph_tgt.sls
@@ -1,0 +1,4 @@
+# Choose one
+ceph_tgt: '-G deepsea:*'
+# ceph_tgt: '*'
+# ceph_tgt: 'ses*'

--- a/srv/pillar/ceph/ceph_tgt.sls
+++ b/srv/pillar/ceph/ceph_tgt.sls
@@ -1,4 +1,8 @@
-# Choose one
+# See `man deepsea.ceph_tgt` for details
+
+# Choose minions with a deepsea grain
 ceph_tgt: '-G deepsea:*'
+# Choose all minions
 # ceph_tgt: '*'
+# Choose custom Salt targeting
 # ceph_tgt: 'ses*'

--- a/srv/pillar/ceph/ceph_tgt.sls
+++ b/srv/pillar/ceph/ceph_tgt.sls
@@ -1,7 +1,7 @@
 # See `man deepsea.ceph_tgt` for details
 
 # Choose minions with a deepsea grain
-ceph_tgt: '-G deepsea:*'
+ceph_tgt: 'G@deepsea:*'
 # Choose all minions
 # ceph_tgt: '*'
 # Choose custom Salt targeting

--- a/srv/pillar/ceph/init.sls
+++ b/srv/pillar/ceph/init.sls
@@ -3,6 +3,5 @@
 
 {% include 'ceph/master_minion.sls' ignore missing %}
 
-{% include 'ceph/rgw.sls' ignore missing %}
+{% include 'ceph/ceph_tgt.sls' ignore missing %}
 
-{% include 'ceph/openattic.sls' ignore missing %}

--- a/srv/salt/ceph/maintenance/upgrade/minion/default.sls
+++ b/srv/salt/ceph/maintenance/upgrade/minion/default.sls
@@ -3,30 +3,30 @@
 
 update salt:
   salt.state:
-    - tgt: '*'
+    - tgt: {{ salt['pillar.get']('ceph_tgt) }}
     - sls: ceph.updates.salt
 
 mines:
   salt.state:
-    - tgt: '*'
+    - tgt: {{ salt['pillar.get']('ceph_tgt) }}
     - sls: ceph.mines
     - failhard: True
 
 sync:
   salt.state:
-    - tgt: '*'
+    - tgt: {{ salt['pillar.get']('ceph_tgt) }}
     - sls: ceph.sync
     - failhard: True
 
 repo:
   salt.state:
-    - tgt: '*'
+    - tgt: {{ salt['pillar.get']('ceph_tgt) }}
     - sls: ceph.repo
     - failhard: True
 
 common packages:
   salt.state:
-    - tgt: '*'
+    - tgt: {{ salt['pillar.get']('ceph_tgt) }}
     - sls: ceph.packages.common
     - failhard: True
 
@@ -55,7 +55,7 @@ wait until the cluster has recovered before processing mon on {{ host }}:
 # OSDs are up and running althouth officially not starting because a missing flag..
 check if all processes are still running after processing mon on {{ host }}:
   salt.state:
-    - tgt: '*'
+    - tgt: {{ salt['pillar.get']('ceph_tgt) }}
     - sls: ceph.processes
     - failhard: True
 
@@ -108,7 +108,7 @@ wait until the cluster has recovered before processing {{ host }}:
 
 check if all processes are still running after processing {{ host }}:
   salt.state:
-    - tgt: '*'
+    - tgt: {{ salt['pillar.get']('ceph_tgt) }}
     - sls: ceph.processes
     - failhard: True
 
@@ -161,12 +161,12 @@ set luminous osds:
 
 updates:
   salt.state:
-    - tgt: '*'
+    - tgt: {{ salt['pillar.get']('ceph_tgt) }}
     - sls: ceph.upgrade
 
 restart:
   salt.state:
-    - tgt: '*'
+    - tgt: {{ salt['pillar.get']('ceph_tgt) }}
     - sls: ceph.updates.restart
 
 {% endif %}

--- a/srv/salt/ceph/stage/configure/default.sls
+++ b/srv/salt/ceph/stage/configure/default.sls
@@ -14,7 +14,8 @@ push proposals:
 
 refresh_pillar1:
   salt.state:
-    - tgt: '*'
+    - tgt: {{ salt['pillar.get']('ceph_tgt', '\'*\'') }}
+    - tgt_type: compound
     - sls: ceph.refresh
     - require:
       - salt: push proposals
@@ -27,7 +28,8 @@ post configuration:
 
 refresh_pillar2:
   salt.state:
-    - tgt: '*'
+    - tgt: {{ salt['pillar.get']('ceph_tgt', '\'*\'') }}
+    - tgt_type: compound
     - sls: ceph.refresh
     - require: 
       - salt: post configuration

--- a/srv/salt/ceph/stage/configure/default.sls
+++ b/srv/salt/ceph/stage/configure/default.sls
@@ -14,7 +14,7 @@ push proposals:
 
 refresh_pillar1:
   salt.state:
-    - tgt: {{ salt['pillar.get']('ceph_tgt', '\'*\'') }}
+    - tgt: '{{ salt['pillar.get']('ceph_tgt') }}'
     - tgt_type: compound
     - sls: ceph.refresh
     - require:
@@ -28,7 +28,7 @@ post configuration:
 
 refresh_pillar2:
   salt.state:
-    - tgt: {{ salt['pillar.get']('ceph_tgt', '\'*\'') }}
+    - tgt: '{{ salt['pillar.get']('ceph_tgt') }}'
     - tgt_type: compound
     - sls: ceph.refresh
     - require: 
@@ -52,6 +52,6 @@ setup monitoring:
 
 setup node exporters:
   salt.state:
-    - tgt: '*'
+    - tgt: '{{ salt['pillar.get']('ceph_tgt') }}'
     - sls: ceph.monitoring.prometheus.exporters.node_exporter
 

--- a/srv/salt/ceph/stage/configure/default.sls
+++ b/srv/salt/ceph/stage/configure/default.sls
@@ -53,5 +53,6 @@ setup monitoring:
 setup node exporters:
   salt.state:
     - tgt: '{{ salt['pillar.get']('ceph_tgt') }}'
+    - tgt_type: compound
     - sls: ceph.monitoring.prometheus.exporters.node_exporter
 

--- a/srv/salt/ceph/stage/discovery/default.sls
+++ b/srv/salt/ceph/stage/discovery/default.sls
@@ -1,3 +1,12 @@
+{% if salt['saltutil.runner']('validate.prep') == False %}
+
+validate failed:
+  salt.state:
+    - name: just.exit
+    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - failhard: True
+
+{% endif %}
 
 ready:
   salt.runner:

--- a/srv/salt/ceph/stage/prep/minion/default-no-update-no-reboot.sls
+++ b/srv/salt/ceph/stage/prep/minion/default-no-update-no-reboot.sls
@@ -1,21 +1,25 @@
 sync:
   salt.state:
     - tgt: '{{ salt['pillar.get']('ceph_tgt') }}'
+    - tgt_type: compound
     - sls: ceph.sync
 
 repo:
   salt.state:
     - tgt: '{{ salt['pillar.get']('ceph_tgt') }}'
+    - tgt_type: compound
     - sls: ceph.repo
 
 common packages:
   salt.state:
     - tgt: '{{ salt['pillar.get']('ceph_tgt') }}'
+    - tgt_type: compound
     - sls: ceph.packages.common
 
 mines:
   salt.state:
     - tgt: '{{ salt['pillar.get']('ceph_tgt') }}'
+    - tgt_type: compound
     - sls: ceph.mines
 
 

--- a/srv/salt/ceph/stage/prep/minion/default-no-update-no-reboot.sls
+++ b/srv/salt/ceph/stage/prep/minion/default-no-update-no-reboot.sls
@@ -1,21 +1,21 @@
 sync:
   salt.state:
-    - tgt: '*'
+    - tgt: '{{ salt['pillar.get']('ceph_tgt') }}'
     - sls: ceph.sync
 
 repo:
   salt.state:
-    - tgt: '*'
+    - tgt: '{{ salt['pillar.get']('ceph_tgt') }}'
     - sls: ceph.repo
 
 common packages:
   salt.state:
-    - tgt: '*'
+    - tgt: '{{ salt['pillar.get']('ceph_tgt') }}'
     - sls: ceph.packages.common
 
 mines:
   salt.state:
-    - tgt: '*'
+    - tgt: '{{ salt['pillar.get']('ceph_tgt') }}'
     - sls: ceph.mines
 
 

--- a/srv/salt/ceph/stage/prep/minion/default-no-update-reboot.sls
+++ b/srv/salt/ceph/stage/prep/minion/default-no-update-reboot.sls
@@ -1,21 +1,21 @@
 sync:
   salt.state:
-    - tgt: '*'
+    - tgt: '{{ salt['pillar.get']('ceph_tgt') }}'
     - sls: ceph.sync
 
 repo:
   salt.state:
-    - tgt: '*'
+    - tgt: '{{ salt['pillar.get']('ceph_tgt') }}'
     - sls: ceph.repo
 
 common packages:
   salt.state:
-    - tgt: '*'
+    - tgt: '{{ salt['pillar.get']('ceph_tgt') }}'
     - sls: ceph.packages.common
 
 mines:
   salt.state:
-    - tgt: '*'
+    - tgt: '{{ salt['pillar.get']('ceph_tgt') }}'
     - sls: ceph.mines
 
 {% if salt['saltutil.runner']('cephprocesses.mon') == True %}
@@ -41,7 +41,7 @@ wait until the cluster has recovered before processing {{ host }}:
 
 check if all processes are still running after processing {{ host }}:
   salt.state:
-    - tgt: '*'
+    - tgt: '{{ salt['pillar.get']('ceph_tgt') }}'
     - sls: ceph.processes
     - failhard: True
 
@@ -108,7 +108,7 @@ finishing remaining minions:
 
 restart:
   salt.state:
-    - tgt: '*'
+    - tgt: '{{ salt['pillar.get']('ceph_tgt') }}'
     - sls: ceph.updates.restart
 
 {% endif %}

--- a/srv/salt/ceph/stage/prep/minion/default-no-update-reboot.sls
+++ b/srv/salt/ceph/stage/prep/minion/default-no-update-reboot.sls
@@ -1,21 +1,25 @@
 sync:
   salt.state:
     - tgt: '{{ salt['pillar.get']('ceph_tgt') }}'
+    - tgt_type: compound
     - sls: ceph.sync
 
 repo:
   salt.state:
     - tgt: '{{ salt['pillar.get']('ceph_tgt') }}'
+    - tgt_type: compound
     - sls: ceph.repo
 
 common packages:
   salt.state:
     - tgt: '{{ salt['pillar.get']('ceph_tgt') }}'
+    - tgt_type: compound
     - sls: ceph.packages.common
 
 mines:
   salt.state:
     - tgt: '{{ salt['pillar.get']('ceph_tgt') }}'
+    - tgt_type: compound
     - sls: ceph.mines
 
 {% if salt['saltutil.runner']('cephprocesses.mon') == True %}
@@ -42,6 +46,7 @@ wait until the cluster has recovered before processing {{ host }}:
 check if all processes are still running after processing {{ host }}:
   salt.state:
     - tgt: '{{ salt['pillar.get']('ceph_tgt') }}'
+    - tgt_type: compound
     - sls: ceph.processes
     - failhard: True
 
@@ -109,6 +114,7 @@ finishing remaining minions:
 restart:
   salt.state:
     - tgt: '{{ salt['pillar.get']('ceph_tgt') }}'
+    - tgt_type: compound
     - sls: ceph.updates.restart
 
 {% endif %}

--- a/srv/salt/ceph/stage/prep/minion/default-update-no-reboot.sls
+++ b/srv/salt/ceph/stage/prep/minion/default-update-no-reboot.sls
@@ -1,21 +1,25 @@
 sync:
   salt.state:
     - tgt: '{{ salt['pillar.get']('ceph_tgt') }}'
+    - tgt_type: compound
     - sls: ceph.sync
 
 repo:
   salt.state:
     - tgt: '{{ salt['pillar.get']('ceph_tgt') }}'
+    - tgt_type: compound
     - sls: ceph.repo
 
 common packages:
   salt.state:
     - tgt: '{{ salt['pillar.get']('ceph_tgt') }}'
+    - tgt_type: compound
     - sls: ceph.packages.common
 
 mines:
   salt.state:
     - tgt: '{{ salt['pillar.get']('ceph_tgt') }}'
+    - tgt_type: compound
     - sls: ceph.mines
 
 {% if salt['saltutil.runner']('cephprocesses.mon') == True %}
@@ -42,6 +46,7 @@ wait until the cluster has recovered before processing {{ host }}:
 check if all processes are still running after processing {{ host }}:
   salt.state:
     - tgt: {{ salt['pillar.get']('ceph_tgt') }}
+    - tgt_type: compound
     - sls: ceph.processes
     - failhard: True
 
@@ -109,6 +114,7 @@ finishing remaining minions:
 updates:
   salt.state:
     - tgt: '{{ salt['pillar.get']('ceph_tgt') }}'
+    - tgt_type: compound
     - sls: ceph.updates
 
 {% endif %}

--- a/srv/salt/ceph/stage/prep/minion/default-update-no-reboot.sls
+++ b/srv/salt/ceph/stage/prep/minion/default-update-no-reboot.sls
@@ -1,21 +1,21 @@
 sync:
   salt.state:
-    - tgt: '*'
+    - tgt: '{{ salt['pillar.get']('ceph_tgt') }}'
     - sls: ceph.sync
 
 repo:
   salt.state:
-    - tgt: '*'
+    - tgt: '{{ salt['pillar.get']('ceph_tgt') }}'
     - sls: ceph.repo
 
 common packages:
   salt.state:
-    - tgt: '*'
+    - tgt: '{{ salt['pillar.get']('ceph_tgt') }}'
     - sls: ceph.packages.common
 
 mines:
   salt.state:
-    - tgt: '*'
+    - tgt: '{{ salt['pillar.get']('ceph_tgt') }}'
     - sls: ceph.mines
 
 {% if salt['saltutil.runner']('cephprocesses.mon') == True %}
@@ -41,7 +41,7 @@ wait until the cluster has recovered before processing {{ host }}:
 
 check if all processes are still running after processing {{ host }}:
   salt.state:
-    - tgt: '*'
+    - tgt: {{ salt['pillar.get']('ceph_tgt') }}
     - sls: ceph.processes
     - failhard: True
 
@@ -108,7 +108,7 @@ finishing remaining minions:
 
 updates:
   salt.state:
-    - tgt: '*'
+    - tgt: '{{ salt['pillar.get']('ceph_tgt') }}'
     - sls: ceph.updates
 
 {% endif %}

--- a/srv/salt/ceph/stage/prep/minion/default.sls
+++ b/srv/salt/ceph/stage/prep/minion/default.sls
@@ -1,21 +1,25 @@
 sync:
   salt.state:
-    - tgt: '*'
+    - tgt: {{ salt['pillar.get']('ceph_tgt', '\'*\'') }}
+    - tgt_type: compound
     - sls: ceph.sync
 
 repo:
   salt.state:
-    - tgt: '*'
+    - tgt: {{ salt['pillar.get']('ceph_tgt', '\'*\'') }}
+    - tgt_type: compound
     - sls: ceph.repo
 
 common packages:
   salt.state:
-    - tgt: '*'
+    - tgt: {{ salt['pillar.get']('ceph_tgt', '\'*\'') }}
+    - tgt_type: compound
     - sls: ceph.packages.common
 
 mines:
   salt.state:
-    - tgt: '*'
+    - tgt: {{ salt['pillar.get']('ceph_tgt', '\'*\'') }}
+    - tgt_type: compound
     - sls: ceph.mines
 
 {% if salt['saltutil.runner']('cephprocesses.mon') == True %}
@@ -41,6 +45,7 @@ wait until the cluster has recovered before processing {{ host }}:
 
 check if all processes are still running after processing {{ host }}:
   salt.state:
+<<<<<<< f73f6b53ce74fbad76b3eeb5560290de1b79460d
     - tgt: '*'
     - sls: ceph.processes
     - failhard: True
@@ -67,6 +72,9 @@ set noout {{ host }}:
 restart {{ host }} if updates require:
   salt.state:
     - tgt: {{ host }}
+=======
+    - tgt: {{ salt['pillar.get']('ceph_tgt', '\'*\'') }}
+>>>>>>> Allow the restriction of Stage 0,1 with ceph_tgt
     - tgt_type: compound
     - sls: ceph.updates.restart
     - failhard: True
@@ -122,9 +130,9 @@ finishing remaining minions:
 
 updates:
   salt.state:
-    - tgt: '*'
+    - tgt: {{ salt['pillar.get']('ceph_tgt', '\'*\'') }}
+    - tgt_type: compound
     - sls: ceph.updates
-
 
 restart:
   salt.state:

--- a/srv/salt/ceph/stage/prep/minion/default.sls
+++ b/srv/salt/ceph/stage/prep/minion/default.sls
@@ -1,24 +1,24 @@
 sync:
   salt.state:
-    - tgt: {{ salt['pillar.get']('ceph_tgt', '\'*\'') }}
+    - tgt: '{{ salt['pillar.get']('ceph_tgt') }}'
     - tgt_type: compound
     - sls: ceph.sync
 
 repo:
   salt.state:
-    - tgt: {{ salt['pillar.get']('ceph_tgt', '\'*\'') }}
+    - tgt: '{{ salt['pillar.get']('ceph_tgt') }}'
     - tgt_type: compound
     - sls: ceph.repo
 
 common packages:
   salt.state:
-    - tgt: {{ salt['pillar.get']('ceph_tgt', '\'*\'') }}
+    - tgt: '{{ salt['pillar.get']('ceph_tgt') }}'
     - tgt_type: compound
     - sls: ceph.packages.common
 
 mines:
   salt.state:
-    - tgt: {{ salt['pillar.get']('ceph_tgt', '\'*\'') }}
+    - tgt: '{{ salt['pillar.get']('ceph_tgt') }}'
     - tgt_type: compound
     - sls: ceph.mines
 
@@ -45,15 +45,14 @@ wait until the cluster has recovered before processing {{ host }}:
 
 check if all processes are still running after processing {{ host }}:
   salt.state:
-<<<<<<< f73f6b53ce74fbad76b3eeb5560290de1b79460d
-    - tgt: '*'
+    - tgt: '{{ salt['pillar.get']('ceph_tgt') }}'
     - sls: ceph.processes
     - failhard: True
 
 unset noout {{ host }}:
   salt.state:
     - sls: ceph.noout.unset
-    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt: '{{ salt['pillar.get']('master_minion') }}'
     - failhard: True
 
 updating {{ host }}:
@@ -72,9 +71,6 @@ set noout {{ host }}:
 restart {{ host }} if updates require:
   salt.state:
     - tgt: {{ host }}
-=======
-    - tgt: {{ salt['pillar.get']('ceph_tgt', '\'*\'') }}
->>>>>>> Allow the restriction of Stage 0,1 with ceph_tgt
     - tgt_type: compound
     - sls: ceph.updates.restart
     - failhard: True
@@ -130,13 +126,13 @@ finishing remaining minions:
 
 updates:
   salt.state:
-    - tgt: {{ salt['pillar.get']('ceph_tgt', '\'*\'') }}
+    - tgt: '{{ salt['pillar.get']('ceph_tgt') }}'
     - tgt_type: compound
     - sls: ceph.updates
 
 restart:
   salt.state:
-    - tgt: '*'
+    - tgt: '{{ salt['pillar.get']('ceph_tgt') }}'
     - sls: ceph.updates.restart
 
 {% endif %}

--- a/srv/salt/ceph/stage/prep/minion/default.sls
+++ b/srv/salt/ceph/stage/prep/minion/default.sls
@@ -46,6 +46,7 @@ wait until the cluster has recovered before processing {{ host }}:
 check if all processes are still running after processing {{ host }}:
   salt.state:
     - tgt: '{{ salt['pillar.get']('ceph_tgt') }}'
+    - tgt_type: compound
     - sls: ceph.processes
     - failhard: True
 
@@ -133,6 +134,7 @@ updates:
 restart:
   salt.state:
     - tgt: '{{ salt['pillar.get']('ceph_tgt') }}'
+    - tgt_type: compound
     - sls: ceph.updates.restart
 
 {% endif %}


### PR DESCRIPTION
New mandatory variable to constrain the scope of minions considered for Ceph.  

The man page has details.  The /srv/pillar/ceph/ceph_tgt.sls has examples.  Note that 'make install' will still default to all minions.

Signed-off-by: Eric Jackson <ejackson@suse.com>
