### PR TITLE
stage1: try doing a pillar refresh before we push proposals

### DIFF
--- a/srv/salt/ceph/stage/discovery/default.sls
+++ b/srv/salt/ceph/stage/discovery/default.sls
@@ -4,9 +4,17 @@ ready:
     - name: minions.ready
     - timeout: {{ salt['pillar.get']('ready_timeout', 300) }}
 
+refresh_pillar0:
+  salt.state:
+    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - sls: ceph.refresh
+
 discover roles:
   salt.runner:
     - name: populate.proposals
+    - require:
+        - salt: refresh_pillar0
+
 
 discover storage profiles:
   salt.runner:

--- a/srv/salt/ceph/stage/discovery/default.sls
+++ b/srv/salt/ceph/stage/discovery/default.sls
@@ -19,3 +19,5 @@ discover roles:
 discover storage profiles:
   salt.runner:
     - name: proposal.populate
+    - require:
+        - salt: refresh_pillar0


### PR DESCRIPTION
Doing a pillar refresh before we discover profiles, this can help cases
where a global/cluster.yml already contains a custom role and we need
populate to use this role so that we can use the role in stage2's
policy.cfg, an existing example would be using rgw_configurations and
creating the rgw-ssl role in global.yml before stage1 which would not be
populated unless a pillar.refresh is done

Fixes: #529
Signed-off-by: Abhishek Lekshmanan <abhishek@suse.com>