### PR TITLE
CentOS 7 support changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,26 @@
 # Override this to install docs somewhere else
 DOCDIR = /usr/share/doc/packages
 
+OS=$(shell source /etc/os-release ; echo $$ID)
+ifeq ($(OS), opensuse)
+USER=salt
+GROUP=salt
+PKG_INSTALL=zypper -n install
+else
+ifeq ($(OS), sles)
+USER=salt
+GROUP=salt
+PKG_INSTALL=zypper -n install
+else
+USER=root
+GROUP=root
+ifeq ($(OS), centos)
+PKG_INSTALL=yum install -y
+endif
+endif
+endif
+
+
 usage:
 	@echo "Usage:"
 	@echo -e "\tmake install\tInstall DeepSea on this host"
@@ -556,28 +576,29 @@ copy-files:
 	# in a buildroot on OBS, hence the leading '-' to ignore failures
 	# and '|| true' to suppress some error output, but will work fine
 	# in development when root runs `make install`.
-	-chown salt:salt $(DESTDIR)/srv/salt/ceph/admin/cache || true
-	-chown salt:salt $(DESTDIR)/srv/salt/ceph/ganesha/cache || true
-	-chown salt:salt $(DESTDIR)/srv/salt/ceph/igw/cache || true
-	-chown salt:salt $(DESTDIR)/srv/salt/ceph/mds/cache || true
-	-chown salt:salt $(DESTDIR)/srv/salt/ceph/mgr/cache || true
-	-chown salt:salt $(DESTDIR)/srv/salt/ceph/mon/cache || true
-	-chown salt:salt $(DESTDIR)/srv/salt/ceph/openattic/cache || true
-	-chown salt:salt $(DESTDIR)/srv/salt/ceph/osd/cache || true
-	-chown salt:salt $(DESTDIR)/srv/salt/ceph/rgw/cache || true
-	-chown salt:salt $(DESTDIR)/srv/salt/ceph/configuration/files/ceph.conf.checksum || true
+
+	-chown $(USER):$(GROUP) $(DESTDIR)/srv/salt/ceph/admin/cache || true
+	-chown $(USER):$(GROUP) $(DESTDIR)/srv/salt/ceph/ganesha/cache || true
+	-chown $(USER):$(GROUP) $(DESTDIR)/srv/salt/ceph/igw/cache || true
+	-chown $(USER):$(GROUP) $(DESTDIR)/srv/salt/ceph/mds/cache || true
+	-chown $(USER):$(GROUP) $(DESTDIR)/srv/salt/ceph/mgr/cache || true
+	-chown $(USER):$(GROUP) $(DESTDIR)/srv/salt/ceph/mon/cache || true
+	-chown $(USER):$(GROUP) $(DESTDIR)/srv/salt/ceph/openattic/cache || true
+	-chown $(USER):$(GROUP) $(DESTDIR)/srv/salt/ceph/osd/cache || true
+	-chown $(USER):$(GROUP) $(DESTDIR)/srv/salt/ceph/rgw/cache || true
+	-chown $(USER):$(GROUP) $(DESTDIR)/srv/salt/ceph/configuration/files/ceph.conf.checksum || true
 
 install: copy-files
 	sed -i '/^sharedsecret: /s!{{ shared_secret }}!'`cat /proc/sys/kernel/random/uuid`'!' $(DESTDIR)/etc/salt/master.d/sharedsecret.conf
