### PR TITLE
Fix return code issue in ui_iscsi.deploy runner.

### DIFF
--- a/srv/modules/runners/ui_iscsi.py
+++ b/srv/modules/runners/ui_iscsi.py
@@ -309,7 +309,7 @@ def deploy(**kwargs):
     """
     runner = salt.runner.RunnerClient(salt.config.client_config('/etc/salt/master'))
     result = runner.cmd('state.orch', ['ceph.stage.iscsi'], print_event=False)
-    return result['data']['retcode'] == 0
+    return result['retcode'] == 0
 
 
 def undeploy(**kwargs):


### PR DESCRIPTION
If the return code is meant then result['retcode'] must be used, see https://github.com/saltstack/salt/blob/2016.11/salt/runners/state.py#L68, otherwise feel free to decline this PR.

@rjfd Please review this PR, too.

Signed-off-by: Volker Theile <vtheile@suse.com>
