### PR TITLE
Properly handle bluestore args

### DIFF
--- a/srv/salt/_modules/osd.py
+++ b/srv/salt/_modules/osd.py
@@ -1782,11 +1782,13 @@ def is_prepared(device):
     """
     config = OSDConfig(device)
     osdc = OSDCommands(config)
+    if osdc.highest_partition(readlink(device), 'lockbox') != 0:
+        log.debug("Found encrypted OSD {}".format(device))
+        return True
     partition = osdc.highest_partition(readlink(device), 'osd')
     if partition == 0:
         log.debug("Do not know which partition to check on {}".format(device))
         return False
-
     log.debug("Checking partition {} on device {}".format(partition, device))
     if osdc.is_partition('osd', config.device, partition) and _fsck(config.device, partition):
         return True

--- a/srv/salt/_modules/osd.py
+++ b/srv/salt/_modules/osd.py
@@ -1085,7 +1085,7 @@ class OSDCommands(object):
 
             # DB cornercase with sizes
             if self.osd.db and self.osd.db_size and self.osd.db != self.osd.device:
-                partition = self.highest_partition(self.osd.wal, 'db')
+                partition = self.highest_partition(self.osd.db, 'db')
                 if partition:
                     args += "--block.db {}{} ".format(self.osd.db, partition)
                 else:

--- a/srv/salt/_modules/osd.py
+++ b/srv/salt/_modules/osd.py
@@ -1098,10 +1098,11 @@ class OSDCommands(object):
                 args += "--block.db {} ".format(self.osd.db)
 
         if self.osd.encryption and (self.osd.wal_size or self.osd.db_size):
-            log.warn("""Your specified wal/db_sizes will not be respected. 
-                           Configure the default sizes via the ceph.conf with
-                           bluestore block db size = size
-                           bluestore block wal size = size""")
+            log.warn(""" The --wal-size and --db-size options are not supported for encrypted OSDs, so
+                         the values you specified will be ignored. Please specify the WAL and DB sizes
+                         via ceph.conf with:
+                                            bluestore block db size = size
+                                            bluestore block wal size = size """)
 
         if self.osd.encryption:
             if self.osd.db:

--- a/tests/unit/_modules/test_osd.py
+++ b/tests/unit/_modules/test_osd.py
@@ -1225,6 +1225,43 @@ class TestOSDCommands():
 
     @mock.patch('srv.salt._modules.osd.OSDCommands.is_partition')
     @mock.patch('srv.salt._modules.osd.glob')
+    def test_highest_partition_encrypted(self, glob_mock, part_mock, osdc_o):
+        """
+        Given there is a device
+        And it's encrypted
+        And the device has partitions & a lockbox
+        And is_partition() returns True
+        Expect to return 5 (lockboxes are always on 5)
+        """
+        kwargs = {'device': '/dev/vdb'}
+        glob_mock.glob.return_value = ['/dev/vdb1', '/dev/vdb2', '/dev/vdb5']
+        part_mock.return_value = True
+        osd_config = OSDConfig(**kwargs)
+        obj = osdc_o(osd_config)
+        ret = obj.highest_partition(osd_config.device, 'lockbox')
+        assert ret == '5'
+
+    @mock.patch('srv.salt._modules.osd.OSDCommands.is_partition')
+    @mock.patch('srv.salt._modules.osd.glob')
+    def test_highest_partition_encrypted_nvme(self, glob_mock, part_mock, osdc_o):
+        """
+        Given there is a device
+        And it's encrypted
+        And the device has partitions & a lockbox
+        And is_partition() returns True
+        And it's a nvme
+        Expect to return 5 (lockboxes are always on 5)
+        """
+        kwargs = {'device': '/dev/nvme1n1'}
+        glob_mock.glob.return_value = ['/dev/nvme1n1p1', '/dev/nvme1n1p2', '/dev/nvme1n1p5']
+        part_mock.return_value = True
+        osd_config = OSDConfig(**kwargs)
+        obj = osdc_o(osd_config)
+        ret = obj.highest_partition(osd_config.device, 'lockbox')
+        assert ret == 'p5'
+
+    @mock.patch('srv.salt._modules.osd.OSDCommands.is_partition')
+    @mock.patch('srv.salt._modules.osd.glob')
     def test_highest_partition_no_nvme(self, glob_mock, part_mock, osdc_o):
         """
         Given there is a device


### PR DESCRIPTION
Issues:

* Encryption:
ceph-disk expects the raw device and handles the creation
of the next higest partition in addition to encrypting
the wal/db/device.

* Bluestore deployment:
refer to #615 

Also refactoring the decision paths in `_bluestore_args()`.

resolves #615 

Tested:

* wal/db defined / no size specified / unencrypted
* wal/db defined  no size specified / encrypted
* wal/db defined / size specified / unencrypted
* wal/db defined / size specified / encrypted
* no wal/db defined / no size specified / unencrypted
* no wal/db defined  no size specified / encrypted
* no wal/db defined / size specified / unencrypted
* no wal/db defined / size specified / encrypted

Signed-off-by: Joshua Schmid <jschmid@suse.de>

Tackles: https://github.com/SUSE/DeepSea/issues/755
EDIT: tests can be found in #623 