### PR TITLE
Fix missing indention.

### DIFF
--- a/srv/salt/_modules/cephimages.py
+++ b/srv/salt/_modules/cephimages.py
@@ -19,7 +19,7 @@ def list():
         rbd_proc = Popen(cmd, stdout=PIPE, stderr=PIPE)
         for rbd_line in rbd_proc.stdout:
             if pool not in images:
-            images[pool] = []
+                images[pool] = []
             images[pool].append(rbd_line.rstrip('\n'))
 
     return images


### PR DESCRIPTION
This will fix the following error:

Okt 05 15:10:17 xxxxxxxx salt-minion[1689]: [ERROR   ] Failed to import module cephimages, this is due most likely to a syntax error:
Okt 05 15:10:17 xxxxxxxx salt-minion[1689]: Traceback (most recent call last):
Okt 05 15:10:17 xxxxxxxx salt-minion[1689]:   File "/usr/lib/python2.7/site-packages/salt/loader.py", line 1333, in _load_module
Okt 05 15:10:17 xxxxxxxx salt-minion[1689]:     mod = imp.load_module(mod_namespace, fn_, fpath, desc)
Okt 05 15:10:17 xxxxxxxx salt-minion[1689]:   File "/var/cache/salt/minion/extmods/modules/cephimages.py", line 22
Okt 05 15:10:17 xxxxxxxx salt-minion[1689]:     images[pool] = []
Okt 05 15:10:17 xxxxxxxx salt-minion[1689]:          ^
Okt 05 15:10:17 xxxxxxxx salt-minion[1689]: IndentationError: expected an indented block

See also #710.

Signed-off-by: Volker Theile <vtheile@suse.com>