### PR TITLE
config: only specifiy one source to force salt to look for it

### DIFF
--- a/srv/salt/ceph/configuration/default.sls
+++ b/srv/salt/ceph/configuration/default.sls
@@ -3,8 +3,7 @@
 /etc/ceph/ceph.conf:
   file:
     - managed
-    - source:
-        - salt://ceph/configuration/cache/ceph.conf
+    - source: salt://ceph/configuration/cache/ceph.conf
     - template: jinja
     - user: root
     - group: root


### PR DESCRIPTION
Otherwise this can cause failure to distribute the config file.

Signed-off-by: Jan Fajerski <jfajerski@suse.com>