### PR TITLE
RGW usage log is not enabled by default (OP-2663)

### DIFF
--- a/srv/salt/ceph/configuration/files/rgw-ssl.conf
+++ b/srv/salt/ceph/configuration/files/rgw-ssl.conf
@@ -1,3 +1,4 @@
 [client.{{ client }}]
 rgw frontends = "civetweb port=443s ssl_certificate=/etc/ceph/rgw.pem"
 rgw dns name = {{ fqdn }}
+rgw enable usage log = true

--- a/srv/salt/ceph/configuration/files/rgw.conf
+++ b/srv/salt/ceph/configuration/files/rgw.conf
@@ -1,3 +1,4 @@
 [client.{{ client }}]
 rgw frontends = "civetweb port=80"
 rgw dns name = {{ fqdn }}
+rgw enable usage log = true


### PR DESCRIPTION
Enable the RGW usage logging to be able to display statistics in the Grafana RGW dashboard.
https://tracker.openattic.org/browse/OP-2663

Signed-off-by: Volker Theile <vtheile@suse.com>