### PR TITLE
qa: health-ok.sh: liberally accept both --encrypted and --encryption

### DIFF
--- a/qa/suites/basic/health-ok.sh
+++ b/qa/suites/basic/health-ok.sh
@@ -36,7 +36,7 @@ function usage {
     exit 1
 }
 
-TEMP=$(getopt -o h --long "cli" \
+TEMP=$(getopt -o h --long "cli,encrypted,encryption" \
      -n 'health-ok.sh' -- "$@")
 
 if [ $? != 0 ] ; then echo "Terminating..." >&2 ; exit 1 ; fi
@@ -50,7 +50,7 @@ ENCRYPTION=""
 while true ; do
     case "$1" in
         --cli) CLI="cli" ; shift ;;
-        --encrypted) ENCRYPTION="encryption" ; shift ;;
+        --encrypted|--encryption) ENCRYPTION="encryption" ; shift ;;
         -h|--help) usage ;;    # does not return
         --) shift ; break ;;
         *) echo "Internal error" ; exit 1 ;;


### PR DESCRIPTION
This fixes a regression introduced by 01833ee983e6da8b41706c3819a07ce9a86b0f49