### PR TITLE
Realize DEV_ENV=true also in case there is exactly one minion

### DIFF
--- a/srv/modules/runners/validate.py
+++ b/srv/modules/runners/validate.py
@@ -170,7 +170,7 @@ class Validate(object):
     def __dev_env(self):
         if 'DEV_ENV' in os.environ:
             return os.environ['DEV_ENV'].lower() != 'false'
-        elif len(self.data.keys()) > 1:
+        elif len(self.data.keys()) >= 1:
             any_minion = self.data.keys()[0]
             if 'DEV_ENV' in self.data[any_minion]:
                 return self.data[any_minion]['DEV_ENV']


### PR DESCRIPTION
In case there is only one single minion (test-environment with everything on a single server) - the result of en(self.data.keys()) is 1 and with that this is not greater than 1 and DEV_ENV=true is not detected. Changing to ">=" to allow also 1.