### PR TITLE
openattic: Check oA config file in /etc/default and always overwrite settings

### DIFF
--- a/srv/salt/_modules/openattic.py
+++ b/srv/salt/_modules/openattic.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import configobj
 import os
+from shutil import copyfile
 import salt.utils
 
 from salt.exceptions import CommandExecutionError
@@ -61,17 +62,15 @@ def configure_salt_api(hostname, port, username, sharedsecret):
     config_file = _select_config_file_path()
 
     config = configobj.ConfigObj(config_file)
-    if 'SALT_API_HOST' not in config:
-        config['SALT_API_HOST'] = hostname
-    if 'SALT_API_PORT' not in config:
-        config['SALT_API_PORT'] = int(port)
 
-    if 'SALT_API_EAUTH' not in config or config['SALT_API_EAUTH'] == 'auto':
-        config['SALT_API_EAUTH'] = 'sharedsecret'
-
+    config['SALT_API_HOST'] = hostname
+    config['SALT_API_PORT'] = int(port)
+    config['SALT_API_EAUTH'] = 'sharedsecret'
     config['SALT_API_USERNAME'] = username
     config['SALT_API_SHARED_SECRET'] = sharedsecret
 
+    # Write backup file
+    copyfile(config_file, "{}.deepsea.bak".format(config_file))
     _write_config_file(config_file, config)
 
 
@@ -79,8 +78,10 @@ def configure_grafana(hostname):
     config_file = _select_config_file_path()
 
     config = configobj.ConfigObj(config_file)
-    if 'GRAFANA_API_HOST' not in config:
-        config['GRAFANA_API_HOST'] = hostname
 
+    config['GRAFANA_API_HOST'] = hostname
+
+    # Write backup file
+    copyfile(config_file, "{}.deepsea.bak".format(config_file))
     _write_config_file(config_file, config)
 

--- a/srv/salt/_modules/openattic.py
+++ b/srv/salt/_modules/openattic.py
@@ -49,7 +49,7 @@ def _write_config_file(config_file, config):
 
 
 def _select_config_file_path():
-    possible_paths = ("/etc/sysconfig/openattic", "/etc/openattic")
+    possible_paths = ("/etc/default/openattic", "/etc/sysconfig/openattic")
     for path in possible_paths:
         if os.access(path, os.F_OK) and os.access(path, os.R_OK | os.W_OK):
             return path


### PR DESCRIPTION
This PR is related to the oA issue: https://tracker.openattic.org/browse/OP-2808

Signed-off-by: Ricardo Dias <rdias@suse.com>