### PR TITLE
[WiP] Add lb/f5 integration for rgw

### DIFF
--- a/srv/pillar/lb/f5/init.sls
+++ b/srv/pillar/lb/f5/init.sls
@@ -1,0 +1,15 @@
+f5:
+  lb1:
+    user: admin
+    password: password
+    mgmt_ip: 10.0.0.1
+    partition: Common
+    pool: ceph01.cloud
+    routing_domain: 10001
+  lb2:
+    user: admin
+    password: passowd
+    mgmt_ip: 10.0.0.2
+    partition: Common
+    pool: ceph01.cloud
+    routing_domain: 10001

--- a/srv/pillar/lb/init.sls
+++ b/srv/pillar/lb/init.sls
@@ -1,0 +1,1 @@
+{% include 'lb/f5/init.sls' %}

--- a/srv/pillar/top.sls
+++ b/srv/pillar/top.sls
@@ -1,3 +1,4 @@
 base:
   '*':
     - ceph
+    - lb

--- a/srv/salt/lb/f5/add_rgw_pool_member.sls
+++ b/srv/salt/lb/f5/add_rgw_pool_member.sls
@@ -1,0 +1,15 @@
+{% if 'rgw' in salt['pillar.get']('roles') %}
+{% for lb_name in salt['pillar.get']('f5') %}
+{% set lb = salt['pillar.get']('f5')[lb_name] %}
+
+add_rgw_pool_member_to_{{ lb_name }}:
+  bigip.add_pool_member:
+    - hostname: {{ lb['mgmt_ip']}}
+    - username: {{ lb['user'] }}
+    - password: {{ lb['password'] }}
+    - name: ~{{ lb['partition'] }}~{{ lb['pool'] }}
+    - member:
+         name: {{ pillar['public_address'] }}%{{ lb['routing_domain'] }}:80
+         partition: {{ lb['partition'] }}
+{% endfor %}
+{% endif %}


### PR DESCRIPTION
Adds state add_rgw_pool_member to orchestrate LBs for new radosgw instances.
This setup will work with BigIP only but other implementation can be placed
to `/srv/salt/lb`.

Signed-off-by: Marc Koderer <marc.koderer@sap.com>