### PR TITLE
stage 0: update mines using mines.update instead of minion restart

### DIFF
--- a/srv/salt/ceph/mines/default.sls
+++ b/srv/salt/ceph/mines/default.sls
@@ -1,15 +1,20 @@
 
 
-configure_mines:
+configure_mine_functions_conf:
   file.managed:
     - name: /etc/salt/minion.d/mine_functions.conf
     - source: salt://ceph/mines/files/mine_functions.conf
     - fire_event: True
 
+add_mine_cephdisks.list_to_minion:
+  module.run:
+    - name: mine.send
+    - func: cephdisks.list
+
 manage_salt_minion_for_mines:
-  service.running:
-    - name: salt-minion
+  module.run:
+    - name: mine.update
     - watch:
-      - file: configure_mines
+      - file: configure_mine_functions_conf
     - fire_event: True
 

--- a/srv/salt/ceph/stage/iscsi/default.sls
+++ b/srv/salt/ceph/stage/iscsi/default.sls
@@ -1,5 +1,13 @@
 {% if salt.saltutil.runner('select.minions', cluster='ceph', roles='igw') %}
 
+add_mine_cephimages.list_function:
+  salt.function:
+    - name: mine.send
+    - arg:
+      - cephimages.list
+    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt_type: compound
+
 igw config:
   salt.state:
     - tgt: {{ salt['pillar.get']('master_minion') }}


### PR DESCRIPTION
The current behavior of updating the salt mines in stage 0 using `service.running` module is making the salt-minion to lose the job information of the following step, which is `ceph.updates`, because it restarts the salt-minion. The consequence is that stage 0 finishes the execution before the ceph.updates job is finished.

This PR fixes the issue by calling the `mine.update` module instead.

Signed-off-by: Ricardo Dias <rdias@suse.com>