### PR TITLE
qa: add openattic-with-rgw deployment test

### DIFF
--- a/qa/common/common.sh
+++ b/qa/common/common.sh
@@ -205,12 +205,25 @@ EOF
 
 # NOTE: RGW does not coexist well with openATTIC
 function policy_cfg_openattic_with_rgw {
-  cat <<EOF >> /srv/pillar/ceph/proposals/policy.cfg
+  local TOTALNODES=$(json_total_nodes)
+  test ! -z "$TOTALNODES"
+  if [ "x$TOTALNODES" = "x1" ] ; then
+    echo "Only one node in cluster; colocating rgw and openattic roles"
+    cat <<EOF >> /srv/pillar/ceph/proposals/policy.cfg
+# Role assignment - openattic (first node)
+role-openattic/cluster/*.sls slice=[:1]
+# Role assignment - rgw (colocate with openattic on first node)
+role-rgw/cluster/*.sls slice=[:1]
+EOF
+  else
+    echo "Deploying rgw and openattic roles on separate nodes"
+    cat <<EOF >> /srv/pillar/ceph/proposals/policy.cfg
 # Role assignment - openattic (first node)
 role-openattic/cluster/*.sls slice=[:1]
 # Role assignment - rgw (second node)
 role-rgw/cluster/*.sls slice=[1:2]
 EOF
+  fi
 }
 
 function policy_cfg_igw {

--- a/qa/common/common.sh
+++ b/qa/common/common.sh
@@ -203,7 +203,15 @@ role-rgw-ssl/cluster/*.sls slice=[:1]
 EOF
 }
 
-
+# NOTE: RGW does not coexist well with openATTIC
+function policy_cfg_openattic_with_rgw {
+  cat <<EOF >> /srv/pillar/ceph/proposals/policy.cfg
+# Role assignment - openattic (first node)
+role-openattic/cluster/*.sls slice=[:1]
+# Role assignment - rgw (second node)
+role-rgw/cluster/*.sls slice=[1:2]
+EOF
+}
 
 function policy_cfg_igw {
   cat <<EOF >> /srv/pillar/ceph/proposals/policy.cfg

--- a/qa/common/common.sh
+++ b/qa/common/common.sh
@@ -258,7 +258,7 @@ function cat_global_conf {
 }
 
 function cat_ceph_conf {
-  cat /etc/ceph/ceph.conf
+  salt '*' cmd.run "cat /etc/ceph/ceph.conf"
 }
 
 function admin_auth_status {

--- a/qa/common/nfs-ganesha.sh
+++ b/qa/common/nfs-ganesha.sh
@@ -35,6 +35,7 @@ cat /etc/sysconfig/nfs-ganesha
 rm -rf /var/log/ganesha/ganesha.log
 systemctl restart nfs-ganesha.service
 systemctl is-active nfs-ganesha.service
+rpm -q nfs-ganesha
 echo "Result: OK"
 EOF
   _run_test_script_on_node $TESTSCRIPT $GANESHANODE

--- a/qa/common/rgw.sh
+++ b/qa/common/rgw.sh
@@ -14,6 +14,20 @@ EOF
   cat $RGWSLS
 }
 
+function rgw_user_and_bucket_list {
+  #
+  # just list rgw users and buckets
+  #
+  local TESTSCRIPT=/tmp/rgw_user_and_bucket_list.sh
+  local RGWNODE=$(_first_x_node rgw)
+  cat << EOF > $TESTSCRIPT
+radosgw-admin user list
+radosgw-admin bucket list
+echo "Result: OK"
+EOF
+  _run_test_script_on_node $TESTSCRIPT $RGWNODE
+}
+
 function rgw_validate_demo_users {
   #
   # prove the demo users from rgw_demo_users were really set up
@@ -23,10 +37,8 @@ function rgw_validate_demo_users {
   cat << EOF > $TESTSCRIPT
 set -ex
 trap 'echo "Result: NOT_OK"' ERR
-radosgw-admin user list
 radosgw-admin user info --uid=demo
 radosgw-admin user info --uid=demo1
-radosgw-admin bucket list
 echo "Result: OK"
 EOF
   _run_test_script_on_node $TESTSCRIPT $RGWNODE

--- a/qa/suites/basic/health-nfs-ganesha.sh
+++ b/qa/suites/basic/health-nfs-ganesha.sh
@@ -108,6 +108,7 @@ for v in "" "3" "4" ; do
             echo "Not testing RGW FSAL on NFSv3"
         else
             rgw_curl_test
+            rgw_user_and_bucket_list
             rgw_validate_demo_users
             nfs_ganesha_write_test rgw "$v"
         fi

--- a/qa/suites/basic/health-openattic.sh
+++ b/qa/suites/basic/health-openattic.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+#
+# DeepSea integration test "suites/basic/health-openattic.sh"
+#
+# This script runs DeepSea stages 0-4 to deploy a Ceph cluster with RGW and
+# openATTIC.  After stage 4 completes, it sends a GET request to the RGW node
+# using curl, and tests that: (a) the response contains the string "anonymous"
+# and (b) the response is legal XML.
+#
+# This script makes the following assumption beyond those listed in qa/README:
+# - minimum of 2 nodes in cluster
+#
+# On success, the script returns 0. On failure, for whatever reason, the script
+# returns non-zero.
+#
+# The script produces verbose output on stdout, which can be captured for later
+# forensic analysis.
+#
+
+set -ex
+BASEDIR=$(pwd)
+source $BASEDIR/common/common.sh
+
+install_deps
+cat_salt_config
+run_stage_0
+run_stage_1
+policy_cfg_base
+policy_cfg_no_client
+policy_cfg_openattic_with_rgw
+cat_policy_cfg
+run_stage_2
+ceph_conf_small_cluster
+run_stage_3
+ceph_cluster_status
+run_stage_4
+ceph_cluster_status
+ceph_health_test
+rgw_curl_test
+
+echo "OK"

--- a/qa/suites/basic/health-rgw-ssl.sh
+++ b/qa/suites/basic/health-rgw-ssl.sh
@@ -34,6 +34,7 @@ ceph_conf_small_cluster
 run_stage_3
 ceph_cluster_status
 run_stage_4
+rgw_user_and_bucket_list
 ceph_cluster_status
 ceph_health_test
 rgw_curl_test

--- a/qa/suites/basic/health-rgw.sh
+++ b/qa/suites/basic/health-rgw.sh
@@ -34,6 +34,7 @@ run_stage_3
 ceph_cluster_status
 run_stage_4
 ceph_cluster_status
+rgw_user_and_bucket_list
 ceph_health_test
 rgw_curl_test
 


### PR DESCRIPTION
For the time being, it only deploys openATTIC and RGW and checks
the RGW deployment for sanity. It does not do any validation of the
oA deployment.

Signed-off-by: Nathan Cutler <ncutler@suse.com>