### PR TITLE
Fix failing upgrade for missing files in rpm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -453,6 +453,8 @@ copy-files:
 	install -m 644 srv/salt/ceph/maintenance/upgrade/minion/*.sls $(DESTDIR)/srv/salt/ceph/maintenance/upgrade/minion
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/maintenance/upgrade/report
 	install -m 644 srv/salt/ceph/maintenance/upgrade/report/*.sls $(DESTDIR)/srv/salt/ceph/maintenance/upgrade/report
+	install -d -m 755 $(DESTDIR)/srv/salt/ceph/maintenance/upgrade/cleanup
+	install -m 644 srv/salt/ceph/maintenance/upgrade/cleanup/*.sls $(DESTDIR)/srv/salt/ceph/maintenance/upgrade/cleanup
 	# state files - orchestrate stages
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/stage/all
 	install -m 644 srv/salt/ceph/stage/all/*.sls $(DESTDIR)/srv/salt/ceph/stage/all/

--- a/deepsea.spec
+++ b/deepsea.spec
@@ -288,6 +288,7 @@ systemctl try-restart salt-api > /dev/null 2>&1 || :
 %dir /srv/salt/ceph/maintenance/upgrade/master
 %dir /srv/salt/ceph/maintenance/upgrade/minion
 %dir /srv/salt/ceph/maintenance/upgrade/report
+%dir /srv/salt/ceph/maintenance/upgrade/cleanup
 %dir /srv/salt/ceph/upgrade
 %dir /srv/salt/ceph/updates
 %dir /srv/salt/ceph/updates/master
@@ -512,6 +513,7 @@ systemctl try-restart salt-api > /dev/null 2>&1 || :
 %config /srv/salt/ceph/maintenance/upgrade/master/*.sls
 %config /srv/salt/ceph/maintenance/upgrade/minion/*.sls
 %config /srv/salt/ceph/maintenance/upgrade/report/*.sls
+%config /srv/salt/ceph/maintenance/upgrade/cleanup/*.sls
 %config /srv/salt/ceph/tools/fio/*.sls
 %config /srv/salt/ceph/tools/fio/files/fio.service
 %config /srv/salt/ceph/updates/*.sls


### PR DESCRIPTION
> ses4node1:~ # salt-run state.orch ceph.maintenance.upgrade
> [WARNING ] All minions are ready
> deepsea_minions          : valid
> master_minion            : valid
> ceph_version             : valid
> 
>         *************** PLEASE READ ***********************
>         Upgrading the salt master may result in an initial
>         failure.  Rerun the orchestration a second time to
>         continue the upgrade.
>         ***************************************************
> [WARNING ] All minions are ready
> [ERROR   ] Template was specified incorrectly: False
> ses4node1.qatest_master:
>     Data failed to compile:
> ----------
>     Specified SLS ceph.maintenance.upgrade.cleanup in saltenv base is not available on the salt master or through a configured fileserver
> 
> ses4node1:/srv # ll /srv/salt/ceph/maintenance/upgrade
> total 8
> -rw-r--r-- 1 root root 58 Oct 16 23:08 default.sls
> -rw-r--r-- 1 root root 74 Oct 16 23:08 init.sls
> drwxr-xr-x 2 root root 41 Oct 17 16:15 master
> drwxr-xr-x 2 root root 41 Oct 17 16:15 minion
> drwxr-xr-x 2 root root 41 Oct 17 16:15 report
> 

Signed-off-by: Joshua Schmid <jschmid@suse.de>