### PR TITLE
Makefile: set master minion id from /etc/salt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -521,11 +521,10 @@ copy-files:
 install: copy-files
 	sed -i '/^sharedsecret: /s!{{ shared_secret }}!'`cat /proc/sys/kernel/random/uuid`'!' $(DESTDIR)/etc/salt/master.d/sharedsecret.conf
 	chown salt:salt $(DESTDIR)/etc/salt/master.d/*
-	sed -i '/^master_minion:/s!_REPLACE_ME_!'`hostname -f`'!' /srv/pillar/ceph/master_minion.sls
 	echo "ceph_tgt: '*'" > /srv/pillar/ceph/ceph_tgt.sls
 	chown -R salt /srv/pillar/ceph
-	systemctl restart salt-master
 	sed -i '/^master_minion:/s!_REPLACE_ME_!'`cat /etc/salt/minion_id`'!' /srv/pillar/ceph/master_minion.sls
+	systemctl restart salt-master
 	zypper -n install salt-api
 	systemctl restart salt-api
 


### PR DESCRIPTION
While this was already merged earlier, there seems to have been another
PR that came in that rewrote the old hostname -f above causing this to
be unused

Signed-off-by: Abhishek Lekshmanan <abhishek@suse.com>