### PR TITLE
filesystem inspection and btrfs subvol creation/migration

### DIFF
--- a/deepsea.spec
+++ b/deepsea.spec
@@ -152,6 +152,7 @@ systemctl try-restart salt-api > /dev/null 2>&1 || :
 %dir /srv/salt/ceph/migrate/nodes
 %dir /srv/salt/ceph/migrate/osds
 %dir /srv/salt/ceph/migrate/policy
+%dir /srv/salt/ceph/migrate/subvolume
 %dir /srv/salt/ceph/mines
 %dir /srv/salt/ceph/mines/files
 %dir /srv/salt/ceph/mon
@@ -381,6 +382,7 @@ systemctl try-restart salt-api > /dev/null 2>&1 || :
 %config /srv/salt/ceph/migrate/nodes/*.sls
 %config /srv/salt/ceph/migrate/osds/*.sls
 %config /srv/salt/ceph/migrate/policy/*.sls
+%config /srv/salt/ceph/migrate/subvolume/*.sls
 %config /srv/salt/ceph/mines/*.sls
 %config /srv/salt/ceph/mines/files/*.conf
 %config /srv/salt/ceph/mon/*.sls

--- a/man/deepsea.commands.7
+++ b/man/deepsea.commands.7
@@ -104,6 +104,9 @@ salt-run state.orch ceph.migrate.osds
 .RS
 .RE
 salt-run state.orch ceph.migrate.policy
+.RS
+.RE
+salt-run state.orch ceph.migrate.subvolume
 .PP
 salt-run state.orch ceph.purge
 .PP

--- a/man/deepsea.commands.7
+++ b/man/deepsea.commands.7
@@ -771,6 +771,17 @@ salt-run filequeue.remove
 .RE
 salt-run filequeue.vacate
 .PP
+salt-run fs.inspect_var
+.RS
+.RE
+salt-run fs.create_var
+.RS
+.RE
+salt-run fs.migrate_var
+.RS
+.RE
+salt-run fs.correct_var_attrs
+.PP
 salt-run minions.ready
 .RS
 .RE

--- a/man/deepsea.commands.7
+++ b/man/deepsea.commands.7
@@ -721,7 +721,7 @@ salt-run benchmark.run
 .PP
 salt-run cephops.set_noout
 .PP
-salt-run cephprocesses.check
+salt-run cephprocesses.check [results=True|False]
 .RS
 .RE
 salt-run cephprocesses.mon

--- a/man/deepsea.commands.7
+++ b/man/deepsea.commands.7
@@ -530,6 +530,56 @@ salt '*' cephprocesses.check
 .RE
 salt '*' cephprocesses.wait
 .PP
+salt '*' fs.btrfs_get_mountpoints_of_subvol subvol='@/var/lib/ceph'
+.RS
+.RE
+salt '*' fs.btrfs_get_default_subvol path='/var/lib/ceph'
+.RS
+.RE
+salt '*' fs.btrfs_subvol_exists subvol='@/var/lib/ceph'
+.RS
+.RE
+salt '*' fs.btrfs_create_subvol subvol='@/var/lib/ceph'
+.RS
+.RE
+salt '*' fs.btrfs_mount_subvol subvol='@/var/lib/ceph' path='/var/lib/ceph'
+.RS
+.RE
+salt '*' fs.get_attrs path='/var/lib/ceph'
+.RS
+.RE
+salt '*' fs.add_attrs path='/var/lib/ceph' attrs='C' [rec=True|False] [omit='/var/lib/ceph/osd']
+.RS
+.RE
+salt '*' fs.remove_attrs path='/var/lib/ceph' attrs='C' [rec=True|False] [omit='/var/lib/ceph/osd']
+.RS
+.RE
+salt '*' fs.set_attrs path='/var/lib/ceph' attrs='C' [rec=True|False] [omit='/var/lib/ceph/osd']
+.RS
+.RE
+salt '*' fs.get_mountpoint_opts mountpoint='/var/lib/ceph'
+.RS
+.RE
+salt '*' fs.get_mountpoint path='/var/lib/ceph'
+.RS
+.RE
+salt '*' fs.get_mount_info path='/var/lib/ceph'
+.RS
+.RE
+salt '*' fs.get_uuid dev_path='/dev/sda1'
+.RS
+.RE
+salt '*' fs.get_device_info mountpoint='/'
+.RS
+.RE
+salt '*' fs.instantiate_btrfs_subvolume subvol='@/var/lib/ceph' path='/var/lib/ceph'
+.RS
+.RE
+salt '*' fs.migrate_path_to_btrfs_subvolume subvol='@/var/lib/ceph' path='/var/lib/ceph'
+.RS
+.RE
+salt '*' fs.inspect_path path='/var/lib/ceph'
+.PP
 salt 'ganehsa*' ganesha.configurations
 .RS
 .RE

--- a/srv/modules/runners/fs.py
+++ b/srv/modules/runners/fs.py
@@ -1,0 +1,420 @@
+# -*- coding: utf-8 -*-
+
+# ------------------------------------------------------------------------------
+# fs.py
+#
+# Runner for performing filesystem operations.
+# Current task is to create/migrate /var/lib/ceph to btrfs subvolumes if applicable.
+#
+# ------------------------------------------------------------------------------
+
+import salt.client
+import salt.utils.error
+import logging
+import pprint
+import deepsea_minions
+import fs
+
+import os
+import sys
+
+log = logging.getLogger(__name__)
+
+class Mount(object):
+    """
+    Structure representing the mount information for a given path.
+    """
+    def __init__(self, mountpoint, opts):
+	self.mountpoint = mountpoint
+	# List of mount opts in the form [ x, y, ... , {k : v}, ... ]
+	self.opts = opts
+
+    def get_opt(self, opt):
+	"""
+	Return 'opt' if found in self.opts.  Since self.opts may contain dictionary entries,
+	this may return the value of such an entry, should 'opt' match a dictionary entry key.
+	"""
+	for o in self.opts:
+	    if o == opt:
+		return o
+	    if isinstance(o, dict) and o.has_key(opt):
+		return o[opt]
+
+	# Didn't find it.
+	return None
+
+    def __str__(self):
+	return "{} opts:{}".format(self.mountpoint, self.opts)
+
+class Device(object):
+    """
+    Structure representing a disk/partition.
+    """
+    def __init__(self, dev, part_dev, dtype, uuid, fstype):
+	# ie. 'vda'
+	self.dev = dev
+	# ie. 'vda2'
+	self.part_dev = part_dev
+	# String representing the device type: 'hd', 'ssd', 'unknown'
+	self.dtype = dtype
+	self.uuid = uuid
+	# String representing the underlying fs: 'btrfs', 'xfs', etc
+	self.fstype = fstype
+
+    def __str__(self):
+	return "uuid:{} (/dev/{}), {}, {}".format(self.uuid, self.part_dev, self.dtype, self.fstype)
+
+class Path(object):
+    """
+    Structure representing a path on a filesystem.
+    """
+    def __init__(self, path, attrs, exists, ptype, device, mount):
+	# The full path, normalized
+	self.path = os.path.normpath(path)
+	# lsattr type attributes
+	self.attrs = attrs
+	self.exists = exists
+	# ie. dir or file
+	self.ptype = ptype
+	# A Device() instance
+	self.device = device
+	# A Mount() instance
+	self.mount = mount
+
+    def __str__(self):
+	return "{} {} {}, mounted on: {}, with device info: {}".format("Existent" if self.exists else "Nonexsitent",
+					 self.ptype if self.ptype else '', self.path, self.mount, self.device)
+
+# ------------------------------------------------------------------------------
+# Runner functions.
+# ------------------------------------------------------------------------------
+
+# Some fun output
+bold = '\033[1m'
+endc = '\033[0m'
+green = '\033[1;32m'
+yellow = '\033[1;33m'
+red = '\033[1;31m'
+ceph_statedir = "/var/lib/ceph"
+
+def _analyze_ceph_statedirs(statedirs):
+    """
+    Based on some elements of statedir, give the admin feedback regarding the ceph variable statedir.
+    """
+    local = salt.client.LocalClient()
+    results = {'ok': [], 'to_create': [], 'to_migrate': [], 'to_correct_cow': [], 'alt_fs': [], 'ceph_down': []}
+
+    for minion, statedir in statedirs.iteritems():
+	if statedir.device.fstype == 'btrfs':
+	    if statedir.exists:
+		# OK, path exists, is there a subvolume mounted on it?
+		# We detect this by checking the mountpoint
+		if statedir.mount.mountpoint == statedir.path:
+		    #subvol = statedir.mount.get_opt('subvol')
+		    # Already a subvolume!  Check if CoW
+		    if not 'C' in statedir.attrs:
+			results['to_correct_cow'].append(minion)
+		    else:
+			# Copy on write disabled, all good!
+			results['ok'].append(minion)
+			# Also check to see if Ceph is running.
+			if not local.cmd(minion, 'cephprocesses.check', [], expre_form='compound')[minion]:
+			    results['ceph_down'].append(minion)
+		else:
+		    # Path exists, but is not a subovlume
+		    results['to_migrate'].append(minion)
+	    else:
+		# Path does not yet exist.
+		results['to_create'].append(minion)
+	else:
+	    # Not btrfs.  Nothing to suggest.
+	    results['alt_fs'].append(minion)
+	    # Also check to see if Ceph is running
+	    if not local.cmd(minion, 'cephprocesses.check', [], expre_form='compound')[minion]:
+		results['ceph_down'].append(minion)
+
+    return results
+
+def create_var(**kwargs):
+    local = salt.client.LocalClient()
+    path = ceph_statedir
+    ret = True
+
+    statedirs = _inspect_ceph_statedir(path)
+    results = _analyze_ceph_statedirs(statedirs)
+
+    if not results['to_create']:
+	print "{}No nodes marked for subvolume creation.{}".format(bold, endc)
+	return True
+
+    for m in results['to_create']:
+	if ret:
+	    print "{}{}: Beginning creation...{}".format(bold, m, endc)
+	    for minion, ret in local.cmd(m, 'fs.instantiate_btrfs_subvolume',
+					 ["path={}".format(path), "subvol=@{}".format(path)],
+					 expr_form='compound').iteritems():
+		if not ret:
+		    print ("{}{}: {}Failed to properly create and mount @{} onto {}{}.  {}Check the local "
+			   "minion logs for further details.{}".format(bold, minion, red, path, path, endc, bold, endc))
+		else:
+		    print ("{}{}: {}Successfully created and mounted @{} onto {}.{}".format(
+			bold, minion, green, path, path, endc))
+		    ret = _correct_ceph_statedir_attrs(minion)
+
+    if ret:
+	print "{}Success.{}".format(green, endc)
+    else:
+	print "{}Failure detected, not proceeding with further creations.{}".format(red, endc)
+
+    return ret
+
+def migrate_var(**kwargs):
+    """
+    Drive the migration of /var/lib/ceph to a btrfs subvolume.  This needs to be done one node at a time.
+    """
+    local = salt.client.LocalClient()
+    path = ceph_statedir
+    ret = True
+
+    statedirs = _inspect_ceph_statedir(path)
+    results = _analyze_ceph_statedirs(statedirs)
+
+    if not results['to_migrate']:
+	print "{}No nodes marked for subvolume migration.{}".format(bold, endc)
+	return True
+
+    for m in results['to_migrate']:
+	if ret:
+	    print "{}{}: Beginning migration...{}".format(bold, m, endc)
+	    for minion, ret in local.cmd(m, 'fs.migrate_path_to_btrfs_subvolume',
+					 ["path={}".format(path), "subvol=@{}".format(path)],
+					 expr_form='compound').iteritems():
+		# Human intervention needed.
+		if ret == None:
+		    print ("{}{}: {}Failure detected while migrating {} to btrfs subvolume.  This failure is "
+			   "potentially serious and will require manual intervention on the node to "
+			   "determine the cause.  Please check /var/log/salt/minion, the status "
+			   "of Ceph daemons and the state of {}.  You may also run: {}{}salt-run fs.inspect_var "
+			   "{}{}to check the status.{}".format(
+			       bold, minion, red, path, path, endc, bold, endc, red, endc))
+		elif ret == False:
+		    print ("{}{}: {}Failure detected while migrating {} to btrfs subvolume.  We have failed to properly "
+			   "migrate {}, however, we have hopefully recovered to the previous state and Ceph "
+			   "should again be running.  Please, however check /var/log/salt/minion, "
+			   "the status of Ceph daemons and the state of {} to confirm.  You may also run: "
+			   "{}{}salt-run fs.inspect_var {}{}to check the status.{}".format(
+			       bold, minion, yellow, path, path, path, endc, bold, endc, yellow, endc))
+		else:
+		    print "{}{}: {}Successfully migrated.{}".format(bold, minion, green, endc)
+		    ret = _correct_ceph_statedir_attrs(m)
+
+    if ret:
+	print "{}Success.{}".format(green, endc)
+    else:
+	print "{}Failure detected, not proceeding with further migrations.{}".format(red, endc)
+
+    return ret
+
+def _correct_ceph_statedir_attrs(minion=None):
+    """
+    Helper function to disable the copy-on-write attr on the ceph statedir.
+    """
+    local = salt.client.LocalClient()
+    path = ceph_statedir
+    attrs = "C"
+    recursive = True
+    ret = True
+
+    if minion:
+	# Omit /var/lib/ceph/osd directory, as underneath we may have OSDs mounted.
+	for minion, rets in local.cmd(minion, 'fs.add_attrs',
+				      ["path={}".format(path), "attrs={}".format(attrs),
+				       "rec={}".format(recursive), "omit={}/osd".format(path)],
+				      expr_form='compound').iteritems():
+	    for p, ret in rets.iteritems():
+		if not ret:
+		    print ("{}{}: {}Failed to recursively disable copy-on-write for {}.{}".format(bold, minion, red, p, endc))
+		    ret = False
+
+	if ret:
+	    print ("{}{}: {}Successfully disabled copy-on-write for {} and it's contents.{}".format(bold, minion, green, path, endc))
+
+    return ret
+
+def correct_var_attrs(**kwargs):
+    """
+    Recursively set No_COW (ie. disable copy-on-write) flag on /var/lib/ceph.
+    """
+    local = salt.client.LocalClient()
+    path = ceph_statedir
+    recursive = True
+    ret = True
+
+    all_btrfs_nodes = kwargs['all_btrfs_nodes'] if kwargs.has_key('all_btrfs_nodes') else False
+
+    statedirs = _inspect_ceph_statedir(path)
+    results = _analyze_ceph_statedirs(statedirs)
+
+    if not all_btrfs_nodes and not results['to_correct_cow']:
+	print "{}No nodes marked for copy-on-write correction.{}".format(bold, endc)
+	return True
+
+    # If all_btrfs_nodes == True, correct COW on all nodes regardless whether they're in results['to_correct_cow'].
+    # Only really useful if the admin manually set No_COW on /var/lib/ceph, but didn't recursively set all
+    # files underneath.
+    for minion, statedir in statedirs.iteritems():
+	if not statedir.exists:
+	    print "{}{}: {} not found.{}".format(bold, minion, path, endc)
+
+	if statedir.exists and statedir.device.fstype == 'btrfs':
+	    minion_to_correct = None
+	    if all_btrfs_nodes:
+		minion_to_correct = minion
+	    else:
+		minion_to_correct = minion if minion in results['to_correct_cow'] else None
+
+	    # Unlike the creation and migration functions, don't abort on first failure.
+	    if not _correct_ceph_statedir_attrs(minion_to_correct):
+		ret = False
+
+    if ret:
+	print "{}Success.{}".format(green, endc)
+    else:
+	print "{}Failure detected disabling copy-on-write for {}.{}".format(red, path, endc)
+
+    return ret
+
+def _inspect_ceph_statedir(path):
+    """
+    Helper function that collects /var/lib/ceph information from all minions.
+
+    Returns a dictionary of Path objects keyed on minion id.
+
+    """
+    target = deepsea_minions.DeepseaMinions()
+    search = target.deepsea_minions
+    local = salt.client.LocalClient()
+
+    # A container of Path's keyed on minion id.
+    statedirs = {}
+
+
+    for minion, path_info in local.cmd(search, 'fs.inspect_path',
+				       ["path={}".format(path)],
+				       expr_form='compound').iteritems():
+	statedirs[minion] = Path(path, path_info['attrs'], path_info['exists'], path_info['type'],
+				 Device(path_info['dev_info']['dev'], path_info['dev_info']['part_dev'],
+					path_info['dev_info']['type'], path_info['dev_info']['uuid'],
+					path_info['dev_info']['fstype']),
+				 Mount(path_info['mount_info']['mountpoint'], path_info['mount_info']['opts'])) if path_info['ret'] else None
+
+    return statedirs
+
+def inspect_var(**kwargs):
+    """
+    Collect /var/lib/ceph information from all minions.
+    """
+    path = ceph_statedir
+
+    # Loud by default.
+    quiet = kwargs['quiet'] if kwargs.has_key('quiet') else False
+
+    statedirs = _inspect_ceph_statedir(path)
+    results = _analyze_ceph_statedirs(statedirs)
+
+    if not quiet:
+	print "{}Inspecting Ceph Statedir ({})...{}".format(bold, path, endc)
+	for minion, statedir in statedirs.iteritems():
+	    print "{}{}:{} {}".format(bold, minion, endc, statedir)
+	print ""
+
+    if not quiet:
+	# Offer some suggestions.
+	# Migration/Creation/COW adjustment.
+
+	if results['ceph_down']:
+	    print "{}The following nodes have Ceph processes which are currently down:{}".format(red, endc)
+	    for minion in results['ceph_down']:
+		print "{}".format(minion)
+	    print "{}Determine the nature of the failures before proceeding.{}\n".format(red, endc)
+
+	if results['to_migrate']:
+	    print "{}For the following nodes using btrfs:{}".format(yellow, endc)
+	    for minion in results['to_migrate']:
+		print "{}".format(minion)
+	    print ("{}{} exists, but no btrfs subvolume is mounted.  "
+		   "Run: {}{}salt-run fs.migrate_var{}{} to "
+		   "migrate {} to the btrfs subvolume @{}{}".format(yellow, path, endc, bold, endc, yellow, path, path, endc))
+	    print ("{}You may then run: {}{}salt-run fs.inspect_var {}{}to check the "
+		   "status.{}\n".format(yellow, endc, bold, endc, yellow, endc))
+	else:
+	    #print "{}No nodes found needing migration of {} to btrfs subvolume @{}.{}\n".format(green, path, path, endc)
+	    pass
+
+	if results['to_create']:
+	    print "{}For the following nodes using btrfs:{}".format(yellow, endc)
+	    for minion in results['to_create']:
+		print "{}".format(minion)
+	    print ("{}{} does not yet exist.  "
+		   "Run: {}{}salt-run fs.create_var{}{} to create and mount "
+		   "the btrfs subvolume @{} onto {}.{}".format(yellow, path, endc, bold,
+							       endc, yellow, path, path, endc))
+	    print ("{}You may then run: {}{}salt-run fs.inspect_var {}{}to check the "
+		   "status.{}\n".format(yellow, endc, bold, endc, yellow, endc))
+	else:
+	    # Migration also creates subvolumes, so let's not confuse the admin.
+	    if not results['to_migrate']:
+		#print "{}No nodes found needing creation of {} as btrfs subvolume @{}.{}\n".format(green, path, path, endc)
+		pass
+
+	if results['to_correct_cow']:
+	    print "{}For the following nodes using btrfs:{}".format(yellow, endc)
+	    for minion in results['to_correct_cow']:
+		print "{}".format(minion)
+	    print ("{}A btrfs subvolume is mounted on {}.  However, copy-on-write is enabled.  Run: "
+		   "{}{}salt-run fs.correct_var_attrs{}{} to disable copy-on-write.".format(
+		       yellow, path, endc, bold, endc, yellow, endc))
+	    print ("{}You may then run: {}{}salt-run fs.inspect_var {}{}to check "
+		   "the status.{}\n".format(yellow, endc, bold, endc, yellow, endc))
+	else:
+	    # Migration also sets No_COW, so let's not confuse the admin.
+	    if not results['to_migrate']:
+		print "{}No nodes found needing adjustment of copy-on-write for {}.{}".format(green, path, endc)
+		print ("{}NOTE: If copy-on-write was disabled manually for {}, you may still want to run "
+		       "{}{}salt-run fs.correct_var_attrs all_btrfs_nodes=True{}{} to correct all "
+		       "relevant files contained within {} on all nodes running btrfs.{}\n".format(
+			   yellow, path, endc, bold, endc, yellow, path, endc))
+
+	if results['ok']:
+	    print "{}The following btrfs nodes have @{} correctly mounted on {}, and do not require any subvolume manipulation:{}".format(green, path, path, endc)
+	    for minion in results['ok']:
+		print "{}".format(minion)
+	    print ""
+
+	if results['alt_fs']:
+	    print "{}The following nodes are not using btrfs, and hence no action is needed:{}".format(green, endc)
+	    for minion in results['alt_fs']:
+		print "{}".format(minion)
+	    print ""
+
+    return True
+
+def help():
+    """
+    Usage.
+    """
+    usage = ("salt-run fs.inspect_var\n\n"
+	     "    Inspects /var/lib/ceph, provides mountpoint and device information along with suggestions regarding "
+	     "migration of /var/lib/ceph to a btrfs subvolume if applicable.\n"
+	     "\n\n"
+	     "salt-run fs.create_var\n\n"
+	     "    Creates /var/lib/ceph (if not yet present) as a btrfs subvolume.\n"
+	     "\n\n"
+	     "salt-run fs.migrate_var\n\n"
+	     "    Migrates /var/lib/ceph to a btrfs subvolume (@/var/lib/ceph) if applicable.\n"
+	     "\n\n"
+	     "salt-run fs.correct_var_attrs [all_btrfs_nodes=True]\n\n"
+	     "    Disables copy-on-write for /var/lib/ceph on btrfs if applicable.\n"
+	     "\n\n")
+    print usage
+    return ""

--- a/srv/salt/_modules/cephprocesses.py
+++ b/srv/salt/_modules/cephprocesses.py
@@ -73,6 +73,12 @@ def check(results=False, quiet=False, **kwargs):
 
     return res if results else running
 
+def down(**kwargs):
+    """
+    Based on check(), return True/False if all Ceph processes that are meant to be running on a node are down.
+    """
+    return True if not check(True, True)['up'].values() else False
+
 def wait(**kwargs):
     """
     Periodically check until all services are up or until the timeout is

--- a/srv/salt/_modules/cephprocesses.py
+++ b/srv/salt/_modules/cephprocesses.py
@@ -2,6 +2,9 @@
 
 import logging
 import time
+import psutil
+import os
+import pwd
 
 log = logging.getLogger(__name__)
 
@@ -13,10 +16,11 @@ A secondary purpose is a utility to check the current state of all services.
 """
 
 
-def check(**kwargs):
+def check(results=False, quiet=False, **kwargs):
     """
     Query the status of running processes for each role.  Return False if any
-    fail.
+    fail.  If results flag is set, return a dictionary of the form:
+      { 'down': [ process, ... ], 'up': { process: [ pid, ... ], ...} }
     """
     processes = {'mon': ['ceph-mon'],
                  'mgr': ['ceph-mgr'],
@@ -26,11 +30,11 @@ def check(**kwargs):
                  'rgw': ['radosgw'],
                  'ganesha': ['ganesha.nfsd', 'rpcbind', 'rpc.statd'],
                  'admin': [],
-                 'openattic': ['openattic'],
+                 'openattic': ['httpd-prefork'],
                  'master': []}
 
     running = True
-    results = {}
+    res = {'up': {}, 'down': []}
 
     if 'rgw_configurations' in __pillar__:
         for rgw_config in __pillar__['rgw_configurations']:
@@ -38,13 +42,36 @@ def check(**kwargs):
 
     if 'roles' in __pillar__:
         for role in kwargs.get('roles', __pillar__['roles']):
-            for process in processes[role]:
-                pid = __salt__['status.pid'](process)
-                if pid == '':
-                    log.error("ERROR: process {} for role {} is not running".format(process, role))
-                    running = False
+            # Checking running first.
+            for running_proc in psutil.process_iter():
+                # NOTE about `ps` and psutils.Process():
+                # `ps -e` determines process names by examining /proc/PID/stat,status files.  The name derived
+                # there is also found in psutil.Process.name.
+                # `ps -ef`, according to strace, appears to also reference /proc/PID/cmdline when determining
+                # process names.  We have found that some processes (ie. ceph-mgr was noted) will _sometimes_
+                # contain a process name in /proc/PIDstat/stat,status that does not match that found in /proc/PID/cmdline.
+                # In our ceph-mgr example, the process name was found to be 'exe' (which happens to also be the name a of
+                # symlink in /proc/PID that points to the executable) while the cmdline entry contained 'ceph-mgr' etc.
+                # As such, we've decided that a check based on executable path is more reliable.
+                pdict = running_proc.as_dict(attrs=['pid', 'name', 'exe', 'uids'])
+                pdict_exe = os.path.basename(pdict['exe'])
+                pdict_pid = pdict['pid']
+                # Convert the numerical UID to name.
+                pdict_uid = pwd.getpwuid(pdict['uids'].real).pw_name
+                if pdict_exe in processes[role]:
+                    # Verify httpd-worker pid belongs to openattic.
+                    if (role != 'openattic') or (role == 'openattic' and pdict_uid == 'openattic'):
+                            res['up'][pdict_exe] = res['up'][pdict_exe] + [pdict_pid] if res['up'].has_key(pdict_exe) else [pdict_pid]
 
-    return running
+            # Any processes for this role that aren't running, mark them down.
+            for proc in processes[role]:
+                if proc not in res['up']:
+                    if not quiet:
+                        log.error("ERROR: process {} for role {} is not running".format(proc, role))
+                    running = False
+                    res['down'] += [proc]
+
+    return res if results else running
 
 def wait(**kwargs):
     """

--- a/srv/salt/_modules/fs.py
+++ b/srv/salt/_modules/fs.py
@@ -1,0 +1,1091 @@
+# -*- coding: utf-8 -*-
+
+# ------------------------------------------------------------------------------
+# fs.py
+#
+# Module for performing filesystem operations.
+#
+# ------------------------------------------------------------------------------
+
+import logging
+import os
+import grp
+import psutil
+import tempfile
+import shutil
+import pprint
+import uuid
+import time
+from subprocess import Popen, PIPE
+
+log = logging.getLogger(__name__)
+
+# ------------------------------------------------------------------------------
+# Utility functions.
+# ------------------------------------------------------------------------------
+
+def _run(cmd):
+    """
+    NOTE: Taken from osd.py module.
+    """
+    log.info(cmd)
+    proc = Popen(cmd, stdout=PIPE, stderr=PIPE, shell=True)
+    proc.wait()
+    _stdout = proc.stdout.read().rstrip()
+    _stderr = proc.stdout.read().rstrip()
+    log.debug("return code: {}".format(proc.returncode))
+    log.debug(_stdout)
+    log.debug(_stderr)
+    log.debug(pprint.pformat(proc.stdout.read()))
+    log.debug(pprint.pformat(proc.stderr.read()))
+    #return proc.returncode, _stdout, _stderr
+    return proc.returncode, _stdout, _stderr
+
+def _systemctl_cmd_target(cmd, target):
+    """
+    Run a systemctl cmd on a target.  Returns True/False.
+    """
+    retries = 5
+    delay = 2
+
+    # TODO: warn that target is null?
+    if not target:
+	return False
+
+    cmd = "systemctl {} {}".format(cmd, target)
+
+    # Try a _few_ times, with a small sleep.
+    rc, _stdout, _stderr = _run(cmd)
+    while retries and rc != 0:
+	rc, _stdout, _stderr = _run(cmd)
+	retries -= 1
+	time.sleep(delay)
+
+    if rc !=0:
+	log.error("Failed to {} target {}.".format(cmd, target))
+	return False
+
+    return True
+
+def _systemctl_stop_target(target):
+    """
+    systemctl stop target.
+    """
+    return _systemctl_cmd_target('stop', target)
+
+def _systemctl_start_target(target):
+    """
+    systemctl start target.
+    """
+    return _systemctl_cmd_target('start', target)
+
+def _systemctl_restart_target(target):
+    """
+    systemctl restart target.
+    """
+    return _systemctl_cmd_target('restart', target)
+
+def _teardown_ceph():
+    """
+    Kill Ceph and return the status obtained from _ceph_is_down()
+    """
+    ret = True
+
+    # TODO: ganesha and others!?
+    # NOTE: yes, this will trigger an error in the log for nodes that don't run _all_ of these targets.
+    for target in [ 'ceph-mon.target', 'ceph-osd.target', 'ceph-mds.target', 'ceph-radosgw.target', 'ceph-mgr.target', 'ceph.target' ]:
+	ret = _systemctl_stop_target(target)
+
+    return _ceph_is_down()
+
+def _startup_ceph():
+    """
+    Start Ceph, check status of Ceph processes, and return True/False
+    """
+    ret = _systemctl_start_target('ceph.target')
+
+    # We 'succeeded'... but that doesn't mean Ceph isn't still running.
+    if ret:
+	# Let things settle.
+	time.sleep(5)
+	return _ceph_is_up()
+    return False
+
+def _ceph_is_down():
+    """
+    Queries whether all Ceph processes meant to be running on this node have been shut down.
+
+    Returns True/False.
+    """
+    retries = 6
+    delay = 2
+    down = False
+    # Processes that don't impede migration (httpd-prefork == openattic, rest are ganesha related).
+    omit_list = ['httpd-prefork', 'ganesha.nfsd', 'rpcbind', 'rpc.statd']
+
+    while retries and not down:
+	running_procs = __salt__['cephprocesses.check'](results=True, quiet=True)['up'].keys()
+	if not running_procs:
+	    down = True
+	else:
+	    # Compute processes which are running, but not in the omit_list.
+	    waiting_for = [proc for proc in running_procs if proc not in omit_list]
+	    if not waiting_for:
+		down = True
+	    else:
+		log.warn("Waiting for the following Ceph processes to stop: {}.".format(waiting_for))
+		retries -= 1
+		time.sleep(delay)
+		delay *= 2
+
+    return down
+
+def _ceph_is_up():
+    """
+    Queries whether all Ceph processes meant to be running on this node are up.
+
+    Returns True/False.
+    """
+    retries = 6
+    delay = 2
+
+    while retries and not __salt__['cephprocesses.check']():
+	log.warn("Waiting for Ceph processes to start.")
+	retries -= 1
+	time.sleep(delay)
+	delay *= 2
+
+    return __salt__['cephprocesses.check']()
+
+def _get_unique_path(path):
+    """
+    Tries to return a unique path, else None on error.
+    """
+    retries = 100
+    tmp_path = "{}.{}".format(path, str(uuid.uuid4()))
+
+    while os.path.exists(tmp_path) and retries:
+	tmp_path = "{}.{}".format(path, str(uuid.uuid4()))
+	retries -= 1
+
+    # Couldn't find a unique path.
+    if not retries and os.path.exists(tmp_path):
+	return None
+
+    return tmp_path
+
+def _get_uid_gid(path):
+    """
+    For a given path, return {'uid': uid, 'gid': gid} or None if path does not exist.
+    """
+    if not os.path.exists(path):
+	return None
+    stats = os.stat(path)
+    return {'uid': stats.st_uid, 'gid': stats.st_gid}
+
+def _mv_contents(path, new_path):
+    """
+    Try to move the contents of path to tmp_path.  Return True/False.
+
+    NOTE: Invoking `mv` as shutil.move() was not preserving ownership metadata.
+    """
+    for e in os.listdir(path):
+	cmd = "mv {}/{} {}".format(path, e, new_path)
+	rc, _stdout, _stderr = _run(cmd)
+	if rc != 0:
+	    return False
+
+    return True
+
+def _add_fstab_entry(uuid, path, fstype, subvol):
+    """
+    Append entry to /etc/fstab if it does not already exist.
+
+    Return True/False.
+    """
+    fstab_entries = None
+
+    if not uuid or not path or not fstype or not subvol:
+	log.error("Refusing to modify /etc/fstab: Unable to form proper fstab entry.")
+	return False
+
+    entry = "UUID={} {} {} subvol={} 0 0".format(uuid, path, fstype, subvol)
+
+    try:
+	with open('/etc/fstab', 'r') as f:
+	    fstab_entries = [line.rstrip('\n') for line in f]
+    except:
+	log.error("Failed to read /etc/fstab.")
+	return False
+
+    # Process entries.
+    if entry in fstab_entries:
+	log.warn("'{}' already exists in /etc/fstab".format(entry))
+	return True
+    if path in fstab_entries:
+	log.error("Refusing to modify /etc/fstab: existing path entry for '{}' found.".format(path))
+	return False
+    elif subvol in fstab_entries:
+	log.error("Refusing to modify /etc/fstab: existing subvol entry for '{}' found.".format(subvol))
+	return False
+
+    # Append entry to /etc/fstab.
+    try:
+	with open('/etc/fstab', 'a') as f:
+	    f.write("{}\n".format(entry))
+    except:
+	log.error("Failed to append '{}' to /etc/fstab.".format(entry))
+	return False
+
+    log.warn("Successfully appended '{}' to /etc/fstab.".format(entry))
+    return True
+
+# ------------------------------------------------------------------------------
+# BTRFS related functions.
+#
+# Note that there appears to be a python btrfs module, but does not appear to
+# exist in OBS/IBS.
+# ------------------------------------------------------------------------------
+
+def _btrfs_path_as_subvol(path):
+    """
+    Returns '@' concatinated with path => @/foo/bar.
+    """
+    return "@{}".format(path)
+
+def btrfs_get_mountpoints_of_subvol(subvol='', **kwargs):
+    """
+    Determine the list of mountpoints for a given subvol (of the form @/foo/bar).
+
+    Returns a list of mountpoint(s), or an empty list.
+    """
+    mountpoints = []
+    if not subvol:
+	return []
+
+    # Seems the easiest way to do this is to walk the disk partitions, extract the opts
+    # string and see if subvol is present.  Remember the leading '/'.
+    for part in psutil.disk_partitions():
+	if "subvol=/{}".format(subvol) in part.opts:
+	    mountpoints.append(part.mountpoint)
+
+    return mountpoints
+
+def btrfs_get_default_subvol(path='', **kwargs):
+    """
+    Returns the default subvolume (in the form @/foo/bar) of a given path or None on error.
+    """
+    cmd = "btrfs subvolume get-default {}".format(path)
+    rc, _stdout, _stderr = _run(cmd)
+
+    if rc == 0 and _stdout:
+	# _stdout example: ID 259 gen 35248 top level 258 path @/.snapshots/1/snapshot
+	# Return only the subvol
+	return _stdout.split()[-1]
+
+    return None
+
+def btrfs_subvol_exists(subvol='', **kwargs):
+    """
+    Determine if subvol, of the form @/foo/bar exists as a btrfs subvolume.  The
+    subvolume need not be mounted.
+
+    Returns True/False.  Returns False for empty subvolumes.
+    """
+    if not subvol:
+	return False
+
+    # If the subvol is mounted somewhere, it obviously exists.
+    if btrfs_get_mountpoints_of_subvol(subvol):
+	return True
+
+    # If it isn't mounted, we have no idea the mountpoint to use in the below
+    # list, so just default to /
+    cmd = "btrfs subvolume list /"
+    rc, _stdout, _stderr = _run(cmd)
+
+    if rc == 0 and _stdout:
+	subvols = _stdout.split('\n')
+	for s in subvols:
+	    if s.endswith("path {}".format(subvol)):
+		return True
+
+    # Haven't found it.
+    return False
+
+def btrfs_create_subvol(subvol='', dev_info=None, **kwargs):
+    """
+    Create a btrfs subvolume for the given subvol.  Expected subvol to be of the
+    form @/foo/bar.  dev_info is either passed (when called directly) or queried
+    by stripping off the '@' from the subvol in order to query the path.
+
+    Return True/False.
+    """
+    ret = True
+    tmp_dir = None
+
+    if not subvol:
+	log.error("Unable to create subvolume '{}'.".format(subvol))
+	return False
+
+    # Check if subvol already exists.
+    if btrfs_subvol_exists(subvol):
+	log.warn("Subvolume '{}' already exists.".format(subvol))
+	return True
+
+    # If we didn't get dev_info (because we're being called directly from the command
+    # line), we _assume_ that the subvol path will ultimately be mounted onto a matching
+    # path, so _try_ to get the device information by converting subvol to it's corresponding
+    # path (ie. by stripping the leading '@').
+    if not dev_info:
+	dev_info = get_device_info(get_mountpoint(subvol[1:]))
+
+    if not dev_info:
+	log.error("Unable to create subvolume '{}': failed to get device information for '{}'".format(subvol, subvol[1:]))
+	return False
+
+    if dev_info['fstype'] != 'btrfs':
+	log.error("Unable to create subvolume '{}': invalid filesystem type ({}).".format(subvol, dev_info['fstype']))
+	return False
+
+    # Get the partition of the mountpoint of the path.
+    part_path = "/dev/{}".format(dev_info['part_dev'])
+
+    # Create a unique tmp directory.
+    try:
+	tmp_dir = tempfile.mkdtemp()
+    except:
+	log.error("Unable to create subvolume '{}': failed to create temporary directory.".format(subvol))
+	return False
+
+    # Mount tmpdir.
+    cmd = "mount -t btrfs -o subvolid=0 '{}' '{}'".format(part_path, tmp_dir)
+    rc, _stdout, _stderr = _run(cmd)
+    if rc != 0:
+	log.error("Failed to mount '{}' with subvolid=0 on '{}'.".format(part_path, tmp_dir))
+	ret = False
+
+    if ret:
+	# Create the subvol.
+	cmd = "btrfs subvolume create '{}/{}'".format(tmp_dir, subvol)
+	rc, _stdout, _stderr = _run(cmd)
+	if rc != 0:
+	    log.error("Failed to create subvolume '{}' on '{}'.".format(subvol, part_path))
+	    ret = False
+
+    # Cleanup tmp_dir.  Don't touch ret here, just log any errors.
+    if os.path.exists(tmp_dir):
+	cmd = "umount '{}'".format(tmp_dir)
+	rc, _stdout, _stderr = _run(cmd)
+	if rc != 0:
+	    log.error("Failed to unmount '{}'.".format(tmp_dir))
+	try:
+	    shutil.rmtree(tmp_dir)
+	except:
+	    log.error("Failed to remove '{}'.".format(tmp_dir))
+
+    if not ret:
+	# We failed somewhere, so take care of removing the subvolume, etc.
+	# TODO: there is a bug with subvolume deletes (https://bugzilla.opensuse.org/show_bug.cgi?id=957198)
+	# so no more cleanup can be dont at this point.
+	log.error("Failed to create subvolume '{}'.".format(subvol))
+    else:
+	log.warn("Successfully created subvolume '{}'.".format(subvol))
+
+    return ret
+
+def btrfs_mount_subvol(subvol='', path='', **kwargs):
+    """
+    Given a subvolume in the form "@/path/to/subvol", mount it atop of path.  If
+    path does not exist, log an error and abort.  If path is already a mountpoint
+    for for subvol, skip.  If path is a mountpoint for something other than path,
+    abort.  Refuse to mount a subvol with a differing path (ie. refuse to mount
+    @/var/lib/foo atop of /var/lib/bar).
+
+    CAUTION: No checks are performed whether path contains existing data!
+    NOTE: Does not touch /etc/fstab, for that, _add_fstab_entry().
+
+    Returns True/False.
+    """
+    if not subvol or not path:
+	log.error("Unable to mount subvolume '{}' onto '{}'.".format(subvol, path))
+	return False
+
+    # Grab the mount info for path.
+    mount_info = get_mount_info(path)
+    if not mount_info:
+	log.error("Unable to mount subvolume '{}' onto '{}': no mount information obtained.".format(subvol, path))
+	return False
+
+    # Grab device info to confirm this is a btrfs filesystem.
+    dev_info = get_device_info(mount_info['mountpoint'])
+    if not dev_info:
+	log.error("Unable to mount subvolume '{}' onto '{}': no filesystem information obtained.".format(subvol, path))
+	return False
+    if dev_info['fstype'] != 'btrfs':
+	log.error("Unable to mount subvolume '{}' onto '{}': invalid filesystem type ({}).".format(
+	    subvol, path, dev_info['fstype']))
+	return False
+
+    # Subvol should exist!
+    if not btrfs_subvol_exists(subvol):
+	log.error("Unable to mount subvolume '{}' onto '{}': '{}' does not exist.".format(subvol, path, subvol))
+	return False
+
+    # Path should exist!
+    if not os.path.exists(path):
+	log.error("Unable to mount subvolume '{}' onto '{}': '{}' does not exist.".format(subvol, path, path))
+	return False
+
+    # Begin mounting process.
+
+    # If path == mountpoint, then we already have a subvolume mounted on this path.
+    if path == mount_info['mountpoint']:
+	# our path is a mountpoint, run some basic checks
+	if path in btrfs_get_mountpoints_of_subvol(subvol):
+	    log.warn("Subvolume '{}' is already mounted onto '{}'.".format(subvol, path))
+	    return True
+	else:
+	    # Another subvolume is mounted on path, output which
+	    log.error("Unable to mount subvolume '{}' onto '{}': a different subvolume ({}) "
+		      "is already mounted.".format(subvol, path, _get_mount_opt('subvol', mount_info['opts'])))
+	    return False
+    else:
+	# TODO: Should we prevent the same subvolume being mounted on multiple different directories?
+	#       btrfs is happy to mount the same subvolume onto multiple directories, so let's not limit
+	#       this behaviour.  If needed, we can always check the current subvol of the path, and if it
+	#       isn't the default subvol (via btrfs_get_default_subvol()), we could assume a subvol is
+	#       already mounted and log an error/return False.
+	pass
+
+    # Finally mount!
+    cmd = "mount '/dev/{}' '{}' -t btrfs -o subvol={}".format(dev_info['part_dev'], path, subvol)
+    rc, _stdout, _stderr = _run(cmd)
+    if rc != 0:
+	log.error("Failed to mount subvolume '{}' onto '{}': stderr: '{}'.".format(subvol, path, _stderr))
+	return False
+
+    log.warn("Successfully mounted subvolume '{}' onto '{}'.".format(subvol, path))
+    return True
+
+# ------------------------------------------------------------------------------
+# General FS related functions.
+# ------------------------------------------------------------------------------
+
+def _get_mount_opt(opt, mount_opts):
+    """
+    Search for the opt string argument in mount_opts (ie. mount_info['opts']).
+    Entries within the mount_info['opts'] list are either strings, or single k:v
+    dictionaries.
+
+    Returns the opt (or it's value if it's a {k:v}) if found, otherwise None.
+    """
+    if not mount_opts:
+	return None
+
+    for o in mount_opts:
+	if o == opt:
+	    return o
+	if isinstance(o, dict) and o.has_key(opt):
+	    return o[opt]
+
+    # Didn't find opt it.
+    return None
+
+def get_attrs(path='', **kwargs):
+    """
+    Obtains the raw output of `lsattr` on a given path.
+
+    Returns the attrs string after having stripped off the path, or None on error
+    or if path is empty.  If path is a directory, it does not recursively follow
+    all child paths.
+
+    # TODO: Any use in adding a recursive flag and dumping output into a list?
+    """
+    # TODO: Should we warn if the path doesn't exist, or quietly return None?
+    if not os.path.exists(path):
+	return None
+
+    cmd = ("lsattr -d {}".format(path) if os.path.isdir(path)
+	   else "lsattr {}".format(path))
+    rc, _stdout, _stderr = _run(cmd)
+
+    if rc == 0 and _stdout:
+	return _stdout.split()[0]
+    else:
+	log.error("Failed to determine attrs for '{}': stderr: '{}'".format(path, _stderr))
+	return None
+
+def _rchattr(op, path, attrs, rec, omit, rets):
+    """
+    Yet another helper for the whole chattr story.  Recursively applies op and attrs to paths which are not
+    present in the omit list.
+
+    Returns a dictionary of { path: True/False, ... } entries representing the succesful/not successful
+    application of op and attrs.
+    """
+    # Basic non recursive case.  Set attrs for a given path, if it's not in the omit list.
+    if not rec:
+	if path not in omit:
+	    cmd = "chattr {} {}{} {}".format('-d' if os.path.isdir(path) else '', op, attrs, path)
+	    rc, _stdout, _stderr = _run(cmd)
+	    rets[path] = rc == 0
+	    return rc == 0
+	else:
+	    log.warn("Refusing to apply '{}' attrs to '{}' which is also in the omit list {}.".format(attrs, path, omit))
+	    rets[path] = False
+	    return False
+    # The fun case.
+    else:
+	# If our path is a directory, compute it's contents in an absolute form.
+	if os.path.isdir(path):
+	    path_contents = [ "{}/{}".format(path, e) for e in os.listdir(path) ]
+	    # Leaf directory with no contents, and not to be omitted.
+	    if not path_contents and path not in omit:
+		cmd = "chattr {} {}{} {}".format('-d' if os.path.isdir(path) else '', op, attrs, path)
+		rc, _stdout, _stderr = _run(cmd)
+		rets[path] = rc == 0
+	    # There are paths present in path_contents, process those.
+	    else:
+		# For each path that is not in the omit list, recurse.
+		for p in path_contents:
+		    if p not in omit:
+			_rchattr(op, p, attrs, rec, omit, rets)
+		# Now process our non-leaf directory.
+		# TODO: I have a feeling we should check this after the isdir() and not process it or it's children.
+		if path not in omit:
+		    # Finally add the path
+		    cmd = "chattr {} {}{} {}".format('-d' if os.path.isdir(path) else '', op, attrs, path)
+		    rc, _stdout, _stderr = _run(cmd)
+		    rets[path] = rc==0
+	# Path is a file.
+	else:
+	    if path not in omit:
+		cmd = "chattr {} {}{} {}".format('-d' if os.path.isdir(path) else '', op, attrs, path)
+		rc, _stdout, _stderr = _run(cmd)
+		rets[path] = rc == 0
+
+def _chattr(op, path, attrs, rec, omit):
+    """
+    {add,remove,set}_attrs helper function.  op should be one of '+', '-', or '=' per `man chatter`.
+    Ultimately invokes the recursive _rchatter and collects results.
+    """
+    supported_ops = {'-': 'remove', '+': 'add', '=': 'set'}
+    rets = {}
+
+    # Convert omit string to list.
+    omit = omit.split(',') if omit else []
+
+    # Verify op.
+    if op not in supported_ops.keys():
+	log.error("Unable to manipulate attrs for '{}': unsuppurted chattr op: {}.".format(path, op))
+	rets[path] = False
+	return rets
+
+    # Hopefully it's obvious why we're unable to proceed.  Maybe an error is a bit much.
+    if not path or not attrs:
+	log.error("Unable to {} attrs '{}' for path '{}'.".format(supported_ops[op], attrs, path))
+	rets[path] = False
+	return rets
+
+    # Make sure path exists.
+    if not os.path.exists(path):
+	log.error("Unable to {} attrs '{}' for '{}': '{}' does not exist.".format(
+	    supported_ops[op], attrs, path, path))
+	rets[path] = False
+	return rets
+
+    _rchattr(op, path, attrs, rec, omit, rets)
+    return rets
+
+def add_attrs(path='', attrs='', rec=False, omit='', **kwargs):
+    """
+    Add attrs to existing attrs for path.  If path is a directory, and rec is True, will attempt
+    to add attrs recursively to path and it's contents.  Omits paths found in omit.
+
+    attrs should be a string of attributes to add.  For example, "CA" would add attributes
+    'C' and 'A' to path.  Please refer to `man chattr` for valid attrs.
+
+    Returns a dictionary (see _rchattr).
+    """
+    rets = _chattr('+', path, attrs, rec, omit)
+    return rets
+
+def remove_attrs(path='', attrs='', rec=False, omit='', **kwargs):
+    """
+    Remove attrs from existing attrs for path.  If path is a directory, and rec is True, will attempt
+    to remove attrs recursively from path and it's contents.  Omits paths found in omit.
+
+    attrs should be a string of attributes to remove.  For example, "CA" would remove attributes
+    'C' and 'A' from path.  Please refer to `man chattr` for valid attrs.
+
+    Returns a dictionary (see _rchattr).
+    """
+    rets = _chattr('-', path, attrs, rec, omit)
+    return rets
+
+def set_attrs(path='', attrs='', rec=False, omit='', **kwargs):
+    """
+    Set attrs for path.  If path is a directory, and rec is True, will attempt to set attrs recursively
+    for path and it's contents.  Omits paths found in omit.
+
+    attrs should be a string of attributes to set.  For example, "CA" would set attributes 'C' and 'A'
+    for path.  Please refer to `man chattr` for valid attrs.
+
+    Returns a dictionary (see _rchattr).
+    """
+    rets = _chattr('=', path, attrs, rec, rets)
+    return rets
+
+def get_mountpoint_opts(mountpoint='', **kwargs):
+    """
+    Determine the mount options set for a given mountpoint.
+
+    Returns a list of mount opts or None on error.  For opts in the form 'key=val',
+    convert the opt into dictionary.  Thus, our return structure may look
+    something like:
+      [ 'rw', 'relatime', ..., { 'subvolid': '259' }, ... ]'
+    """
+    opts = None
+
+    for part in psutil.disk_partitions():
+	if part.mountpoint == mountpoint:
+	    opts = part.opts.split(',')
+
+    # Convert foo=bar to dictionary entries if opts is not None or not an empty list.
+    opts = [ o if '=' not in o else {k:v for (k,v) in [tuple(o.split('='))]}
+	     for o in opts ] if opts else None
+
+    if not opts:
+	log.error("Failed to determine mount opts for '{}'.".format(mountpoint))
+
+    return opts
+
+def _get_mountpoint(path):
+    """
+    Check if path is a mount point.  If not, split the path until either a mount
+    point is found, or path is empty.  Returns a mount point path or None.
+    """
+    if not path or os.path.ismount(path):
+	return path
+
+    return _get_mountpoint(os.path.split(path)[0])
+
+def get_mountpoint(path='', **kwargs):
+    """
+    Recursively finds the mount point for a given path.  If a path does not exist,
+    returns the mount point of the path _if_ it were to be created.
+
+    Returns the mount point or an empty path if mount point was not found.
+
+    For cases where, for example, path=="var", we make no special assumptions
+    about the parent, nor do we take an abspath().  This example would simply
+    return ''.
+    """
+    mountpoint = _get_mountpoint(path)
+    if not mountpoint:
+	log.error("Failed to determine mountpoint of '{}'.".format(path))
+
+    return mountpoint
+
+def get_mount_info(path='', **kwargs):
+    """
+    Determine the mount point and mount options for a given path.
+
+    Returns { 'mountpoint': String, 'opts': [ String | {k:v} ] } or None on error.
+      - 'opts' may contain a { 'subvol': String } list entry indicating the btrfs
+	subvolume mounted atop the 'mount_point'.
+
+    TODO: Should a lack of mountpoint opts trigger a None return and error?
+    """
+    mount_info = {'mountpoint': '', 'opts': []}
+
+    mountpoint = get_mountpoint(path)
+    if not mountpoint:
+	log.error("Failed to obtain mount information for '{}'.".format(path))
+	return None
+    mount_info['mountpoint'] = mountpoint
+
+    opts = get_mountpoint_opts(mountpoint)
+    if not opts:
+	log.error("Failed to obtain mount information for '{}'.".format(path))
+	return None
+    mount_info['opts'] = opts
+
+    return mount_info
+
+def get_uuid(dev_path='', **kwargs):
+    """
+    Determine the UUID of a given dev_path (ie. /dev/sdb2).
+
+    Returns the UUID of dev, or None on error.
+
+    NOTE: Simplified form of original found in osd.py
+    """
+    pathname="/dev/disk/by-uuid"
+
+    cmd = "find -L {} -samefile {}".format(pathname, dev_path)
+    rc, _stdout, _stderr = _run(cmd)
+
+    if rc == 0 and _stdout:
+	return os.path.basename(_stdout)
+    else:
+	log.error("Failed to determine uuid of '{}'.".format(dev_path))
+	return None
+
+def get_device_info(mountpoint='', **kwargs):
+    """
+    Determine the device, uuid, type and fs type for a given mountpoint.
+
+    Returns { 'dev': String, 'part_dev': String, 'uuid': String,
+	      'type': String (ssd|hd|unknown),
+	      'fstype': String (btrfs|xfs|extX|unknown) }
+    or None on error.
+    """
+    dev_info = {'dev': None, 'part_dev': None, 'uuid': None, 'type': None, 'fstype': None}
+    dev_path = None
+    dev = None
+    part_dev = None
+    fstype = None
+
+    if not mountpoint:
+	log.error("Unable to determine the device of mountponit '{}'.".format(mountpoint))
+	return None
+
+    # Grab device path and fs type in one shot.
+    for part in psutil.disk_partitions():
+	if part.mountpoint == mountpoint:
+	    dev_path = part.device
+	    fstype = part.fstype
+
+    if not dev_path:
+	log.error("Failed to determine the device of mountpoint '{}'.".format(mountpoint))
+	return None
+
+    part_dev = os.path.basename(dev_path)
+
+    # From part_dev (ie. sdb2), grab the underlying device
+    dev = part_dev.rstrip("1234567890")
+    # For nvme, strip the trailing 'p' as well.
+    if "nvme" in dev:
+	dev = dev[:-1]
+
+    dev_info['part_dev'] = part_dev
+    dev_info['dev'] = dev
+
+    if not fstype:
+	log.error("Failed to determine the filesystem type of mountpoint '{}'.".format(mountpoint))
+	return None
+    dev_info['fstype'] = fstype
+
+    # Check if we're on an SSD or not.
+    try:
+	with open("/sys/block/{}/queue/rotational".format(dev, 'r')) as f:
+	    line = f.readline().rstrip()
+	    if line == '0':
+		dev_info['type'] = 'ssd'
+	    elif line == '1':
+		dev_info['type'] = 'hd'
+	    else:
+		dev_info['type'] = 'unknown'
+    except:
+	# For some reason, the file doesn't exist or we can't open it.
+	log.error("Failed to determine if '{}' is a solid state device.".format(dev_path))
+	return None
+
+    uuid = get_uuid(dev_path)
+    if not uuid:
+	return None
+    dev_info['uuid'] = uuid
+
+    return dev_info
+
+# ------------------------------------------------------------------------------
+# Driver functions.
+# ------------------------------------------------------------------------------
+
+def instantiate_btrfs_subvolume(subvol='', path='', **kwargs):
+    """
+    Drive creation and mounting of btrfs subvolumes. Expects subvol in the form @/foo/bar.
+
+    Returns True/False.
+    """
+    uid_gid = None
+
+    if not path or not subvol:
+	log.error("Unable to create subvolume '{}' and mount onto '{}'.".format(subvol, path))
+	return False
+
+    # Grab device info to confirm this is a btrfs filesystem.
+    dev_info = get_device_info(get_mountpoint(path))
+    if not dev_info:
+	log.error("Unable to create subvolume '{}' without filesystem information.".format(subvol))
+	return False
+    if dev_info['fstype'] != 'btrfs':
+	log.error("Unable to create subvolume on '{}' filesystem.".format(dev_info['fstype']))
+	return False
+
+    # Logs error already.
+    ret = btrfs_create_subvol(subvol, dev_info)
+
+    # Create the mount path if it does not yet exist.  If it does, grab it's uid and gid so we can set
+    # it back after mount (root:root otherwise).
+    if ret:
+	if not os.path.exists(path):
+	    try:
+		os.mkdir(path)
+	    except:
+		log.error("Failed to create '{}' for mounting of '{}'.".format(path, subvol))
+		return False
+	else:
+	    uid_gid = _get_uid_gid(path)
+
+    # Try to mount the subvolume.
+    ret = btrfs_mount_subvol(subvol, path)
+
+    if ret and uid_gid:
+	# Make sure path has correct uid/gid.
+	try:
+	    os.chown(path, uid_gid['uid'], uid_gid['gid'])
+	except:
+	    log.error("Failed to set {}:{} ownership of existing '{}' after mounting subvolume '{}'.".format(
+		uid_gid['uid'], uid_gid['gid'], path, subvol))
+	    # NOTE: I'd rather proceed with /etc/fstab in spite of this failure, not setting ret to False.
+
+    if ret:
+	# Create an /etc/fstab entry as well, so mount survives reboots.  Logs it's own errors.
+	ret = _add_fstab_entry(dev_info['uuid'], path, dev_info['fstype'], subvol)
+
+    return ret
+
+def _unmount_osd(osd_mountpoint):
+    """
+    Unmount the OSD defined by osd_mountpoint.  Returns True/False.
+    """
+    rc = 0
+    if get_mountpoint(osd_mountpoint) == osd_mountpoint:
+	cmd = "umount {}".format(osd_mountpoint)
+	rc, _stdout, _stderr = _run(cmd)
+
+    return rc == 0
+
+def _mount_osd(osd_dev, osd_mountpoint):
+    """
+    Activate the OSD defined by osd_dev.  Returns True/False
+    """
+    rc = 0
+    if get_mountpoint(osd_mountpoint) != osd_mountpoint:
+	cmd = "mount {} {}".format(osd_dev, osd_mountpoint)
+	rc, _stdout, _stderr = _run(cmd)
+
+    return rc == 0
+
+def migrate_path_to_btrfs_subvolume(path='', subvol='', **kwargs):
+    """
+    Migrate an existing path to a btrfs subvolume.  This should be done one node at a time (controlled from
+    the fs runner), as Ceph services need to be stopped and OSD's unmounted.
+
+    Returns True/False or None.  None indicates a servere, unrecoverable error.
+    """
+    ret = True
+    path_uid_gid = None
+
+    if not path or not subvol:
+	log.error("Unable to migrate path '{}' to subvolume '{}'.".format(path, subvol))
+	return False
+
+    # If path doesn't exist, there's nothing to migrate.
+    if not os.path.exists(path):
+	log.error("Unable to migrate '{}' to subvolume '{}': '{}' does not exist.".format(path, subvol, path))
+	return False
+
+    # Inspect the path, we could do this piecewise.
+    # TODO: The ret check is a bit harsh.  We could also check the specific parts of path_info.
+    path_info = inspect_path(path)
+    if not path_info or not path_info['ret']:
+	log.error("Unable to migrate '{}' to subvolume '{}': unable to obtain path information.".format(path, subvol))
+	return False
+
+    # Let's make sure (paranoia) that fstype is correct.
+    if path_info['dev_info']['fstype'] != 'btrfs':
+	log.error("Unable to migrate '{}' to subvolume '{}': invalid filesystem type ({}).".format(
+	    path, subvol, path_info['dev_info']['fstype']))
+	return False
+
+    # Check if path is already a mount point.  For a btrfs path to be a mountpoint implies that a subvolume
+    # is mounted.
+    if path_info['mount_info']['mountpoint'] == path:
+	# Check if subvol matches the mounted subvol... this mainly for thoroughness and information.
+	# Remember to strip off the leading '/' when getting the subvol opt.
+	subvol_opt = _get_mount_opt('subvol', path_info['mount_info']['opts'])[1:]
+	if subvol == subvol_opt:
+	    log.warn("No need to migrate '{}': '{}' is already a mountpoint for subvolume '{}'.".format(path, path, subvol))
+	    return True
+	else:
+	    log.error("Unable to migrate '{}' to subvolume '{}': a different subvolume ({}) "
+		      "is mounted.".format(path, subvol, subvol_opt))
+	    return False
+
+    # At this point, we've determined that path is not a mount point for the requested subvol.
+
+    # Check if path is empty.  If it is, we don't really need to do a full migration.
+    # TODO: possible race if a rogue issues zypper install ceph...
+    if not os.listdir(path):
+	log.warn("No need to migrate empty '{}'. Creating '{}' to be mounted onto '{}'.".format(path, subvol, path))
+	return instantiate_btrfs_subvolume(subvol, path)
+
+    # path is not empty, thus begin with migration...
+
+    # Determine a unique tmp path.
+    tmp_path = _get_unique_path(path)
+    if not tmp_path:
+	log.error("Unable to migrate '{}' to subvolume '{}': failed to obtain unique temporary path.".format(path, subvol))
+	return False
+
+    # Try to create tmp_path.
+    try:
+	os.mkdir(tmp_path)
+    except:
+	log.error("Unable to migrate '{}' to subvolume '{}': failed to create '{}'.".format(path, subvol, tmp_path))
+	return False
+
+    # Grab uid/gid of path.
+    uid_gid = _get_uid_gid(path)
+
+    # From here, some intelligent recovery/cleanup may be needed.
+
+    # Grab osd device pairs needed for unmounting and re-activating.
+    osd_pairs = __salt__['osd.part_pairs']()
+
+    # Stop all Ceph processes on this node.  If unable to stop Ceph, we can't proceed and bail out.
+    # Note that just because systemctl call succeeded, doesn't mean the services have actually been stopped, hence
+    # the additional check.
+    if not _teardown_ceph():
+	log.error("Unable to migrate '{}' to subvolume '{}': unable to stop Ceph daemons.".format(path, subvol))
+	ret = False
+
+    # Unmount all OSDs on this node.  If we fail to do so, we can't proceed further.  Cleanup will remount
+    # OSDs and restart Ceph.
+    if ret:
+	for osd_pair in osd_pairs:
+	    if ret:
+		if not _unmount_osd(osd_pair[1]):
+		    log.error("Unable to migrate '{}' to subvolume '{}': failed to unmount OSD at '{}'.".format(
+			path, subvol, osd_pair[1]))
+		    ret = False
+
+    if ret:
+	# Try to move contents of path to tmp_path.
+	if not _mv_contents(path, tmp_path):
+	    log.error("Unable to migrate '{}' to subvolume '{}': failed to move contents of '{}' to '{}'.".format(
+		path, subvol, path, tmp_path))
+	    ret = False
+
+    if ret:
+	# Try to create and mount the subvolume (including modifying /etc/fstab).
+	if not instantiate_btrfs_subvolume(subvol, path):
+	    # Failed to have instiated btrfs subvol, either:
+	    #   i. Failed to have created subvol
+	    #   ii. Failed to have mounted subvol onto path
+	    #   iii. Failed to have modified /etc/fstab
+	    if not btrfs_subvol_exists(subvol) or btrfs_get_mountpoint_of_subvol(subvol) != path:
+		log.error("Unable to migrate '{}' to subvolume '{}': failed to create/mount '{}'.".format(
+		    path, subvol, subvol))
+		ret = False
+	    else:
+		# We created/mounted the subvolume, but just couldn't write /etc/fstab.  This is so close,
+		# and while if we reboot this node, subvol will no longer be mounted on path, we hope the
+		# admin will be able to resolve this on seeing the error log.
+		log.error("Migration of '{}' to subvolume '{}' succeeded, but /etc/fstab could not be written. "
+			  "Manual intervention needed.".format(path, subvol))
+		ret = False
+
+    # Cleanup...
+
+    # Make sure path has correct uid/gid.
+    try:
+	os.chown(path, uid_gid['uid'], uid_gid['gid'])
+    except:
+	log.error("Failed to set {}:{} ownership of '{}' after migration to subvolume '{}'.".format(
+	    uid_gid['uid'], uid_gid['gid'], path, subvol))
+	# Not worth an abrupt failure at this point, but do log it and alert at the runner.
+	ret = False
+
+    # Move contents of tmp_path back to path, if tmp_path is not empty.  If it's empty, we failed to
+    # move contents of path.
+    if os.listdir(tmp_path) and not _mv_contents(tmp_path, path):
+	# Unrecoverable, don't delete either paths as we may lose data.  Return immediately with
+	# None indicating manual intervention.
+	log.error("Unable to migrate '{}' to subvolume '{}': failed to move contents of '{}' back to path '{}'. "
+		  "Manual intervention needed!".format(path, subvol, tmp_path, path))
+	return None
+
+    # At this point, it's safe to remove tmp_path.
+    try:
+	os.rmdir(tmp_path)
+    except:
+	# shutil.move() would have failed above if we failed to move everything from tmp_path to path,
+	# treating this as a cleanup error.
+	log.error("Failed to cleanup from migration of '{}' to subvolume '{}': failed to remove '{}'".format(
+	    path, subvol, tmp_path))
+
+    # Try to remount as many OSDs as possible.  If we fail on any one, return None at the end.
+    mount_ret = True
+    for osd_pair in osd_pairs:
+	if not _mount_osd(osd_pair[0], osd_pair[1]):
+	    log.error("Failed to re-mount OSD onto '{}' after migration of '{}' to subvolume '{}'.  "
+		      "Manual intervention needed!".format(osd_pair[1], path, subvol))
+	    mount_ret = False
+    if not mount_ret:
+	return None
+
+    # Finally, restart Ceph
+    if not _startup_ceph():
+	log.error("Failed to restart Ceph after migration of '{}' to subvolume '{}'.  "
+		  "Manual intervention needed".format(path, subvol))
+	return None
+
+    if not ret:
+	log.error("Failed to successfully migrate '{}' to subvolume '{}'.".format(path, subvol))
+    else:
+	log.warn("Succesfully migrated '{}' to subvolume '{}'.".format(path, subvol))
+
+    return ret
+
+def inspect_path(path='', **kwargs):
+    """
+    Determine some intersting information for a given path.
+
+    Returns { 'ret': Bool, 'exists': exists(path), 'type': String ('directory', 'file'),
+	      'attrs': get_attrs(path),
+	      'mount_info': { get_mount_info(path) },
+	      'dev_info': { get_device_info(mountpoint) }
+    or None if path not supplied.  On an error return from any of the composite
+    functions, set 'ret' = False.
+    """
+    path_info = {'ret': True, 'exists': None, 'type': None, 'attrs': None, 'mount_info': None, 'dev_info': None}
+
+    if not path:
+	log.error("Unable to inspect '{}'.".format(path))
+	return None
+
+    path_info['exists'] = os.path.exists(path)
+
+    # Keeping it simple: 'directory' or 'file'.  If it doesn't exist, None.
+    if path_info['exists']:
+	path_info['type'] = 'directory' if os.path.isdir(path) else 'file'
+
+    path_info['attrs'] = get_attrs(path)
+    if path_info['exists'] and not path_info['attrs']:
+	# Only set a fail flag when collecting attrs for existing paths.
+	path_info['ret'] = False
+
+    path_info['mount_info'] = get_mount_info(path)
+    if not path_info['mount_info']:
+	path_info['ret'] = False
+
+    path_info['dev_info'] = get_device_info(path_info['mount_info']['mountpoint'])
+    if not path_info['dev_info']:
+	path_info['ret'] = False
+
+    return path_info

--- a/srv/salt/_modules/osd.py
+++ b/srv/salt/_modules/osd.py
@@ -81,6 +81,21 @@ def pairs():
 
     return pairs
 
+def part_pairs():
+    """
+    Return an array of partitions and paths
+    """
+    paths = [ pathname for pathname in glob.glob("/var/lib/ceph/osd/*") ]
+    pairs = []
+    with open('/proc/mounts') as mounts:
+	for line in mounts:
+	    partition, path = line.split()[:2]
+	    if path in paths:
+		m = re.match(r'^(.+)\d+$', partition)
+		part = m.group(0)
+		pairs.append([ part, path ])
+    return pairs
+
 def _filter_devices(devices, **kwargs):
     """
     Filter devices if provided.

--- a/srv/salt/ceph/migrate/subvolume/default.sls
+++ b/srv/salt/ceph/migrate/subvolume/default.sls
@@ -1,0 +1,12 @@
+
+create /var/lib/ceph as subvolume if /var/lib/ceph doesn't exist:
+  salt.runner:
+    - name: fs.create_var
+
+migrate existing /var/lib/ceph to subvolume:
+  salt.runner:
+    - name: fs.migrate_var
+
+disable copy-on-write for /var/lib/ceph:
+  salt.runner:
+    - name: fs.correct_var_attrs

--- a/srv/salt/ceph/migrate/subvolume/init.sls
+++ b/srv/salt/ceph/migrate/subvolume/init.sls
@@ -1,0 +1,3 @@
+
+include:
+  - .{{ salt['pillar.get']('migrate_subvolume', 'default') }}


### PR DESCRIPTION
The actual goal of this work is to help those using btrfs, to create/migrate the Ceph variable state directory to a btrfs subvolume.  The hope is that it can be extended for other filesystem related things in the future.

Runner adds:
`salt-run fs.inspect_var` - Inspection of /var/lib/ceph
`salt-run fs.create_var` - Creation of /var/lib/ceph as a btrfs subvolume
`salt-run fs.migrate_var` - Migration of existing /var/lib/ceph to a btrfs subvolume
`salt-run fs.correct_var_attrs` - Removing copy-on-write from /var/lib/ceph and it's children, while omitting /var/lib/ceph/osd/*

Use:
Automatic: `salt-run state.orch ceph.migrate.subvolume`
Controlled: `salt-run fs.inspect_var` and read/follow recommendations

Requires some testing beyond my 4 node virtual cluster.  Main pain points are actually with `systemctl start/stop` and determining if Ceph processes have indeed been terminated/started (hence the various sleeps and loops/checks/timeouts, etc).