### PR TITLE
prometheus: make rule_files a top level config setting

### DIFF
--- a/srv/salt/ceph/monitoring/prometheus/files/prometheus.yml.j2
+++ b/srv/salt/ceph/monitoring/prometheus/files/prometheus.yml.j2
@@ -7,7 +7,7 @@ global:
   external_labels:
       monitor: 'ses'
 
-  rule_files: []
+rule_files: []
 
 scrape_configs:
   # The job name is added as a label `job=<job_name>` to any timeseries scraped from this config.


### PR DESCRIPTION
rule_files needs to be at the top level, not a child of global,
or prometheus won't start (tested with prometheus v2.beta.1)

Signed-off-by: Tim Serong <tserong@suse.com>