### PR TITLE
Improve select.minions runner to be able to search for multiple roles.

### DIFF
--- a/srv/modules/runners/select.py
+++ b/srv/modules/runners/select.py
@@ -17,7 +17,11 @@ def minions(host = False, **kwargs):
     for key in kwargs:
         if key[0] == "_":
             continue
-        criteria.append("I@{}:{}".format(key, kwargs[key]))
+        values = kwargs[key]
+        if not isinstance(values, list):
+            values = [values]
+        for value in values:
+            criteria.append("I@{}:{}".format(key, value))
 
     search = " and ".join(criteria)
 


### PR DESCRIPTION
Improve `select.minions` runner to be able to search for multiple roles. Now it is possible to call this function like `salt.saltutil.runner('select.one_minion', cluster='ceph', roles=['admin','rgw'])`

Signed-off-by: Volker Theile <vtheile@suse.com>