### PR TITLE
validate: log validation results at info severity

### DIFF
--- a/qa/common/common.sh
+++ b/qa/common/common.sh
@@ -8,6 +8,9 @@ source $BASEDIR/common/json.sh
 source $BASEDIR/common/rbd.sh
 source $BASEDIR/common/rgw.sh
 
+export DEV_ENV="true"         # FIXME set only when TOTALNODES < 4
+export INTEGRATION_ENV="true" # since we can't rely on DEV_ENV always being set
+
 # determine hostname of Salt Master
 MASTER_MINION_SLS=/srv/pillar/ceph/master_minion.sls
 if test -s $MASTER_MINION_SLS ; then
@@ -35,8 +38,6 @@ else
     echo "Cannot find salt-key. Is Salt installed? Is this running on the Salt Master?"
     exit 1
 fi
-
-export DEV_ENV='true'
 
 
 #

--- a/srv/modules/runners/validate.py
+++ b/srv/modules/runners/validate.py
@@ -47,15 +47,15 @@ class PrettyPrinter:
         # Need to make colors optional, but looks better currently
         for attr in passed.keys():
             format_str="{:25}: {}{}{}{}".format(attr, bcolors.BOLD, bcolors.OKGREEN, passed[attr], bcolors.ENDC)
-            log.info("VALIDATE " + format_str)
+            log.info("VALIDATE PASSED  " + format_str)
             print format_str
         for attr in errors.keys():
             format_str="{:25}: {}{}{}{}".format(attr, bcolors.BOLD, bcolors.FAIL, errors[attr], bcolors.ENDC)
-            log.error("VALIDATE " + format_str)
+            log.info("VALIDATE ERROR   " + format_str)
             print format_str
         for attr in warnings.keys():
             format_str="{:25}: {}{}{}{}".format(attr, bcolors.BOLD, bcolors.WARNING, warnings[attr], bcolors.ENDC)
-            log.warning("VALIDATE " + format_str)
+            log.info("VALIDATE WARNING " + format_str)
             print format_str
 
     def print_result(self):


### PR DESCRIPTION
Before we were emitting log messages at "warning" and "error" severity, which
meant they were appearing on the screen, causing duplicate messages.