### PR TITLE
validate: no conflict when rgw and oA are not on same node

### DIFF
--- a/srv/modules/runners/validate.py
+++ b/srv/modules/runners/validate.py
@@ -590,7 +590,8 @@ class Validate(object):
         local = salt.client.LocalClient()
         for node in self.data.keys():
             if ('roles' in self.data[node] and
-                'openattic' in self.data[node]['roles']):
+                'openattic' in self.data[node]['roles'] and
+                'rgw' in self.data[node]['roles']):
                 # Would use file.contains if it supported '='
                 result = local.cmd(node, 'file.contains_regex', [ '/etc/ceph/ceph.conf', 'port\=80'], expr_form="glob")
                 if result[node]:


### PR DESCRIPTION
Fixes https://bugzilla.suse.com/show_bug.cgi?id=1057011 for the case when rgw and openattic roles are not colocated.

I discussed the colocated case with a couple folks and the consensus seemed to be that we should not support it. In other words, Stage 4 should fail if we detect colocation of rgw and openattic roles in the validation.

The colocated case is still WIP in #602 but I split this commit off into a separate PR since it's a simple fix for the usual (non-colocated) case.