### PR TITLE
 Staged restarts of services

### DIFF
--- a/srv/salt/ceph/restart/ganesha/default.sls
+++ b/srv/salt/ceph/restart/ganesha/default.sls
@@ -6,6 +6,13 @@
         - tgt: {{ master }}
         - sls: ceph.wait
 
+    check if all processes are still running on {{ host }}:
+      salt.state:
+        - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
+        - tgt_type: compound
+        - sls: ceph.processes
+        - failhard: True
+
     restarting ganesha on {{ host }}:
       salt.state:
         - tgt: {{ host }}

--- a/srv/salt/ceph/restart/igw/default.sls
+++ b/srv/salt/ceph/restart/igw/default.sls
@@ -6,6 +6,13 @@
         - tgt: {{ master }}
         - sls: ceph.wait
 
+    check if all processes are still running on {{ host }}:
+      salt.state:
+        - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
+        - tgt_type: compound
+        - sls: ceph.processes
+        - failhard: True
+
     restarting igw on {{ host }}:
       salt.state:
         - tgt: {{ host }}

--- a/srv/salt/ceph/restart/mds/default.sls
+++ b/srv/salt/ceph/restart/mds/default.sls
@@ -1,3 +1,4 @@
+{% if salt.saltutil.runner('changed.mds') == True %}
 {% set master = salt['pillar.get']('master_minion') %}
 {% for host in salt.saltutil.runner('select.minions', cluster='ceph', roles='mds') %}
     
@@ -5,6 +6,13 @@
       salt.state:
         - tgt: {{ master }}
         - sls: ceph.wait
+
+    check if all processes are still running on {{ host }}:
+      salt.state:
+        - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
+        - tgt_type: compound
+        - sls: ceph.processes
+        - failhard: True
 
     restarting mds on {{ host }}:
       salt.state:
@@ -14,3 +22,4 @@
         - failhard: True
 
 {% endfor %}
+{% endif %}

--- a/srv/salt/ceph/restart/mon/default.sls
+++ b/srv/salt/ceph/restart/mon/default.sls
@@ -6,6 +6,13 @@
         - tgt: {{ master }}
         - sls: ceph.wait
 
+    check if all processes are still running on {{ host }}:
+      salt.state:
+        - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
+        - tgt_type: compound
+        - sls: ceph.processes
+        - failhard: True
+
     restarting mons on {{ host }}:
       salt.state:
         - tgt: {{ host }}

--- a/srv/salt/ceph/restart/mon/default.sls
+++ b/srv/salt/ceph/restart/mon/default.sls
@@ -1,3 +1,4 @@
+{% if salt.saltutil.runner('changed.mon') == True %}
 {% set master = salt['pillar.get']('master_minion') %}
 {% for host in salt.saltutil.runner('select.minions', cluster='ceph', roles='mon') %}
 
@@ -21,3 +22,4 @@
         - failhard: True
 
 {% endfor %}
+{% endif %}

--- a/srv/salt/ceph/restart/osd/default.sls
+++ b/srv/salt/ceph/restart/osd/default.sls
@@ -1,3 +1,4 @@
+{% if salt.saltutil.runner('changed.osd') == True %}
 {% set master = salt['pillar.get']('master_minion') %}
 {% for host in salt.saltutil.runner('select.minions', cluster='ceph', roles='storage') %}
     
@@ -5,6 +6,13 @@
       salt.state:
         - tgt: {{ master }}
         - sls: ceph.wait
+
+    check if all processes are still running on {{ host }}:
+      salt.state:
+        - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
+        - tgt_type: compound
+        - sls: ceph.processes
+        - failhard: True
 
     restarting osds on {{ host }}:
       salt.state:
@@ -14,3 +22,4 @@
         - failhard: True
 
 {% endfor %}
+{% endif %}

--- a/srv/salt/ceph/restart/rgw/default.sls
+++ b/srv/salt/ceph/restart/rgw/default.sls
@@ -1,3 +1,4 @@
+{% if salt.saltutil.runner('changed.rgw') == True %}
 {% set master = salt['pillar.get']('master_minion') %}
 {% for host in salt.saltutil.runner('select.minions', cluster='ceph', roles='rgw') %}
 
@@ -21,3 +22,4 @@
         - failhard: True
 
 {% endfor %}
+{% endif %}

--- a/srv/salt/ceph/restart/rgw/default.sls
+++ b/srv/salt/ceph/restart/rgw/default.sls
@@ -6,6 +6,12 @@
         - tgt: {{ master }}
         - sls: ceph.wait
 
+    check if all processes are still running on {{ host }}:
+      salt.state:
+        - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
+        - tgt_type: compound
+        - sls: ceph.processes
+        - failhard: True
 
     restarting rgw on {{ host }}:
       salt.state:


### PR DESCRIPTION
We technically have everything in place to follow the controlled/staged
restart. Adding the cephprocesses check as ceph.wait doesn't interrupt
a failed restart for interfaces/services

If you now want to _forcefully_ restart services use:

salt -I 'roles:$service' ceph.$service.restart

Addresses: #221 
Signed-off-by: Joshua Schmid <jschmid@suse.de>