### PR TITLE
Make install: set salt-master to minion_id from /etc/salt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -523,9 +523,9 @@ copy-files:
 install: copy-files
 	sed -i '/^sharedsecret: /s!{{ shared_secret }}!'`cat /proc/sys/kernel/random/uuid`'!' $(DESTDIR)/etc/salt/master.d/sharedsecret.conf
 	chown salt:salt $(DESTDIR)/etc/salt/master.d/*
-	sed -i '/^master_minion:/s!_REPLACE_ME_!'`hostname -f`'!' /srv/pillar/ceph/master_minion.sls
 	chown -R salt /srv/pillar/ceph
 	systemctl restart salt-master
+	sed -i '/^master_minion:/s!_REPLACE_ME_!'`cat /etc/salt/minion_id`'!' /srv/pillar/ceph/master_minion.sls
 	zypper -n install salt-api
 	systemctl restart salt-api
 


### PR DESCRIPTION
Currently we set the master minion_id as fqdn, in vagrant systems and
such if a machine has multiple host entries, for different interfaces
the mininon_id may not match what hostname -f reports. Since we assume
salt-master and salt-minion is installed anyway for make install, we can
safely assume that `/etc/salt/minion_id` is already populated

Signed-off-by: Abhishek Lekshmanan <abhishek@suse.com>