### PR TITLE
Split users from rgw_configuration, add system user

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -404,8 +404,11 @@ copy-files:
 	install -m 644 srv/salt/ceph/rgw/keyring/*.sls $(DESTDIR)/srv/salt/ceph/rgw/keyring/
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/rgw/users
 	install -m 644 srv/salt/ceph/rgw/users/*.sls $(DESTDIR)/srv/salt/ceph/rgw/users/
+	install -d -m 755 $(DESTDIR)/srv/salt/ceph/rgw/users/users.d
+	install -m 644 srv/salt/ceph/rgw/users/users.d/README $(DESTDIR)/srv/salt/ceph/rgw/users/users.d
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/rgw/files
 	install -m 644 srv/salt/ceph/rgw/files/*.j2 $(DESTDIR)/srv/salt/ceph/rgw/files/
+	install -m 644 srv/salt/ceph/rgw/files/*.yml $(DESTDIR)/srv/salt/ceph/rgw/files/
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/rgw/restart
 	install -m 644 srv/salt/ceph/rgw/restart/default.sls $(DESTDIR)/srv/salt/ceph/rgw/restart
 	install -m 644 srv/salt/ceph/rgw/restart/init.sls $(DESTDIR)/srv/salt/ceph/rgw/restart

--- a/deepsea.spec
+++ b/deepsea.spec
@@ -243,6 +243,7 @@ systemctl try-restart salt-api > /dev/null 2>&1 || :
 %dir /srv/salt/ceph/rgw/keyring
 %dir /srv/salt/ceph/rgw/restart
 %dir /srv/salt/ceph/rgw/users
+%dir /srv/salt/ceph/rgw/users/users.d
 %dir /srv/salt/ceph/stage
 %dir /srv/salt/ceph/stage/all
 %dir /srv/salt/ceph/stage/cephfs
@@ -454,6 +455,7 @@ systemctl try-restart salt-api > /dev/null 2>&1 || :
 %config /srv/salt/ceph/restart/ganesha/*.sls
 %config /srv/salt/ceph/rgw/*.sls
 %config /srv/salt/ceph/rgw/files/*.j2
+%config /srv/salt/ceph/rgw/files/*.yml
 %config /srv/salt/ceph/rgw/key/*.sls
 %config /srv/salt/ceph/rgw/auth/*.sls
 %config /srv/salt/ceph/rgw/buckets/*.sls
@@ -461,6 +463,7 @@ systemctl try-restart salt-api > /dev/null 2>&1 || :
 %config /srv/salt/ceph/rgw/keyring/*.sls
 %config /srv/salt/ceph/rgw/restart/*.sls
 %config /srv/salt/ceph/rgw/users/*.sls
+%config /srv/salt/ceph/rgw/users/users.d/README
 %config /srv/salt/ceph/stage/0
 %config /srv/salt/ceph/stage/1
 %config /srv/salt/ceph/stage/2

--- a/qa/common/rgw.sh
+++ b/qa/common/rgw.sh
@@ -3,13 +3,10 @@
 #
 
 function rgw_demo_users {
-  local RGWSLS=/srv/pillar/ceph/rgw.sls
+  local RGWSLS=/srv/salt/ceph/rgw/users/users.d/users.yml
   cat << EOF >> $RGWSLS
-rgw_configurations:
-  rgw:
-    users:
-      - { uid: "demo", name: "Demo", email: "demo@demo.nil" }
-      - { uid: "demo1", name: "Demo1", email: "demo1@demo.nil" }
+- { uid: "demo", name: "Demo", email: "demo@demo.nil" }
+- { uid: "demo1", name: "Demo1", email: "demo1@demo.nil" }
 EOF
   cat $RGWSLS
 }

--- a/srv/modules/runners/ui_rgw.py
+++ b/srv/modules/runners/ui_rgw.py
@@ -127,7 +127,7 @@ class Radosgw(object):
         for minion in cached:
             if 'rgw_configurations' in cached[minion]:
                 # TODO: where is the master minion when we need it
-                rgw_names = cached[minion]['rgw_configurations'].keys()
+                rgw_names = cached[minion]['rgw_configurations']
 
         conf_file_dir = "/srv/salt/ceph/configuration/files/"
         rgw_conf_files = []
@@ -135,7 +135,6 @@ class Radosgw(object):
             # Check for user created configurations
             pathname = "{}/ceph.conf.d/ceph.conf.{}".format(conf_file_dir, rgw_name)
             if os.path.exists(pathname):
-                print "adding ", pathname
                 rgw_conf_files.append(pathname)
                 continue
 

--- a/srv/pillar/ceph/init.sls
+++ b/srv/pillar/ceph/init.sls
@@ -5,5 +5,4 @@
 
 {% include 'ceph/deepsea_minions.sls' ignore missing %}
 
-{% include 'ceph/rgw.sls' ignore missing %}
 

--- a/srv/salt/ceph/ganesha/files/ganesha.conf.j2
+++ b/srv/salt/ceph/ganesha/files/ganesha.conf.j2
@@ -25,7 +25,7 @@ EXPORT
 
 {% if salt.saltutil.runner('select.minions', cluster='ceph', roles=role) != [] %}
 
-{% for user in salt['rgw.users'](role) %}
+{% for user in salt['rgw.users']() %}
 EXPORT
 {
 	Export_ID={{ loop.index + 1 }};

--- a/srv/salt/ceph/rgw/files/system.user.yml
+++ b/srv/salt/ceph/rgw/files/system.user.yml
@@ -1,0 +1,3 @@
+
+      - { uid: "admin", name: "Admin", email: "admin@admin.nil", system: True }
+

--- a/srv/salt/ceph/rgw/files/users.j2
+++ b/srv/salt/ceph/rgw/files/users.j2
@@ -1,0 +1,12 @@
+
+realm:
+  default:
+{% if salt['file.file_exists']('/srv/salt/ceph/rgw/users/system.user.yml') %}
+{% include "ceph/rgw/users/system.user.yml" %}
+{% else %}
+{% include "ceph/rgw/files/system.user.yml" %}
+{% endif %}
+{% for file in salt['file.find']('/srv/salt/ceph/rgw/users/users.d', type='f', name='*.yml') %}
+{% macro include_indent() %}{% include file %}{% endmacro %}
+{{ include_indent() | indent(6, true) }}
+{% endfor %}

--- a/srv/salt/ceph/rgw/users/users.d/README
+++ b/srv/salt/ceph/rgw/users/users.d/README
@@ -1,0 +1,8 @@
+Initial Users
+
+The /srv/salt/ceph/rgw/files/users.j2 will include any rgw users created in
+this directory.  Add users to one or more files with a yml extension.  For example, create two demo users by adding these entries to a file or individual files.
+
+- { uid: "demo", name: "Demo", email: "demo@demo.nil" }
+- { uid: "demo1", name: "Demo1", email: "demo1@demo.nil" }
+


### PR DESCRIPTION
Users are not tied to configurations (or zones).  This has been inherently wrong.   Users can optionally be maintained under .../ceph/rgw/users/users.d with this change.  The /srv/pillar/ceph/rgw.sls is redundant with the structure under /srv/pillar/ceph/stack.  The rgw_configurations has become a simple array and can be maintained in either the global.yml or ceph/cluster.yml.

Fixes: https://github.com/SUSE/DeepSea/issues/314

Signed-off-by: Eric Jackson <ejackson@suse.com>