### PR TITLE
Echo validation messages to log

### DIFF
--- a/srv/modules/runners/validate.py
+++ b/srv/modules/runners/validate.py
@@ -43,13 +43,20 @@ class bcolors:
 class PrettyPrinter:
 
     def add(self, name, passed, errors, warnings):
+        format_str=""
         # Need to make colors optional, but looks better currently
         for attr in passed.keys():
-            print "{:25}: {}{}{}{}".format(attr, bcolors.BOLD, bcolors.OKGREEN, passed[attr], bcolors.ENDC)
+            format_str="{:25}: {}{}{}{}".format(attr, bcolors.BOLD, bcolors.OKGREEN, passed[attr], bcolors.ENDC)
+            log.info("VALIDATE " + format_str)
+            print format_str
         for attr in errors.keys():
-            print "{:25}: {}{}{}{}".format(attr, bcolors.BOLD, bcolors.FAIL, errors[attr], bcolors.ENDC)
+            format_str="{:25}: {}{}{}{}".format(attr, bcolors.BOLD, bcolors.FAIL, errors[attr], bcolors.ENDC)
+            log.error("VALIDATE " + format_str)
+            print format_str
         for attr in warnings.keys():
-            print "{:25}: {}{}{}{}".format(attr, bcolors.BOLD, bcolors.WARNING, warnings[attr], bcolors.ENDC)
+            format_str="{:25}: {}{}{}{}".format(attr, bcolors.BOLD, bcolors.WARNING, warnings[attr], bcolors.ENDC)
+            log.warning("VALIDATE " + format_str)
+            print format_str
 
     def print_result(self):
         pass


### PR DESCRIPTION
Don't know exactly why (presumably the runner is a subprocess and its stdout is
not captured), but the validation report does not appear in the teuthology log.

Not being able to see the validation messages makes it hard to debug test
failures. Therefore, echo these messages to the logger at the appropriate
severity level.

Fixes: https://github.com/SUSE/DeepSea/issues/611
Signed-off-by: Nathan Cutler <ncutler@suse.com>