### PR TITLE
ui_rgw: don't glob over all conf files searching for rgws

### DIFF
--- a/srv/modules/runners/ui_rgw.py
+++ b/srv/modules/runners/ui_rgw.py
@@ -124,13 +124,16 @@ class Radosgw(object):
         admin_path = 'admin'
 
         rgw_names = ['rgw']
-        if 'roles' in __pillar__:
-            if 'rgw_configurations' in __pillar__:
-                rgw_names = __pillar__['rgw_configurations'].keys()
+        for minion in cached:
+            if 'rgw_configurations' in cached[minion]:
+                # TODO: where is the master minion when we need it
+                rgw_names = cached[minion]['rgw_configurations'].keys()
 
         conf_file_dir = "/srv/salt/ceph/configuration/files/"
         rgw_conf_files = [os.path.join(conf_file_dir,"ceph.conf." + rgw_name) for rgw_name in rgw_names]
-        for rgw_conf_file_path in rgw_conf_files:
+
+        for rgw_name in rgw_names:
+            rgw_conf_file_path = os.path.join(conf_file_dir, "ceph.conf."+ rgw_name)
             if os.path.exists(rgw_conf_file_path) and os.path.isfile(rgw_conf_file_path):
                 with open(rgw_conf_file_path) as rgw_conf_file:
                     for line in rgw_conf_file:
@@ -144,15 +147,16 @@ class Radosgw(object):
                             if match:
                                 admin_path = match.group(1)
 
-        local = salt.client.LocalClient()
-        fqdns = local.cmd('I@roles:rgw', 'grains.item', ['fqdn'], expr_form="compound")
-        for _, grains in fqdns.items():
-            result.append({
-                'host': grains['fqdn'],
-                'port': port,
-                'ssl': ssl == 's',
-                'url': "http{}://{}:{}/{}".format(ssl, grains['fqdn'], port, admin_path)
-            })
+            local = salt.client.LocalClient()
+            fqdns = local.cmd('I@roles:'+ rgw_name, 'grains.item', ['fqdn'], expr_form="compound")
+            for _, grains in fqdns.items():
+                result.append({
+                    'host': grains['fqdn'],
+                    'port': port,
+                    'ssl': ssl == 's',
+                    'url': "http{}://{}:{}/{}".format(ssl, grains['fqdn'], port, admin_path)
+                })
+
         return result
 
 

--- a/srv/modules/runners/ui_rgw.py
+++ b/srv/modules/runners/ui_rgw.py
@@ -122,7 +122,15 @@ class Radosgw(object):
         port = '7480'  # civetweb default port
         ssl = ''
         admin_path = 'admin'
-        for rgw_conf_file_path in glob.glob("/srv/salt/ceph/configuration/files/ceph.conf.*"):
+
+        rgw_names = ['rgw']
+        if 'roles' in __pillar__:
+            if 'rgw_configurations' in __pillar__:
+                rgw_names = __pillar__['rgw_configurations'].keys()
+
+        conf_file_dir = "/srv/salt/ceph/configuration/files/"
+        rgw_conf_files = [os.path.join(conf_file_dir,"ceph.conf." + rgw_name) for rgw_name in rgw_names]
+        for rgw_conf_file_path in rgw_conf_files:
             if os.path.exists(rgw_conf_file_path) and os.path.isfile(rgw_conf_file_path):
                 with open(rgw_conf_file_path) as rgw_conf_file:
                     for line in rgw_conf_file:


### PR DESCRIPTION
This commit makes ui_rgw only search for rgw conf bits in filenames that
we deploy the configuration files for ie. all the members of
`rgw_configurations` or `rgw` if nothing is configured, otherwise the
current runner just overrides the value with the last filename that
contains rgw_frontends which may not be valid anymore as more conf files
are added but not actually deployed

Signed-off-by: Abhishek Lekshmanan <abhishek@suse.com>