### PR TITLE
Remove quotes from NFS Ganesha CLIENT.clients field

### DIFF
--- a/srv/modules/runners/ui_ganesha.py
+++ b/srv/modules/runners/ui_ganesha.py
@@ -127,11 +127,11 @@ class GaneshaConfParser(object):
 
     @staticmethod
     def write_block_body(block, depth=0):
-        def format_val(val):
-            if isinstance(val, int):
+        def format_val(key, val):
+            if isinstance(val, list):
+                return ', '.join([format_val(key, v) for v in val])
+            elif isinstance(val, int) or (block['block_name'] == 'CLIENT' and key == 'clients'):
                 return '{}'.format(val)
-            elif isinstance(val, list):
-                return ', '.join([format_val(v) for v in val])
             else:
                 return '"{}"'.format(val)
 
@@ -144,7 +144,7 @@ class GaneshaConfParser(object):
                     conf_str += GaneshaConfParser.write_block(blo, depth)
             elif val:
                 conf_str += GaneshaConfParser._indentation(depth)
-                conf_str += '{} = {};\n'.format(key, format_val(val))
+                conf_str += '{} = {};\n'.format(key, format_val(key, val))
         return conf_str
 
     @staticmethod


### PR DESCRIPTION
Quotes are not allowed for CLIENT.clients field on _ganesha.conf_ file.

This PR will change the _ganesha.conf_ writer to not write quotes on this field, to prevent an error when nfs-ganesha parses the configuration file generated by DeepSea.

### Examples

**VALID** _ganesha.conf_ file:
```
EXPORT {
    ...
    CLIENT {
        clients = 11.150.96.27;
        access_type = "RO";
        ...
    }
    ...
}

```

**INVALID** _ganesha.conf_ file:
```
EXPORT {
     ...
    CLIENT {
        clients = "11.150.96.27";
        access_type = "RO";
       ...
    }
    ...
}

```

Signed-off-by: Ricardo Marques <rimarques@suse.com>