### PR TITLE
Re-added the loading of rgw.sls to the pillar/ceph/init.sls

### DIFF
--- a/srv/pillar/ceph/init.sls
+++ b/srv/pillar/ceph/init.sls
@@ -5,3 +5,5 @@
 
 {% include 'ceph/ceph_tgt.sls' ignore missing %}
 
+{% include 'ceph/rgw.sls' ignore missing %}
+


### PR DESCRIPTION
This commit fixes a regression introduced in #0051a27

Fixes: #548 

Signed-off-by: Ricardo Dias <rdias@suse.com>