### PR TITLE
Only use ceph.client.storage.keyring when it exists

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -292,6 +292,8 @@ copy-files:
 	install -m 644 srv/salt/ceph/remove/igw/auth/*.sls $(DESTDIR)/srv/salt/ceph/remove/igw/auth/
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/remove/mds
 	install -m 644 srv/salt/ceph/remove/mds/*.sls $(DESTDIR)/srv/salt/ceph/remove/mds/
+	install -d -m 755 $(DESTDIR)/srv/salt/ceph/remove/migrated
+	install -m 644 srv/salt/ceph/remove/migrated/*.sls $(DESTDIR)/srv/salt/ceph/remove/migrated/
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/remove/mgr
 	install -m 644 srv/salt/ceph/remove/mgr/*.sls $(DESTDIR)/srv/salt/ceph/remove/mgr/
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/remove/mon

--- a/deepsea.spec
+++ b/deepsea.spec
@@ -411,6 +411,7 @@ systemctl try-restart salt-api > /dev/null 2>&1 || :
 %config /srv/salt/ceph/remove/igw/auth/*.sls
 %config /srv/salt/ceph/remove/mon/*.sls
 %config /srv/salt/ceph/remove/mds/*.sls
+%config /srv/salt/ceph/remove/migrated/*.sls
 %config /srv/salt/ceph/remove/mgr/*.sls
 %config /srv/salt/ceph/remove/openattic/*.sls
 %config /srv/salt/ceph/remove/rgw/*.sls

--- a/srv/salt/ceph/migrate/nodes/default.sls
+++ b/srv/salt/ceph/migrate/nodes/default.sls
@@ -26,7 +26,7 @@ cleanup {{ host }} osds:
   salt.state:
     - tgt: {{ salt['pillar.get']('master_minion') }}
     - tgt_type: compound
-    - sls: ceph.remove.storage
+    - sls: ceph.remove.migrated
 
 wait on {{ host }}:
   salt.state:

--- a/srv/salt/ceph/migrate/osds/default.sls
+++ b/srv/salt/ceph/migrate/osds/default.sls
@@ -27,7 +27,7 @@ cleanup {{ host }} osds:
   salt.state:
     - tgt: {{ salt['pillar.get']('master_minion') }}
     - tgt_type: compound
-    - sls: ceph.remove.storage
+    - sls: ceph.remove.migrated
 
 wait on {{ host }}:
   salt.state:

--- a/srv/salt/ceph/remove/migrated/default.sls
+++ b/srv/salt/ceph/remove/migrated/default.sls
@@ -1,8 +1,8 @@
 
-reweight nop:
+remove migrated nop:
   test.nop
 
-{% for id in salt.saltutil.runner('rescinded.ids', cluster='ceph') %}
+{% for id in salt.saltutil.runner('rescinded.osds', cluster='ceph') %}
 
 remove osd.{{ id }}:
   cmd.run:

--- a/srv/salt/ceph/remove/migrated/init.sls
+++ b/srv/salt/ceph/remove/migrated/init.sls
@@ -1,0 +1,4 @@
+
+
+include:
+  - .{{ salt['pillar.get']('remove_migrated', 'default') }}


### PR DESCRIPTION
Fix removal of OSDs during Stage 5
Adjust migration to use its own removal

Signed-off-by: Eric Jackson <ejackson@suse.com>