### PR TITLE
Refactor RGW Prometheus exporter to use node_exporter (OP-2678)

### DIFF
--- a/srv/salt/ceph/monitoring/prometheus/exporters/ceph_rgw_exporter.sls
+++ b/srv/salt/ceph/monitoring/prometheus/exporters/ceph_rgw_exporter.sls
@@ -12,30 +12,9 @@ install_rgw_exporter:
     - source: salt://ceph/monitoring/prometheus/exporters/files/ceph_rgw.py
     - makedirs: True
 
-create_rgw_exporter_service_unit:
-  file.managed:
-    - name: /usr/lib/systemd/system/prometheus-ceph_rgw_exporter.service
-    - mode: 644
-    - contents: |
-        [Unit]
-        Description=Prometheus exporter for Ceph Object Gateway metrics
-
-        [Service]
-        Restart=always
-        ExecStart=/var/lib/prometheus/node-exporter/ceph_rgw.py
-        ExecReload=/bin/kill -HUP $MAINPID
-        TimeoutStopSec=20s
-        SendSIGKILL=no
-
-        [Install]
-        WantedBy=multi-user.target
-
-start_rgw_exporter_service:
-  module.run:
-    - name: service.systemctl_reload
-    - onchanges:
-      - file: create_rgw_exporter_service_unit
-  service.running:
-    - name: prometheus-ceph_rgw_exporter
-    - enable: True
+install_rgw_exporter_cron_job:
+  cron.present:
+    - name: '/var/lib/prometheus/node-exporter/ceph_rgw.py > /var/lib/prometheus/node-exporter/ceph_rgw.prom 2> /dev/null'
+    - minute: '*/5'
+    - identifier: 'Prometheus rgw_exporter cron job'
 {% endif %}

--- a/srv/salt/ceph/monitoring/prometheus/exporters/ceph_rgw_exporter.sls
+++ b/srv/salt/ceph/monitoring/prometheus/exporters/ceph_rgw_exporter.sls
@@ -1,4 +1,3 @@
-{% if 'rgw' in salt['pillar.get']('roles') %}
 install_package:
   pkg.installed:
     - name: python-prometheus-client
@@ -17,4 +16,3 @@ install_rgw_exporter_cron_job:
     - name: '/var/lib/prometheus/node-exporter/ceph_rgw.py > /var/lib/prometheus/node-exporter/ceph_rgw.prom 2> /dev/null'
     - minute: '*/5'
     - identifier: 'Prometheus rgw_exporter cron job'
-{% endif %}

--- a/srv/salt/ceph/monitoring/prometheus/files/prometheus.yml.j2
+++ b/srv/salt/ceph/monitoring/prometheus/files/prometheus.yml.j2
@@ -18,10 +18,3 @@ scrape_configs:
   - job_name: 'node-exporter'
     file_sd_configs:
       - files: [ '/etc/prometheus/ses_nodes/*.yml' ]
-
-  - job_name: 'ceph-rgw-exporter'
-    static_configs:
-      - targets:
-        {% for fqdn in salt.saltutil.runner('select.minions', cluster='ceph', roles='rgw') -%}
-        - '{{ fqdn }}:9156'
-        {% endfor -%}

--- a/srv/salt/ceph/rescind/rgw/default.sls
+++ b/srv/salt/ceph/rescind/rgw/default.sls
@@ -1,7 +1,4 @@
 
-rgw nop:
-  test.nop
-
 {% if 'master' not in salt['pillar.get']('roles') and
       'rgw' not in salt['pillar.get']('roles') %}
 
@@ -15,7 +12,11 @@ uninstall ceph-radosgw:
   pkg.removed:
     - name: ceph-radosgw
 
-include:
-- .keyring
-- .monitoring
 {% endif %}
+
+include:
+{% if 'master' not in salt['pillar.get']('roles') and
+      'rgw' not in salt['pillar.get']('roles') %}
+  - .keyring
+{% endif %}
+  - .monitoring

--- a/srv/salt/ceph/rescind/rgw/default.sls
+++ b/srv/salt/ceph/rescind/rgw/default.sls
@@ -1,4 +1,7 @@
 
