### PR TITLE
radosgw: fix creation of radosgw system user

### DIFF
--- a/srv/salt/_modules/rgw.py
+++ b/srv/salt/_modules/rgw.py
@@ -102,6 +102,8 @@ def add_users(pathname="/srv/salt/ceph/rgw/cache", jinja="/srv/salt/ceph/rgw/fil
                 args = ''
                 if 'email' in user:
                     args += " --email={}".format(user['email'])
+                if 'system' in user and user['system']:
+                    args += " --system"
                 if 'access_key' in user:
                     args += " --access-key={}".format(user['access_key'])
 


### PR DESCRIPTION
Fixes a regression introduced in commit 0b5116e of PR #765 

In the commit referenced above, the verification of the 'system' flag was removed and thus currently DeepSea does not create the admin user with the `--system` option.

@smithfarm could you check why our radosgw suite did not catch this regression?

**Credits for finding this bug goes to @tspmelo (Tiago Melo)**

Signed-off-by: Ricardo Dias <rdias@suse.com>