### PR TITLE
modules/cephprocess: support rgw_configurations

### DIFF
--- a/srv/salt/_modules/cephprocesses.py
+++ b/srv/salt/_modules/cephprocesses.py
@@ -31,6 +31,10 @@ def check(**kwargs):
     running = True
     results = {}
 
+    if 'rgw_configurations' in __pillar__:
+        for rgw_config in __pillar__['rgw_configurations']:
+            processes[rgw_config] = ['radosgw']
+
     if 'roles' in __pillar__:
         for role in kwargs.get('roles', __pillar__['roles']):
             for process in processes[role]:


### PR DESCRIPTION
currently running stage0 after having an install with rgw_configurations
would fail because cephprocesses wouldn't have the relevant keys for
rgw_configurations other than the default. Solve this by adding all the
keys of rgw_configurations which correspond to the role name to the
process dictionary

Fixes: https://github.com/SUSE/DeepSea/issues/647
Signed-off-by: Abhishek Lekshmanan <abhishek@suse.com>