### PR TITLE
Add client processes to list of checked processes

### DIFF
--- a/srv/salt/_modules/cephprocesses.py
+++ b/srv/salt/_modules/cephprocesses.py
@@ -36,6 +36,10 @@ def check(results=False, quiet=False, **kwargs):
                  'ganesha': ['ganesha.nfsd', 'rpcbind', 'rpc.statd'],
                  'admin': [],
                  'openattic': ['httpd-prefork'],
+                 'client-cephfs': [],
+                 'client-iscsi': [],
+                 'client-nfs': [],
+                 'client-radosgw': [],
                  'master': []}
 
     running = True


### PR DESCRIPTION
Fix same error as in https://github.com/SUSE/DeepSea/pull/661 with client-cephfs, client-nfs, client-radosgw and client-iscsi roles

Signed-off-by: Jozef Pupava <jpupava@suse.com>