### PR TITLE
qa: Add basic restart mechanism for ceph.restart tests

### DIFF
--- a/qa/suites/basic/health-ok.sh
+++ b/qa/suites/basic/health-ok.sh
@@ -72,5 +72,16 @@ test_systemd_ceph_osd_target_wants
 rados_write_test
 ceph_version_test
 run_stage_0 "$CLI"
+restart_services
+mon_restarted "1" # 1 means not restarted
+osd_restarted "1"
+# apply config change
+change_osd_conf
+change_mon_conf
+# construct and spread config
+run_stage_3 "$CLI"
+restart_services
+mon_restarted "0" # 0 means restarted
+osd_restarted "0"
 
 echo "OK"

--- a/qa/suites/basic/health-rgw.sh
+++ b/qa/suites/basic/health-rgw.sh
@@ -94,5 +94,13 @@ rgw_user_and_bucket_list
 rgw_validate_demo_users
 ceph_health_test
 run_stage_0 "$CLI"
+restart_services
+rgw_restarted "1" # 1 means not restarted
+# apply config change
+change_rgw_conf
+# construct and spread config
+run_stage_3 "$CLI"
+restart_services
+rgw_restarted "0" # 0 means restarted
 
 echo "OK"


### PR DESCRIPTION
Implementing basic validation for restarted services
for now only: MON, OSD, RGW

Depends on: #734 
Signed-off-by: Joshua Schmid <jschmid@suse.de>