### PR TITLE
qa: do not try to turn -x off and on during the test

### DIFF
--- a/qa/common/helper.sh
+++ b/qa/common/helper.sh
@@ -22,12 +22,10 @@ function _run_stage {
   test -z "$cli" && cli="classic"
   local stage_log_path="/tmp/stage.${stage_num}.log"
 
-  set +x
   echo ""
   echo "*********************************************"
   echo "********** Running DeepSea Stage $stage_num **********"
   echo "*********************************************"
-  set -x
 
   # CLI case
   if [ "x$cli" = "xcli" ] ; then


### PR DESCRIPTION
This did not work out as expected. The test goes so quickly that, if a stage
fails, the next one starts before set -x is issued.

Signed-off-by: Nathan Cutler <ncutler@suse.com>