-	chown salt:salt $(DESTDIR)/etc/salt/master.d/*
+	chown $(USER):$(GROUP) $(DESTDIR)/etc/salt/master.d/*
 	echo "deepsea_minions: '*'" > /srv/pillar/ceph/deepsea_minions.sls
-	chown -R salt /srv/pillar/ceph
+	chown -R $(USER) /srv/pillar/ceph
 	sed -i '/^master_minion:/s!_REPLACE_ME_!'`cat /etc/salt/minion_id`'!' /srv/pillar/ceph/master_minion.sls
 	systemctl restart salt-master
-	zypper -n install salt-api
+	$(PKG_INSTALL) salt-api python-ipaddress
 	systemctl restart salt-api
 	# deepsea-cli
-	zypper -n install python-setuptools python-click
+	$(PKG_INSTALL) python-setuptools python-click
 	python setup.py install --root=$(DESTDIR)/
 
 rpm: tarball test

--- a/cli/stage_parser.py
+++ b/cli/stage_parser.py
@@ -438,7 +438,11 @@ class SLSParser(object):
             """
             # changing process user to "salt" so that any runner side-effects during SLS rendering
             # are done with salt user as owner
-            pw = pwd.getpwnam("salt")
+            try:
+                pw = pwd.getpwnam("salt")
+            except KeyError:
+                # salt user not found, fallback to root
+                pw = pwd.getpwnam("root")
             os.setgid(pw.pw_gid)
             os.setuid(pw.pw_uid)
 

--- a/srv/salt/_modules/deepsea.py
+++ b/srv/salt/_modules/deepsea.py
@@ -95,3 +95,23 @@ def render_sls(state_arg):
         return result
     else:
         return None
+
+
+def user():
+    """
+    Returns the system user name for running the salt-master and own files
+    """
+    if __grains__.get('os_family', '') == 'Suse':
+        return 'salt'
+    else:
+        return 'root'
+
+
+def group():
+    """
+    Returns the system group name used for running the salt-master and own files
+    """
+    if __grains__.get('os_family', '') == 'Suse':
+        return 'salt'
+    else:
+        return 'root'

--- a/srv/salt/ceph/admin/key/default.sls
+++ b/srv/salt/ceph/admin/key/default.sls
@@ -4,11 +4,11 @@
 {% set keyring_file = "/srv/salt/ceph/admin/cache/ceph.client.admin.keyring" %}
 {{ keyring_file }}:
   file.managed:
-    - source: 
+    - source:
       - salt://ceph/admin/files/keyring.j2
     - template: jinja
-    - user: salt
-    - group: salt
+    - user: {{ salt['deepsea.user']() }}
+    - group: {{ salt['deepsea.group']() }}
     - mode: 600
     - makedirs: True
     - context:

--- a/srv/salt/ceph/configuration/create/default.sls
+++ b/srv/salt/ceph/configuration/create/default.sls
@@ -1,4 +1,3 @@
-
 removing minion cache:
   file.absent:
     - name: /var/cache/salt/minion/files/base/ceph/configuration
@@ -7,8 +6,8 @@ removing minion cache:
   file.managed:
     - source: salt://ceph/configuration/files/ceph.conf.j2
     - template: jinja
-    - user: salt
-    - group: salt
+    - user: {{ salt['deepsea.user']() }}
+    - group: {{ salt['deepsea.group']() }}
     - mode: 644
     - makedirs: True
     - fire_event: True

--- a/srv/salt/ceph/ganesha/config/default.sls
+++ b/srv/salt/ceph/ganesha/config/default.sls
@@ -2,7 +2,6 @@
 {# need the context role to be silver, silver, gold, platinum, red, blue #}
 {# red and blue are cephfs configs #}
 
-
 prevent empty rendering:
   test.nop:
     - name: skip
@@ -24,8 +23,8 @@ check {{ role }}:
       - salt://ceph/ganesha/files/{{ role }}.conf.j2
     - template: jinja
     - makedirs: True
-    - user: salt
-    - group: salt
+    - user: {{ salt['deepsea.user']() }}
+    - group: {{ salt['deepsea.group']() }}
     - mode: 600
     - context:
       role: {{ salt['rgw.configuration'](role) }}

--- a/srv/salt/ceph/ganesha/install/default.sls
+++ b/srv/salt/ceph/ganesha/install/default.sls
@@ -1,6 +1,23 @@
+{% if grains.get('os', '') == 'CentOS' %}
 
-install ganesha:
-  cmd.run:
-    - name: "zypper --non-interactive in nfs-ganesha nfs-ganesha-ceph nfs-ganesha-rgw nfs-ganesha-utils"
-    - shell: /bin/bash
+install_ganesha_repo:
+  pkgrepo.managed:
+    - name: nfs-ganesha-repo
+    - humanname: NFS Ganesha repo
+    - baseurl: http://download.ceph.com/nfs-ganesha/rpm-V2.5-stable/luminous/$basearch/
+    - gpgcheck: False
+    - enabled: True
+    - fire_event: True
 
+{% endif %}
+
+install_ganesha:
+  pkg.installed:
+    - pkgs:
+        - nfs-ganesha
+        - nfs-ganesha-ceph
+        - nfs-ganesha-rgw
+{% if grains.get('os_family', '') == 'Suse' %}
+        - nfs-ganesha-utils
+{% endif %}
+    - fire_event: True

--- a/srv/salt/ceph/ganesha/key/default.sls
+++ b/srv/salt/ceph/ganesha/key/default.sls
@@ -1,4 +1,3 @@
-
 prevent empty rendering:
   test.nop:
     - name: skip
@@ -16,11 +15,11 @@ check {{ role }}:
 
 {{ keyring_file}}:
   file.managed:
-    - source: 
+    - source:
       - salt://ceph/ganesha/files/{{ role }}.j2
     - template: jinja
-    - user: salt
-    - group: salt
+    - user: {{ salt['deepsea.user']() }}
+    - group: {{ salt['deepsea.group']() }}
     - mode: 600
     - makedirs: True
     - context:

--- a/srv/salt/ceph/ganesha/service/default.sls
+++ b/srv/salt/ceph/ganesha/service/default.sls
@@ -1,3 +1,15 @@
+{% if grains.get('os', '') == 'CentOS' %}
+
+# for some reason the systemd service for nfs-ganesha is not working properly
+# for CentOS, and therefore we are starting the service manually
+start-ganesha:
+  cmd.run:
+    - name: "/usr/bin/ganesha.nfsd -L /var/log/ganesha/ganesha.log -f /etc/ganesha/ganesha.conf -N NIV_EVENT"
+    - shell: /bin/bash
+    - unless: "pgrep ganesha.nfsd"
+
+{% else %}
+
 start-ganesha:
   cmd.run:
     - name: "systemctl restart nfs-ganesha"
@@ -7,3 +19,5 @@ enable-ganesha:
   cmd.run:
     - name: "systemctl enable nfs-ganesha"
     - shell: /bin/bash
+
+{% endif %}

--- a/srv/salt/ceph/igw/config/default.sls
+++ b/srv/salt/ceph/igw/config/default.sls
@@ -1,4 +1,3 @@
-
 igw nop:
   test.nop
 
@@ -23,11 +22,11 @@ demo image:
 
 /srv/salt/ceph/igw/cache/lrbd.conf:
   file.managed:
-    - source: 
+    - source:
       - salt://ceph/igw/files/lrbd.conf.j2
     - template: jinja
-    - user: salt
-    - group: salt
+    - user: {{ salt['deepsea.user']() }}
+    - group: {{ salt['deepsea.group']() }}
     - mode: 600
 
 # this will guarantee that lrbd.conf will be seen by minions

--- a/srv/salt/ceph/igw/key/default.sls
+++ b/srv/salt/ceph/igw/key/default.sls
@@ -1,4 +1,3 @@
-
 prevent empty rendering:
   test.nop:
     - name: skip
@@ -8,15 +7,16 @@ prevent empty rendering:
 {% set keyring_file = salt['keyring.file']('igw', client)  %}
 {{ keyring_file}}:
   file.managed:
-    - source: 
+    - source:
       - salt://ceph/igw/files/keyring.j2
     - template: jinja
-    - user: salt
-    - group: salt
+    - user: {{ salt['deepsea.user']() }}
+    - group: {{ salt['deepsea.group']() }}
     - mode: 600
     - makedirs: True
     - context:
       client: {{ client }}
       secret: {{ salt['keyring.secret'](keyring_file) }}
+    - fire_event: True
 
 {% endfor %}

--- a/srv/salt/ceph/mds/key/default.sls
+++ b/srv/salt/ceph/mds/key/default.sls
@@ -1,4 +1,3 @@
-
 prevent empty rendering:
   test.nop:
     - name: skip
@@ -8,11 +7,11 @@ prevent empty rendering:
 {% set keyring_file = salt['keyring.file']('mds', host)  %}
 {{ keyring_file}}:
   file.managed:
-    - source: 
+    - source:
       - salt://ceph/mds/files/keyring.j2
     - template: jinja
-    - user: salt
-    - group: salt
+    - user: {{ salt['deepsea.user']() }}
+    - group: {{ salt['deepsea.group']() }}
     - mode: 600
     - makedirs: True
     - context:

--- a/srv/salt/ceph/mgr/key/default.sls
+++ b/srv/salt/ceph/mgr/key/default.sls
@@ -1,4 +1,3 @@
-
 prevent empty rendering:
   test.nop:
     - name: skip
@@ -11,8 +10,8 @@ prevent empty rendering:
     - source:
       - salt://ceph/mgr/files/keyring.j2
     - template: jinja
-    - user: salt
-    - group: salt
+    - user: {{ salt['deepsea.user']() }}
+    - group: {{ salt['deepsea.group']() }}
     - mode: 600
     - makedirs: True
     - context:

--- a/srv/salt/ceph/mon/key/default.sls
+++ b/srv/salt/ceph/mon/key/default.sls
@@ -1,12 +1,11 @@
-
 {% set keyring_file = "/srv/salt/ceph/mon/cache/mon.keyring" %}
 {{ keyring_file }}:
   file.managed:
     - source:
       - salt://ceph/mon/files/keyring.j2
     - template: jinja
-    - user: salt
-    - group: salt
+    - user: {{ salt['deepsea.user']() }}
+    - group: {{ salt['deepsea.group']() }}
     - mode: 600
     - makedirs: True
     - context:

--- a/srv/salt/ceph/monitoring/grafana/init.sls
+++ b/srv/salt/ceph/monitoring/grafana/init.sls
@@ -1,3 +1,16 @@
+{% if grains.get('os', '') == 'CentOS' %}
+
+configure_grafana_repo:
+  pkgrepo.managed:
+    - name: grafana-repo
+    - humanname: CentoOS-$releasever - Grafana Repo
+    - baseurl: https://packagecloud.io/grafana/stable/el/$releasever/$basearch/
+    - gpgcheck: False
+    - enabled: True
+    - fire_event: True
+
+{% endif %}
+
 grafana:
   pkg.installed:
     - name: grafana

--- a/srv/salt/ceph/monitoring/prometheus/alertmanager.sls
+++ b/srv/salt/ceph/monitoring/prometheus/alertmanager.sls
@@ -1,3 +1,18 @@
+{% if grains.get('os', '') == 'CentOS' %}
+
+install_alertmanager:
+  pkg.installed:
+    - name: alertmanager
+    - refresh: True
+    - fire_event: True
+
+start alertmanager service:
+  service.running:
+    - name: alertmanager
+    - enable: True
+
+{% else %}
+
 golang-github-prometheus-alertmanager:
   pkg.installed:
     - fire_event: True
@@ -7,3 +22,5 @@ start prometheus-alertmanager:
   service.running:
     - name: prometheus-alertmanager
     - enable: True
+
+{% endif %}

--- a/srv/salt/ceph/monitoring/prometheus/exporters/ceph_rgw_exporter/default.sls
+++ b/srv/salt/ceph/monitoring/prometheus/exporters/ceph_rgw_exporter/default.sls
@@ -1,6 +1,10 @@
 install_package:
   pkg.installed:
+  {% if grains.get('os', '') == 'CentOS' %}
+    - name: python2-prometheus_client
+  {% else %}
     - name: python-prometheus-client
+  {% endif %}
     - refresh: True
 
 install_rgw_exporter:

--- a/srv/salt/ceph/monitoring/prometheus/exporters/node_exporter.sls
+++ b/srv/salt/ceph/monitoring/prometheus/exporters/node_exporter.sls
@@ -1,8 +1,28 @@
+{% if grains.get('os', '') == 'CentOS' %}
+install_prometheus_repo:
+  pkgrepo.managed:
+    - name: prometheus-rpm_release
+    - humanname: Prometheus release repo
+    - baseurl: https://packagecloud.io/prometheus-rpm/release/el/$releasever/$basearch
+    - gpgcheck: False
+    - enabled: True
+    - fire_event: True
+
+install_node_exporter:
+  pkg.installed:
+    - name: node_exporter
+    - refresh: True
+    - fire_event: True
+
+{% else %}
+
 install node exporter package:
   pkg.installed:
     - name: golang-github-prometheus-node_exporter
     - refresh: True
     - fire_event: True
+
+{% endif %}
 
 set node exporter service args:
   file.managed:
@@ -13,11 +33,25 @@ set node exporter service args:
               -collector.filesystem.ignored-mount-points=^/(sys|proc|dev|run)($|/) \
               -collector.textfile.directory=/var/lib/prometheus/node-exporter"
 
+{% if grains.get('os', '') == 'CentOS' %}
+
+install smartmontools and cron packages:
+  pkg.installed:
+    - pkgs:
+      - cronie
+      - smartmontools
+    - fire_event: True
+
+{% else %}
+
 install smartmontools and cron packages:
   pkg.installed:
     - pkgs:
       - cron
       - smartmontools
+    - fire_event: True
+
+{% endif %}
 
 smartmon text exporter:
   file.managed:
@@ -36,6 +70,17 @@ run smartmon exporter hourly:
         #!/bin/sh
         /var/lib/prometheus/node-exporter/smartmon.sh > /var/lib/prometheus/node-exporter/smartmon.prom 2> /dev/null
 
+{% if grains.get('os', '') == 'CentOS' %}
+
+start node exporter:
+  service.running:
+    - name: node_exporter
+    - enable: True
+    - watch:
+      - file: /etc/sysconfig/prometheus-node_exporter
+
+{% else %}
+
 start node exporter:
   service.running:
     - name: prometheus-node_exporter
@@ -43,3 +88,5 @@ start node exporter:
     # restart node_exporter if env_args change
     - watch:
       - file: /etc/sysconfig/prometheus-node_exporter
+
+{% endif %}

--- a/srv/salt/ceph/monitoring/prometheus/exporters/rbd_exporter.sls
+++ b/srv/salt/ceph/monitoring/prometheus/exporters/rbd_exporter.sls
@@ -2,7 +2,11 @@
 install rbd exporter dependencies:
   pkg.installed:
     - pkgs:
+{% if grains.get('os', '') == 'CentOS' %}
+      - cronie
+{% else %}
       - cron
+{% endif %}
       - jq
     - refresh: True
 

--- a/srv/salt/ceph/monitoring/prometheus/init.sls
+++ b/srv/salt/ceph/monitoring/prometheus/init.sls
@@ -1,8 +1,28 @@
+{% if grains.get('os', '') == 'CentOS' %}
+install_prometheus_repo:
+  pkgrepo.managed:
+    - name: prometheus-rpm_release
+    - humanname: Prometheus release repo
+    - baseurl: https://packagecloud.io/prometheus-rpm/release/el/$releasever/$basearch
+    - gpgcheck: False
+    - enabled: True
+    - fire_event: True
+
+install_prometheus:
+  pkg.installed:
+    - name: prometheus
+    - refresh: True
+    - fire_event: True
+
+{% else %}
+
 golang-github-prometheus-prometheus:
   pkg.installed:
     - fire_event: True
     - name: golang-github-prometheus-prometheus
     - refresh: True
+
+{% endif %}
 
 /etc/prometheus/prometheus.yml:
   file.managed:

--- a/srv/salt/ceph/openattic/key/default.sls
+++ b/srv/salt/ceph/openattic/key/default.sls
@@ -1,12 +1,11 @@
-
 {% set keyring_file = "/srv/salt/ceph/openattic/cache/ceph.client.openattic.keyring" %}
 {{ keyring_file }}:
   file.managed:
-    - source: 
+    - source:
       - salt://ceph/openattic/files/keyring.j2
     - template: jinja
-    - user: salt
-    - group: salt
+    - user: {{ salt['deepsea.user']() }}
+    - group: {{ salt['deepsea.group']() }}
     - mode: 600
     - makedirs: True
     - context:

--- a/srv/salt/ceph/osd/key/default.sls
+++ b/srv/salt/ceph/osd/key/default.sls
@@ -1,12 +1,10 @@
-
-
 {% set keyring_file = salt['keyring.file']('osd') %}
 {{ keyring_file}}:
   file.managed:
     - source: salt://ceph/osd/files/keyring.j2
     - template: jinja
-    - user: salt
-    - group: salt
+    - user: {{ salt['deepsea.user']() }}
+    - group: {{ salt['deepsea.group']() }}
     - mode: 600
     - makedirs: True
     - context:
@@ -18,8 +16,8 @@
   file.managed:
     - source: salt://ceph/osd/files/storage.j2
     - template: jinja
-    - user: salt
-    - group: salt
+    - user: {{ salt['deepsea.user']() }}
+    - group: {{ salt['deepsea.group']() }}
     - mode: 600
     - makedirs: True
     - context:

--- a/srv/salt/ceph/packages/common/default.sls
+++ b/srv/salt/ceph/packages/common/default.sls
@@ -28,6 +28,33 @@ stage prep dependencies ubuntu:
     - fire_event: True
     - refresh: True
 
+{% elif os == 'CentOS' %}
+
+hwinfo repo for CentOS:
+  pkgrepo.managed:
+    - name: centos-nux-dextop-repo
+    - humanname: CentoOS-$releasever - Nux Dextop
+    - baseurl: http://li.nux.ro/download/nux/dextop/el$releasever/$basearch/
+    - gpgcheck: False
+    - enabled: True
+    - fire_event: True
+
+stage prep dependencies CentOS:
+  pkg.installed:
+    - pkgs:
+      - lsscsi
+      - pciutils
+      - gdisk
+      - python-boto
+      - python-rados
+      - iperf3
+      - lshw
+      - hwinfo
+      - python-ipaddress
+      - python-netaddr
+    - fire_event: True
+    - refresh: True
+
 {% else %}
 
 nop:

--- a/srv/salt/ceph/packages/default.sls
+++ b/srv/salt/ceph/packages/default.sls
@@ -5,4 +5,3 @@ ceph:
       - ceph
     - dist-upgrade: True
     - fire_event: True
-

--- a/srv/salt/ceph/repo/default.sls
+++ b/srv/salt/ceph/repo/default.sls
@@ -1,3 +1,16 @@
 
 nop:
   test.nop
+
+{% if grains.get('os', '') == 'CentOS' %}
+
+deepsea_centos_packages_repo:
+  pkgrepo.managed:
+    - name: deepsea_centos_packages_repo
+    - humanname: DeepSea - CentoOS-$releasever Repo
+    - baseurl: https://copr-be.cloud.fedoraproject.org/results/rjdias/home/epel-$releasever-$basearch/
+    - gpgcheck: False
+    - enabled: True
+    - fire_event: True
+
+{% endif %}

--- a/srv/salt/ceph/rgw/key/default.sls
+++ b/srv/salt/ceph/rgw/key/default.sls
@@ -1,4 +1,3 @@
-
 prevent empty rendering:
   test.nop:
     - name: skip
@@ -16,11 +15,11 @@ check {{ role }}:
 
 {{ keyring_file}}:
   file.managed:
-    - source: 
+    - source:
       - salt://ceph/rgw/files/{{ role }}.j2
     - template: jinja
-    - user: salt
-    - group: salt
+    - user: {{ salt['deepsea.user']() }}
+    - group: {{ salt['deepsea.group']() }}
     - mode: 600
     - makedirs: True
     - context:

--- a/srv/salt/ceph/salt-api/configure.sls
+++ b/srv/salt/ceph/salt-api/configure.sls
@@ -1,12 +1,11 @@
-
 {% set shared_secret = salt['cmd.run']('cat /proc/sys/kernel/random/uuid') %}
 /etc/salt/master.d/sharedsecret.conf:
   file.managed:
     - source:
       - salt://ceph/salt-api/files/sharedsecret.conf.j2
     - template: jinja
-    - user: salt
-    - group: salt
+    - user: {{ salt['deepsea.user']() }}
+    - group: {{ salt['deepsea.group']() }}
     - mode: 600
     - replace: False
     - context:

--- a/srv/salt/ceph/stage/prep/master/default.sls
+++ b/srv/salt/ceph/stage/prep/master/default.sls
@@ -39,10 +39,12 @@ unlock:
     - item: 'lock'
     - unless: "rpm -q --last kernel-default | head -1 | grep -q {{ kernel }}"
 
+{% if grains.get('os_family', '') == 'Suse' %}
 restart master:
   salt.state:
     - tgt: {{ salt['pillar.get']('master_minion') }}
     - sls: ceph.updates.restart
+{% endif %}
 
 complete marker:
   salt.runner:

--- a/srv/salt/ceph/stage/prep/minion/default.sls
+++ b/srv/salt/ceph/stage/prep/minion/default.sls
@@ -69,12 +69,14 @@ set noout {{ host }}:
     - tgt: {{ salt['pillar.get']('master_minion') }}
     - failhard: True
 
+{% if grains.get('os_family', '') == 'Suse' %}
 restart {{ host }} if updates require:
   salt.state:
     - tgt: {{ host }}
     - tgt_type: compound
     - sls: ceph.updates.restart
     - failhard: True
+{% endif %}
 
 finished {{ host }}:
   salt.runner:
@@ -83,7 +85,7 @@ finished {{ host }}:
 
 {% endfor %}
 
-unset noout after final iteration: 
+unset noout after final iteration:
   salt.state:
     - sls: ceph.noout.unset
     - tgt: {{ salt['pillar.get']('master_minion') }}
@@ -101,12 +103,14 @@ updating minions without roles:
     - sls: ceph.updates
     - failhard: True
 
+{% if grains.get('os_family', '') == 'Suse' %}
 restarting minions without roles:
   salt.state:
     - tgt: I@cluster:ceph
     - tgt_type: compound
     - sls: ceph.updates.restart
     - failhard: True
+{% endif %}
 
 finishing remaining minions:
   salt.runner:
@@ -131,10 +135,12 @@ updates:
     - tgt_type: compound
     - sls: ceph.updates
 
+{% if grains.get('os_family', '') == 'Suse' %}
 restart:
   salt.state:
     - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
     - tgt_type: compound
     - sls: ceph.updates.restart
+{% endif %}
 
 {% endif %}

--- a/srv/salt/ceph/updates/default.sls
+++ b/srv/salt/ceph/updates/default.sls
@@ -1,3 +1,5 @@
 include:
+{% if grains.get('os_family', '') == 'Suse' %}
   - .kernel
+{% endif %}
   - .regular

--- a/srv/salt/ceph/updates/kernel/default.sls
+++ b/srv/salt/ceph/updates/kernel/default.sls
@@ -2,8 +2,8 @@ switch kernel:
   module.run:
     - name: kernel.replace
     - kwargs:
-        os: 
-          SUSE: 
+        os:
+          SUSE:
             kernel: kernel-default
             candidates:
             - kernel-default-base
@@ -12,8 +12,7 @@ packagemanager patch only kernel:
   module.run:
     - name: packagemanager.up
     - kwargs:
-        'reboot': {{ salt['pillar.get']('auto_reboot', True) }} 
-        'debug': {{ salt['pillar.get']('debug', False) }} 
+        'reboot': {{ salt['pillar.get']('auto_reboot', True) }}
+        'debug': {{ salt['pillar.get']('debug', False) }}
         'kernel': True
     - fire_event: True
-

--- a/srv/salt/ceph/updates/regular/default.sls
+++ b/srv/salt/ceph/updates/regular/default.sls
@@ -1,8 +1,19 @@
+{% if grains.get('os_family', '') == 'Suse' %}
+
 packagemanager update regular:
   module.run:
     - name: packagemanager.up
     - kwargs:
-        'reboot': {{ salt['pillar.get']('auto_reboot', True) }} 
-        'debug': {{ salt['pillar.get']('debug', False) }} 
+        'reboot': {{ salt['pillar.get']('auto_reboot', True) }}
+        'debug': {{ salt['pillar.get']('debug', False) }}
         'kernel': False
     - fire_event: True
+
+{% else %}
+
+upgrade packages:
+  pkg.uptodate:
+    - refresh: True
+    - fire_event: True
+
+{% endif %}

--- a/srv/salt/ceph/updates/restart/default.sls
+++ b/srv/salt/ceph/updates/restart/default.sls
@@ -1,6 +1,6 @@
 
 {% set kernel = grains['kernelrelease'] | replace('-default', '')  %}
-{% set installed = salt['cmd.run']('rpm -q --last kernel-default | head -1 | cut -f1 -d\  ') | replace('kernel-default-', '') %}
+{% set installed = salt['kernel.installed_kernel_version']() %}
 
 warning:
   module.run:


### PR DESCRIPTION
This PR pushes changes to make DeepSea to work in CentOS 7 distro.

A demo can be found in:
https://asciinema.org/a/147996

I've created a github repo to hold the packaging files for fedora Copr. That repo is available in:
https://github.com/rjfd/deepsea_rpm
You can take a look if you want.

The RPM package for CentOS is available in:
https://copr.fedorainfracloud.org/coprs/rjdias/home/packages/