### PR TITLE
spec/fix: add new Prometheus RGW exporter files

### DIFF
--- a/deepsea.spec
+++ b/deepsea.spec
@@ -165,6 +165,9 @@ systemctl try-restart salt-api > /dev/null 2>&1 || :
 %dir /srv/salt/ceph/monitoring/grafana/files
 %dir /srv/salt/ceph/monitoring/prometheus
 %dir /srv/salt/ceph/monitoring/prometheus/exporters
+%dir /srv/salt/ceph/monitoring/prometheus/exporters/ceph_rgw_exporter
+%dir /srv/salt/ceph/monitoring/prometheus/exporters/ceph_rgw_exporter/cron
+%dir /srv/salt/ceph/monitoring/prometheus/exporters/ceph_rgw_exporter/files
 %dir /srv/salt/ceph/monitoring/prometheus/exporters/files
 %dir /srv/salt/ceph/monitoring/prometheus/files
 %dir /srv/salt/ceph/noout
@@ -400,6 +403,9 @@ systemctl try-restart salt-api > /dev/null 2>&1 || :
 %config /srv/salt/ceph/monitoring/grafana/files/*.json
 %config /srv/salt/ceph/monitoring/prometheus/*.sls
 %config /srv/salt/ceph/monitoring/prometheus/exporters/*.sls
+%config /srv/salt/ceph/monitoring/prometheus/exporters/ceph_rgw_exporter/*.sls
+%config /srv/salt/ceph/monitoring/prometheus/exporters/ceph_rgw_exporter/cron/*.sls
+%config /srv/salt/ceph/monitoring/prometheus/exporters/ceph_rgw_exporter/files/*
 %config /srv/salt/ceph/monitoring/prometheus/exporters/files/*
 %config /srv/salt/ceph/monitoring/prometheus/files/*.j2
 %config /srv/salt/ceph/noout/set/*.sls


### PR DESCRIPTION
This commit adds needed SPEC changes for SR#805:
> Refactor Prometheus RGW exporter customization according to the DeepSea conventions.