### PR TITLE
add sortbitwise flag and split them up nicely

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -492,6 +492,10 @@ copy-files:
 	install -m 644 srv/salt/ceph/sync/*.sls $(DESTDIR)/srv/salt/ceph/sync/
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/setosdflags
 	install -m 644 srv/salt/ceph/setosdflags/*.sls $(DESTDIR)/srv/salt/ceph/setosdflags
+	install -d -m 755 $(DESTDIR)/srv/salt/ceph/setosdflags/requireosdrelease
+	install -m 644 srv/salt/ceph/setosdflags/requireosdrelease/*.sls $(DESTDIR)/srv/salt/ceph/setosdflags/requireosdrelease
+	install -d -m 755 $(DESTDIR)/srv/salt/ceph/setosdflags/sortbitwise
+	install -m 644 srv/salt/ceph/setosdflags/sortbitwise/*.sls $(DESTDIR)/srv/salt/ceph/setosdflags/sortbitwise
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/time
 	install -m 644 srv/salt/ceph/time/default.sls $(DESTDIR)/srv/salt/ceph/time/
 	install -m 644 srv/salt/ceph/time/disabled.sls $(DESTDIR)/srv/salt/ceph/time/

--- a/deepsea.spec
+++ b/deepsea.spec
@@ -281,6 +281,8 @@ systemctl try-restart salt-api > /dev/null 2>&1 || :
 %dir /srv/salt/ceph/sysctl
 %dir /srv/salt/ceph/sysctl/files
 %dir /srv/salt/ceph/setosdflags
+%dir /srv/salt/ceph/setosdflags/sortbitwise
+%dir /srv/salt/ceph/setosdflags/requireosdrelease
 %dir /srv/salt/ceph/time
 %dir /srv/salt/ceph/time/ntp
 %dir /srv/salt/ceph/time/ntp/files
@@ -508,6 +510,8 @@ systemctl try-restart salt-api > /dev/null 2>&1 || :
 %config /srv/salt/ceph/sysctl/*.sls
 %config /srv/salt/ceph/sysctl/files/*.conf
 %config /srv/salt/ceph/setosdflags/*.sls
+%config /srv/salt/ceph/setosdflags/requireosdrelease/*.sls
+%config /srv/salt/ceph/setosdflags/sortbitwise/*.sls
 %config /srv/salt/ceph/time/*.sls
 %config /srv/salt/ceph/time/ntp/*.sls
 %config /srv/salt/ceph/time/ntp/files/*.j2

--- a/srv/salt/ceph/maintenance/upgrade/master/default.sls
+++ b/srv/salt/ceph/maintenance/upgrade/master/default.sls
@@ -9,6 +9,12 @@ sync all:
     - sls: ceph.sync
     - failhard: True
 
+set sortbitwise flag: 
+  salt.state:
+    - sls: ceph.setosdflags.sortbitwise
+    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - failhard: True
+
 # May generate an unpack error which is safe to ignore
 update deepsea and master:
   salt.state:

--- a/srv/salt/ceph/maintenance/upgrade/minion/default.sls
+++ b/srv/salt/ceph/maintenance/upgrade/minion/default.sls
@@ -153,7 +153,7 @@ unset noout after final iteration:
 
 set luminous osds: 
   salt.state:
-    - sls: ceph.setosdflags
+    - sls: ceph.setosdflags.requireosdrelease
     - tgt: {{ salt['pillar.get']('master_minion') }}
     - failhard: True
 

--- a/srv/salt/ceph/setosdflags/default.sls
+++ b/srv/salt/ceph/setosdflags/default.sls
@@ -1,4 +1,3 @@
-osd flags:
-  cmd.run:
-    - name: "ceph osd require-osd-release luminous"
-    - fire_event: True
+include:
+  - .requireosdrelease
+  - .sortbitwise

--- a/srv/salt/ceph/setosdflags/requireosdrelease/default.sls
+++ b/srv/salt/ceph/setosdflags/requireosdrelease/default.sls
@@ -1,0 +1,4 @@
+osd flags require osd release luminous:
+  cmd.run:
+    - name: "ceph osd require-osd-release luminous"
+    - fire_event: True

--- a/srv/salt/ceph/setosdflags/requireosdrelease/init.sls
+++ b/srv/salt/ceph/setosdflags/requireosdrelease/init.sls
@@ -1,0 +1,2 @@
+include:
+  - .{{ salt['pillar.get']('require_osd_release_lum_init', 'default') }}

--- a/srv/salt/ceph/setosdflags/sortbitwise/default.sls
+++ b/srv/salt/ceph/setosdflags/sortbitwise/default.sls
@@ -1,0 +1,4 @@
+osd flags sortbitwise:
+  cmd.run:
+    - name: "ceph osd set sortbitwise"
+    - fire_event: True

--- a/srv/salt/ceph/setosdflags/sortbitwise/init.sls
+++ b/srv/salt/ceph/setosdflags/sortbitwise/init.sls
@@ -1,0 +1,2 @@
+include:
+  - .{{ salt['pillar.get']('sortbitwise_init', 'default') }}


### PR DESCRIPTION
Make sure to set the osd flag before we upgrade the cluster to not run
into http://tracker.ceph.com/issues/20416.

Signed-off-by: Joshua Schmid <jschmid@suse.de>