### PR TITLE
Fix syntax for inline pillar [deepsea_minions] parsing.

### DIFF
--- a/srv/salt/ceph/maintenance/upgrade/minion/default.sls
+++ b/srv/salt/ceph/maintenance/upgrade/minion/default.sls
@@ -3,30 +3,30 @@
 
 update salt:
   salt.state:
-    - tgt: {{ salt['pillar.get']('deepsea_minions') }}
+    - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
     - sls: ceph.updates.salt
 
 mines:
   salt.state:
-    - tgt: {{ salt['pillar.get']('deepsea_minions') }}
+    - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
     - sls: ceph.mines
     - failhard: True
 
 sync:
   salt.state:
-    - tgt: {{ salt['pillar.get']('deepsea_minions') }}
+    - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
     - sls: ceph.sync
     - failhard: True
 
 repo:
   salt.state:
-    - tgt: {{ salt['pillar.get']('deepsea_minions') }}
+    - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
     - sls: ceph.repo
     - failhard: True
 
 common packages:
   salt.state:
-    - tgt: {{ salt['pillar.get']('deepsea_minions') }}
+    - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
     - sls: ceph.packages.common
     - failhard: True
 
@@ -55,7 +55,7 @@ wait until the cluster has recovered before processing mon on {{ host }}:
 # OSDs are up and running althouth officially not starting because a missing flag..
 check if all processes are still running after processing mon on {{ host }}:
   salt.state:
-    - tgt: {{ salt['pillar.get']('deepsea_minions') }}
+    - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
     - sls: ceph.processes
     - failhard: True
 
@@ -108,7 +108,7 @@ wait until the cluster has recovered before processing {{ host }}:
 
 check if all processes are still running after processing {{ host }}:
   salt.state:
-    - tgt: {{ salt['pillar.get']('deepsea_minions') }}
+    - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
     - sls: ceph.processes
     - failhard: True
 
@@ -161,12 +161,12 @@ set luminous osds:
 
 updates:
   salt.state:
-    - tgt: {{ salt['pillar.get']('deepsea_minions') }}
+    - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
     - sls: ceph.upgrade
 
 restart:
   salt.state:
-    - tgt: {{ salt['pillar.get']('deepsea_minions') }}
+    - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
     - sls: ceph.updates.restart
 
 {% endif %}

--- a/srv/salt/ceph/stage/prep/minion/default-update-no-reboot.sls
+++ b/srv/salt/ceph/stage/prep/minion/default-update-no-reboot.sls
@@ -45,7 +45,7 @@ wait until the cluster has recovered before processing {{ host }}:
 
 check if all processes are still running after processing {{ host }}:
   salt.state:
-    - tgt: {{ salt['pillar.get']('deepsea_minions') }}
+    - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
     - tgt_type: compound
     - sls: ceph.processes
     - failhard: True


### PR DESCRIPTION
When we get deepsea_minions from the pillar it will be understood as * without the quotation marks.
The SLS syntax requires the target to be wrapped, though.