### PR TITLE
Bug fixing the sort order of iperf result which was not natural

### DIFF
--- a/srv/modules/runners/net.py
+++ b/srv/modules/runners/net.py
@@ -82,9 +82,9 @@ def iperf(cluster=None, exclude=None, output=None, **kwargs):
         _create_server(cluster_addresses)
         c_result = _create_client(cluster_addresses)
         p_sort = _add_unit(sorted(p_result.items(),
-                                  key=operator.itemgetter(1)))
+                                  key=operator.itemgetter(1), reverse=True))
         c_sort = _add_unit(sorted(c_result.items(),
-                                  key=operator.itemgetter(1)))
+                                  key=operator.itemgetter(1), reverse=True))
 
         if output:
             result.update({'Public Network': p_sort})
@@ -92,11 +92,11 @@ def iperf(cluster=None, exclude=None, output=None, **kwargs):
             return result
         else:
             result.update({'Public Network':
-                           {"Slowest 2 hosts": p_sort[:2],
-                            "Fastest 2 hosts": p_sort[-2:]}})
+                           {"Slowest 2 hosts": p_sort[-2:],
+                            "Fastest 2 hosts": p_sort[:2]}})
             result.update({'Cluster Network':
-                           {"Slowest 2 hosts": c_sort[:2],
-                            "Fastest 2 hosts": c_sort[-2:]}})
+                           {"Slowest 2 hosts": c_sort[-2:],
+                            "Fastest 2 hosts": c_sort[:2]}})
             return result
     else:
         search = deepsea_minions.DeepseaMinions().deepsea_minions
@@ -120,12 +120,13 @@ def iperf(cluster=None, exclude=None, output=None, **kwargs):
         _create_server(addresses)
         result = _create_client(addresses)
         sort_result = _add_unit(sorted(result.items(),
-                                       key=operator.itemgetter(1)))
+                                       key=operator.itemgetter(1),
+                                       reverse=True))
         if output:
             return sort_result
         else:
-            return {"Slowest 2 hosts": sort_result[:2],
-                    "Fastest 2 hosts": sort_result[-2:]}
+            return {"Slowest 2 hosts": sort_result[-2:],
+                    "Fastest 2 hosts": sort_result[:2]}
 
 
 def _add_unit(records):

--- a/srv/modules/runners/net.py
+++ b/srv/modules/runners/net.py
@@ -442,8 +442,8 @@ def _summarize_iperf(results):
     for result in results:
         for host in result:
             log.debug("Server {}".format(result[host]['server']))
-        if not result[host]['server'] in server_results:
-            server_results.update({result[host]['server']: ""})
+            if not result[host]['server'] in server_results:
+                server_results.update({result[host]['server']: ""})
             if result[host]['succeeded']:
                 # print "filter:\n{}".format(result[host]['filter'])
                 server_results[result[host]['server']] +=\


### PR DESCRIPTION
Taking out the dict, because salt return sort by key no matter what I do. 
So I can only return list when which look not as good as dict, unless someone has a better idea. 

What I do was taking out the text and convert the int, then sort. Instead of doing natural sort with string which I need to install another library or implement something much bigger with lots of corner case. 
