### PR TITLE
stage2: keep default-notimeout in sync with default

### DIFF
--- a/srv/salt/ceph/stage/discovery/default-notimeout.sls
+++ b/srv/salt/ceph/stage/discovery/default-notimeout.sls
@@ -1,9 +1,9 @@
 
-ready:
-  salt.runner:
-    - name: minions.ready
+include:
+  - .default
 
-discover:
-  salt.runner:
-    - name: populate.proposals
-
+extend:
+  ready:
+    salt.runner:
+      - name: minions.ready
+      - timeout: 0


### PR DESCRIPTION
Since we're only overriding one function call and the rest remains the
same, use includes and excludes to achieve the same goal and avoid the
need to update this file when newer functions are called in default

Signed-off-by: Abhishek Lekshmanan <abhishek@suse.com>