### PR TITLE
pyfakefs 3.3 removes support for python 2.6

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ commands =  py.test --tb=line -v --junitxml=junit-{envname}.xml {posargs}
 deps =
     {[base]deps}
     mock
-    pyfakefs
+    pyfakefs<3.3
     pytest
     salttesting
     configobj


### PR DESCRIPTION
Signed-off-by: Eric Jackson <ejackson@suse.com>