### PR TITLE
Fixed typo in deepsea_minions.sls

### DIFF
--- a/srv/pillar/ceph/deepsea_minions.sls
+++ b/srv/pillar/ceph/deepsea_minions.sls
@@ -1,4 +1,4 @@
-# See `man deepsea.minions` for details
+# See `man deepsea-minions` for details
 
 # Choose minions with a deepsea grain
 deepsea_minions: 'G@deepsea:*'


### PR DESCRIPTION
The man page is named `deepsea-minions`, not `deepsea.minions`.