### PR TITLE
Add openattic to list of checked processes

### DIFF
--- a/srv/salt/_modules/cephprocesses.py
+++ b/srv/salt/_modules/cephprocesses.py
@@ -26,6 +26,7 @@ def check(**kwargs):
                  'rgw': ['radosgw'],
                  'ganesha': ['ganesha.nfsd', 'rpcbind', 'rpc.statd'],
                  'admin': [],
+                 'openattic': ['openattic'],
                  'master': []}
 
     running = True


### PR DESCRIPTION
EDIT: moved rgw-ssl role addition to #680

~Furthermore~ we don't respect openattic at all although I was pretty sure we had that in. Did i miss the reason to drop it?


Signed-off-by: Joshua Schmid <jschmid@suse.de>