### PR TITLE
select: Use host grain for short hostname

### DIFF
--- a/srv/modules/runners/select.py
+++ b/srv/modules/runners/select.py
@@ -41,6 +41,13 @@ def help_():
     return ""
 
 
+def _grain_host(client, minion):
+    """
+    Return the host grain for a given minion, for use a short hostname
+    """
+    return client.cmd(minion, 'grains.item', ['host']).values()[0]['host']
+
+
 def minions(host=False, **kwargs):
     """
     Some targets needs to match all minions within a search criteria.
@@ -67,7 +74,7 @@ def minions(host=False, **kwargs):
     sys.stdout = _stdout
 
     if host:
-        return ([k.split('.')[0] for k in _minions.keys()])
+        return [_grain_host(local, k) for k in _minions.keys()]
     return _minions.keys()
 
 
@@ -107,7 +114,7 @@ def public_addresses(tuples=False, host=False, **kwargs):
 
     if tuples:
         if host:
-            addresses = [[k.split('.')[0], v] for k, v in result.items()]
+            addresses = [[_grain_host(local, k), v] for k, v in result.items()]
         else:
             addresses = [[k, v] for k, v in result.items()]
     else:
@@ -143,7 +150,7 @@ def attr(host=False, **kwargs):
     sys.stdout = _stdout
 
     if host:
-        pairs = [[k.split('.')[0], v] for k, v in _minions.items()]
+        pairs = [[_grain_host(local, k), v] for k, v in _minions.items()]
     else:
         pairs = [[k, v] for k, v in _minions.items()]
     return pairs


### PR DESCRIPTION
````
Usually, it's safe to assume that the short hostname (as is used for
MON, MDS, MGR and RGW instance IDs) is everything up to the first dot
in the FQDN.  Unfortunately that's not necessarily true when importing
a Ceph cluster that was deployed by Crowbar, into DeepSea.

Crowbar will give systems hostnames like this:

  d52-54-00-76-21-bc.example.com

That's the FQDN of the salt minion, on Crowbar's admin network
(192.168.124.0/24).  That's fine so far.  But, when Crowbar deploys
MON, MDS, RGW, etc., these will usually be running on Crowbar's public
network (192.168.126.0/24).  There'll be a separate DNS entry for these
public IP addresses (e.g.: public.d52-54-00-76-21-bc.example.com),
and -- here's the problem -- the instance ID used for, say, the MONs,
will be:

  public.d52-54-00-76-21-bc

That "shortish" name is what needs to be used for daemon instance and
key IDs, but it's impossible to derive that from the minion's FQDN.
Fortunately, we can cheat, by having the administrator manually prepend
"public." to the host grain for each host, e.g.:

  # salt d52-54-00-76-21-bc.example.com grains.set host public.d52-54-00-76-21-bc
  # (...repeat for all other hosts...)

The SLS files that create the daemon services all use grains['host']
already for instance IDs, so the service activation works with this
trick.  The missing piece is key IDs, which use:

  salt.saltutil.runner('select.minions', cluster='ceph', roles='...', host=True)

That's what this commit changes.  The various select functions now
dig out the value of the host grain, rather than just cutting off
the first part of the FQDN, in case the host grain has been overriden
as described above.

Signed-off-by: Tim Serong <tserong@suse.com>
````