### PR TITLE
validate: detect DEV_ENV=true from pillar in single minion case

### DIFF
--- a/srv/modules/runners/validate.py
+++ b/srv/modules/runners/validate.py
@@ -170,7 +170,7 @@ class Validate(object):
     def __dev_env(self):
         if 'DEV_ENV' in os.environ:
             return os.environ['DEV_ENV'].lower() != 'false'
-        elif len(self.data.keys()) > 1:
+        elif self.data:
             any_minion = self.data.keys()[0]
             if 'DEV_ENV' in self.data[any_minion]:
                 return self.data[any_minion]['DEV_ENV']


### PR DESCRIPTION
In case there is only one single minion (test-environment with everything on a
single server) and DEV_ENV=true is being set in the pillar, the result of
len(self.data.keys()) is 1 and with that this is not greater than 1 and
DEV_ENV=true is not detected.

Reported-by: Martin Weiss <Martin.Weiss@suse.com>
Signed-off-by: Nathan Cutler <ncutler@suse.com>