### PR TITLE
Run stage.0 after deploying as bevahiour changes

### DIFF
--- a/qa/suites/basic/health-igw.sh
+++ b/qa/suites/basic/health-igw.sh
@@ -72,5 +72,6 @@ ceph_health_test
 iscsi_kludge # see bsc#1049669
 igw_info
 iscsi_mount_and_sanity_test
+run_stage_0 "$CLI"
 
 echo "OK"

--- a/qa/suites/basic/health-mds.sh
+++ b/qa/suites/basic/health-mds.sh
@@ -70,5 +70,6 @@ run_stage_4 "$CLI"
 ceph_cluster_status
 ceph_health_test
 cephfs_mount_and_sanity_test
+run_stage_0 "$CLI"
 
 echo "OK"

--- a/qa/suites/basic/health-nfs-ganesha.sh
+++ b/qa/suites/basic/health-nfs-ganesha.sh
@@ -121,5 +121,6 @@ for v in "" "3" "4" ; do
     nfs_ganesha_umount
     sleep 10
 done
+run_stage_0 "$CLI"
 
 echo "OK"

--- a/qa/suites/basic/health-ok-encrypted.sh
+++ b/qa/suites/basic/health-ok-encrypted.sh
@@ -68,5 +68,6 @@ run_stage_3 "$CLI"
 ceph_cluster_status
 ceph_health_test
 rados_write_test
+run_stage_0 "$CLI"
 
 echo "OK"

--- a/qa/suites/basic/health-ok.sh
+++ b/qa/suites/basic/health-ok.sh
@@ -70,5 +70,6 @@ ceph_log_grep_enoent_eaccess
 test_systemd_ceph_osd_target_wants
 rados_write_test
 ceph_version_test
+run_stage_0 "$CLI"
 
 echo "OK"

--- a/qa/suites/basic/health-openattic.sh
+++ b/qa/suites/basic/health-openattic.sh
@@ -76,5 +76,6 @@ rgw_curl_test
 rgw_user_and_bucket_list
 ceph_health_test
 ceph_version_test
+run_stage_0 "$CLI"
 
 echo "OK"

--- a/qa/suites/basic/health-rgw.sh
+++ b/qa/suites/basic/health-rgw.sh
@@ -92,5 +92,6 @@ fi
 rgw_user_and_bucket_list
 rgw_validate_demo_users
 ceph_health_test
+run_stage_0 "$CLI"
 
 echo "OK"


### PR DESCRIPTION
Stage.0 behaves differently (executes updates sequentially and checks for cluster health and service status). To increase the exercised codepath we should run this _after_ the initial deployment.

Signed-off-by: Joshua Schmid <jschmid@suse.de>