### PR TITLE
Add rgw-ssl to list of checked processes

### DIFF
--- a/srv/salt/_modules/cephprocesses.py
+++ b/srv/salt/_modules/cephprocesses.py
@@ -26,6 +26,7 @@ def check(**kwargs):
                  'rgw': ['radosgw'],
                  'ganesha': ['ganesha.nfsd', 'rpcbind', 'rpc.statd'],
                  'admin': [],
+                 'rgw-ssl': ['radosgw'],
                  'master': []}
 
     running = True


### PR DESCRIPTION
In a rgw-ssl deployment we define an actual[ 'role-rgw-ssl' ](https://github.com/SUSE/DeepSea/blob/1fcfea497493c9b3931dd8858c3d8345291dcb5e/qa/common/common.sh#L251)in the policy.cfg & pillar.

We already do add custom rgw_configurations [here](https://github.com/SUSE/DeepSea/blob/master/srv/salt/_modules/cephprocesses.py#L34) but iterate over all [roles](https://github.com/SUSE/DeepSea/blob/master/srv/salt/_modules/cephprocesses.py#L34) resulting in a key error.


Signed-off-by: Joshua Schmid <jschmid@suse.de>