+rgw nop:
+  test.nop
+
 {% if 'master' not in salt['pillar.get']('roles') and
       'rgw' not in salt['pillar.get']('roles') %}
 
@@ -12,11 +15,7 @@ uninstall ceph-radosgw:
   pkg.removed:
     - name: ceph-radosgw
 
-{% endif %}
-
 include:
-{% if 'master' not in salt['pillar.get']('roles') and
-      'rgw' not in salt['pillar.get']('roles') %}
   - .keyring
+
 {% endif %}
-  - .monitoring

--- a/srv/salt/ceph/rescind/rgw/monitoring/default.sls
+++ b/srv/salt/ceph/rescind/rgw/monitoring/default.sls
@@ -1,3 +1,7 @@
+monitoring_nop:
+  test.nop
+
+{% if 'rgw' not in salt['pillar.get']('roles') %}
 
 remove_rgw_exporter_cron_job:
   cron.absent:
@@ -11,4 +15,6 @@ remove_rgw_exporter:
 uninstall_package:
   pkg.removed:
     - name: python-prometheus-client
+{% endif %}
+
 {% endif %}

--- a/srv/salt/ceph/rescind/rgw/monitoring/default.sls
+++ b/srv/salt/ceph/rescind/rgw/monitoring/default.sls
@@ -1,12 +1,7 @@
 
-stop_rgw_exporter_service:
-  service.dead:
-    - name: prometheus-ceph_rgw_exporter
-    - enable: False
-
-remove_rgw_exporter_service_unit:
-  file.absent:
-   - name: /usr/lib/systemd/system/prometheus-ceph_rgw_exporter.service
+remove_rgw_exporter_cron_job:
+  cron.absent:
+    - identifier: 'Prometheus rgw_exporter cron job'
 
 remove_rgw_exporter:
   file.absent:

--- a/srv/salt/ceph/rescind/rgw/monitoring/default.sls
+++ b/srv/salt/ceph/rescind/rgw/monitoring/default.sls
@@ -1,20 +1,17 @@
-monitoring_nop:
-  test.nop
-
-{% if 'rgw' not in salt['pillar.get']('roles') %}
-
 remove_rgw_exporter_cron_job:
   cron.absent:
     - identifier: 'Prometheus rgw_exporter cron job'
 
 remove_rgw_exporter:
   file.absent:
-    - name: /var/lib/prometheus/node-exporter/ceph_rgw.py
+    - names:
+      - /var/lib/prometheus/node-exporter/ceph_rgw.py
+      - /var/lib/prometheus/node-exporter/ceph_rgw.prom
 
 {% if 'python-prometheus-client' in salt['pkg.list_pkgs']() %}
+
 uninstall_package:
   pkg.removed:
     - name: python-prometheus-client
-{% endif %}
 
 {% endif %}

--- a/srv/salt/ceph/stage/deploy/default.sls
+++ b/srv/salt/ceph/stage/deploy/default.sls
@@ -99,12 +99,6 @@ setup ceph exporter:
     - tgt_type: compound
     - sls: ceph.monitoring.prometheus.exporters.ceph_exporter
 
-setup ceph rgw exporter:
-  salt.state:
-    - tgt: "{{ salt.saltutil.runner('select.one_minion', cluster='ceph', roles='rgw') }}"
-    - tgt_type: compound
-    - sls: ceph.monitoring.prometheus.exporters.ceph_rgw_exporter
-
 setup rbd exporter:
   salt.state:
     - tgt: {{ salt['pillar.get']('master_minion') }}

--- a/srv/salt/ceph/stage/deploy/default.sls
+++ b/srv/salt/ceph/stage/deploy/default.sls
@@ -101,7 +101,7 @@ setup ceph exporter:
 
 setup ceph rgw exporter:
   salt.state:
-    - tgt: 'I@roles:rgw and I@cluster:ceph'
+    - tgt: "{{ salt.saltutil.runner('select.one_minion', cluster='ceph', roles='rgw') }}"
     - tgt_type: compound
     - sls: ceph.monitoring.prometheus.exporters.ceph_rgw_exporter
 

