### PR TITLE
validate: openattic validation succeeds for non 80 ports

### DIFF
--- a/srv/modules/runners/validate.py
+++ b/srv/modules/runners/validate.py
@@ -600,7 +600,7 @@ class Validate(object):
                 'openattic' in self.data[node]['roles'] and
                 'rgw' in self.data[node]['roles']):
                 # Would use file.contains if it supported '='
-                result = local.cmd(node, 'file.contains_regex', [ '/etc/ceph/ceph.conf', 'port\=80'], expr_form="glob")
+                result = local.cmd(node, 'file.search', [ '/etc/ceph/ceph.conf', r'port\=80\b'], expr_form="glob")
                 if result[node]:
                     msg = "rgw port conflicts with openATTIC on {} - check ceph.conf".format(node)
                     self.errors.setdefault('openattic', []).append(msg)


### PR DESCRIPTION
Use file.search, which supports a regex (since file.contains_regex was
deprecated), and only match port=80, earlier we use to match port=8000
which cause issue when oa and rgw are colocated. This still fails in an
obnoxious case when someone tries ssl over port 80, since 80s would
still not match, and pass validate, and would try to install oa and
rgw-ssl with the same port 80 but 80s is a source of trouble for
many other cases anyway

Fixes: https://github.com/SUSE/DeepSea/issues/652
Reported-by: Martin Weiss <mweiss@suse.com>
Signed-off-by: Abhishek Lekshmanan <abhishek@suse.com>