### PR TITLE
rgw: ssl: make pem files readable only to ceph user & group

### DIFF
--- a/qa/common/common.sh
+++ b/qa/common/common.sh
@@ -440,3 +440,18 @@ EOF
   # FIXME: assert script not running on the iSCSI gateway node
   _run_test_script_on_node $TESTSCRIPT $CLIENTNODE
 }
+
+function validate_rgw_cert_perm {
+    local TESTSCRIPT=/tmp/test_rados_put.sh
+    local RGWNODE=$(_first_x_node rgw-ssl)
+    cat << 'EOF' > $TESTSCRIPT
+set -ex
+trap 'echo "Result: NOT_OK"' ERR
+RGW_PEM=/etc/ceph/rgw.pem
+test -f "$RGW_PEM"
+test "$(stat -c'%U' $RGW_PEM)" == "ceph"
+test "$(stat -c'%G' $RGW_PEM)" == "ceph"
+test "$(stat -c'%a' $RGW_PEM)" -eq 600
+EOF
+    _run_test_script_on_node $TESTSCRIPT $RGWNODE
+}

--- a/qa/suites/basic/health-rgw-ssl.sh
+++ b/qa/suites/basic/health-rgw-ssl.sh
@@ -73,5 +73,6 @@ ceph_cluster_status
 ceph_health_test
 rgw_curl_test
 rgw_curl_test_ssl
+validate_rgw_cert_perm
 
 echo "OK"

--- a/srv/salt/ceph/rgw/cert/default.sls
+++ b/srv/salt/ceph/rgw/cert/default.sls
@@ -3,3 +3,6 @@ deploy the rgw.pem file:
   file.managed:
     - name: /etc/ceph/rgw.pem
     - source: salt://ceph/rgw/cert/rgw.pem
+    - user: ceph
+    - group: ceph
+    - mode: 600


### PR DESCRIPTION
Fixes: https://github.com/SUSE/DeepSea/issues/636

Reported-by: Martin Weiss <mweiss@suse.com>
Signed-off-by: Abhishek Lekshmanan <abhishek@suse.com>
