### PR TITLE
[DNM] Fixes re-deployment bug on encrypted disks.

### DIFF
--- a/srv/salt/_modules/osd.py
+++ b/srv/salt/_modules/osd.py
@@ -1820,11 +1820,13 @@ def is_prepared(device):
     """
     config = OSDConfig(device)
     osdc = OSDCommands(config)
+    if osdc.highest_partition(readlink(device), 'lockbox') != 0:
+        log.debug("Found encrypted OSD {}".format(device))
+        return True
     partition = osdc.highest_partition(readlink(device), 'osd')
     if partition == 0:
         log.error("Do not know which partition to check on {}".format(device))
         return False
-
     log.debug("Checking partition {} on device {}".format(partition, device))
     if osdc.is_partition('osd', config.device, partition) and _fsck(config.device, partition):
         return True

--- a/tests/unit/_modules/test_osd.py
+++ b/tests/unit/_modules/test_osd.py
@@ -1171,6 +1171,43 @@ class TestOSDCommands():
 
     @mock.patch('srv.salt._modules.osd.OSDCommands.is_partition')
     @mock.patch('srv.salt._modules.osd.glob')
+    def test_highest_partition_encrypted(self, glob_mock, part_mock, osdc_o):
+        """
+        Given there is a device
+        And it's encrypted
+        And the device has partitions & a lockbox
+        And is_partition() returns True
+        Expect to return 5 (lockboxes are always on 5)
+        """
+        kwargs = {'device': '/dev/vdb'}
+        glob_mock.glob.return_value = ['/dev/vdb1', '/dev/vdb2', '/dev/vdb5']
+        part_mock.return_value = True
+        osd_config = OSDConfig(**kwargs)
+        obj = osdc_o(osd_config)
+        ret = obj.highest_partition(osd_config.device, 'lockbox')
+        assert ret == '5'
+
+    @mock.patch('srv.salt._modules.osd.OSDCommands.is_partition')
+    @mock.patch('srv.salt._modules.osd.glob')
+    def test_highest_partition_encrypted_nvme(self, glob_mock, part_mock, osdc_o):
+        """
+        Given there is a device
+        And it's encrypted
+        And the device has partitions & a lockbox
+        And is_partition() returns True
+        And it's a nvme
+        Expect to return 5 (lockboxes are always on 5)
+        """
+        kwargs = {'device': '/dev/nvme1n1'}
+        glob_mock.glob.return_value = ['/dev/nvme1n1p1', '/dev/nvme1n1p2', '/dev/nvme1n1p5']
+        part_mock.return_value = True
+        osd_config = OSDConfig(**kwargs)
+        obj = osdc_o(osd_config)
+        ret = obj.highest_partition(osd_config.device, 'lockbox')
+        assert ret == 'p5'
+
+    @mock.patch('srv.salt._modules.osd.OSDCommands.is_partition')
+    @mock.patch('srv.salt._modules.osd.glob')
     def test_highest_partition_no_nvme(self, glob_mock, part_mock, osdc_o):
         """
         Given there is a device


### PR DESCRIPTION
Tests:

- [x] Bluestore unencrypted colocated wal/db
- [x] Bluestore encrypted colocated wal/db
- [x] Bluestore unencrypted dedicated wal/db
- [x] Bluestore encrypted dedicated wal/db

The last bullet point led me to this:
https://github.com/SUSE/DeepSea/issues/755
and
https://github.com/SUSE/DeepSea/issues/754

Part of this was already targeted by https://github.com/SUSE/DeepSea/pull/620