--- a/srv/salt/ceph/stage/radosgw/default.sls
+++ b/srv/salt/ceph/stage/radosgw/default.sls
@@ -20,9 +20,11 @@ rgw users:
     - sls: ceph.rgw
 {% endfor %}
 
+# Install the Prometheus RGW exporter on the master node because it
+# requires the admin keyring.
 setup prometheus rgw exporter:
   salt.state:
-    - tgt: "{{ salt.saltutil.runner('select.one_minion', cluster='ceph', roles='rgw') }}"
+    - tgt: {{ salt['pillar.get']('master_minion') }}
     - tgt_type: compound
     - sls: ceph.monitoring.prometheus.exporters.ceph_rgw_exporter
 

--- a/srv/salt/ceph/stage/radosgw/default.sls
+++ b/srv/salt/ceph/stage/radosgw/default.sls
@@ -20,6 +20,12 @@ rgw users:
     - sls: ceph.rgw
 {% endfor %}
 
+setup prometheus rgw exporter:
+  salt.state:
+    - tgt: "{{ salt.saltutil.runner('select.one_minion', cluster='ceph', roles='rgw') }}"
+    - tgt_type: compound
+    - sls: ceph.monitoring.prometheus.exporters.ceph_rgw_exporter
+
 {% for config in salt['pillar.get']('rgw_configurations', [ 'rgw' ]) %}
 {% if salt.saltutil.runner('changed.config', service=config) == True %}
 

--- a/srv/salt/ceph/stage/removal/default-remove.sls
+++ b/srv/salt/ceph/stage/removal/default-remove.sls
@@ -65,3 +65,15 @@ remove openattic:
     - tgt: {{ salt['pillar.get']('master_minion') }}
     - tgt_type: compound
     - sls: ceph.remove.openattic
+
+{% if (salt.saltutil.runner('select.minions', cluster='ceph', roles='rgw') == []) and
+      (salt.saltutil.runner('select.minions', cluster='ceph', roles='rgw_configurations') == []) %}
+
+# Remove the Prometheus RGW exporter if no 'rgw' node is configured.
+remove prometheus rgw exporter:
+  salt.state:
+    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt_type: compound
+    - sls: ceph.rescind.rgw.monitoring
+
+{% endif %}

--- a/srv/salt/ceph/stage/removal/default.sls
+++ b/srv/salt/ceph/stage/removal/default.sls
@@ -53,3 +53,15 @@ remove openattic:
     - tgt: {{ salt['pillar.get']('master_minion') }}
     - tgt_type: compound
     - sls: ceph.remove.openattic
+
+{% if (salt.saltutil.runner('select.minions', cluster='ceph', roles='rgw') == []) and
+      (salt.saltutil.runner('select.minions', cluster='ceph', roles='rgw_configurations') == []) %}
+
+# Remove the Prometheus RGW exporter if no 'rgw' node is configured.
+remove prometheus rgw exporter:
+  salt.state:
+    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt_type: compound
+    - sls: ceph.rescind.rgw.monitoring
+
+{% endif %}


### PR DESCRIPTION
https://tracker.openattic.org/browse/OP-2678

- Do not run the Prometheus RGW exporter as a webserver
- Remove systemd unit to handle the RGW exporter
- Introduce cron job to execute the RGW exporter every 5 minutes and write the content to a *.prom file
- Use node_exporter to process the metrics
- RGW exporter: Create a new registry, otherwise unwanted default collectors are added automatically
- Relocate installation of Prometheus RGW exporter from ceph.stage.deploy to ceph.stage.radosgw
- The Prometheus RGW exporter will be installed on the 'master' node if there is at least one 'rgw' node. The role 'master' takes care that the required admin keyring is installed which is required by the radosgw-admin CLI tool that is used by the exporter script. See https://bugzilla.suse.com/show_bug.cgi?id=1059621.

Signed-off-by: Volker Theile <vtheile@suse.com>