### PR TITLE
Add version.txt support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ wheels/
 *.egg-info/
 .installed.cfg
 *.egg
+*.tar*
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/Makefile
+++ b/Makefile
@@ -645,6 +645,7 @@ copy-files:
 
 install: copy-files
 	sed -i '/^sharedsecret: /s!{{ shared_secret }}!'`cat /proc/sys/kernel/random/uuid`'!' $(DESTDIR)/etc/salt/master.d/sharedsecret.conf
+	sed -i "s/@VERSION@/$(VERSION)/" $(DESTDIR)/srv/modules/runners/deepsea.py
 	chown salt:salt $(DESTDIR)/etc/salt/master.d/*
 	echo "deepsea_minions: '*'" > /srv/pillar/ceph/deepsea_minions.sls
 	chown -R salt /srv/pillar/ceph
@@ -668,6 +669,7 @@ tarball:
 	cat $(DS_DIR)/deepsea.spec.in | sed -e "s/@VERSION@/$(VERSION)/g" > $(DS_DIR)/deepsea.spec
 	echo "$(VERSION)" > $(DS_DIR)/version.txt
 	sed -i "s/@VERSION@/$(VERSION)/" $(DS_DIR)/setup.py
+	sed -i "s/@VERSION@/$(VERSION)/" $(DS_DIR)/srv/modules/runners/deepsea.py
 	tar -cjf deepsea-$(VERSION).tar.bz2 -C $(TEMPDIR) deepsea-$(VERSION)
 	rm -r $(TEMPDIR)
 

--- a/deepsea.spec.in
+++ b/deepsea.spec.in
@@ -22,7 +22,7 @@
 # See also http://en.opensuse.org/openSUSE:Shared_library_packaging_policy
 
 Name:           deepsea
-Version:        0.8
+Version:        @VERSION@
 Release:        0
 Summary:        Salt solution for deploying and managing Ceph
 
@@ -53,8 +53,6 @@ A collection of Salt files providing a deployment of Ceph as a series of stages.
 
 %build
 make DESTDIR=%{buildroot} pyc
-# rewrite version number in deepsea.spec that lives inside the tarball
-sed -i 's/^Version:.*/Version: %{version}/g' deepsea.spec
 
 %install
 make DESTDIR=%{buildroot} DOCDIR=%{_docdir} copy-files

--- a/setup.py
+++ b/setup.py
@@ -1,22 +1,20 @@
 # -*- coding: utf-8 -*-
-import re
+from __future__ import absolute_import
+
+import sys
 from setuptools import setup
 
 
-def _get_deepsea_version():
-    try:
-        with open('deepsea.spec', 'r') as f:
-            for line in f:
-                if line.startswith("Version:"):
-                    match = re.match('^Version:(.*)', line)
-                    if match:
-                        return match.group(1).strip()
-    except IOError:
-        return "(dev-version)"
+ver_string = None
+if '--set-version' in sys.argv:
+    idx = sys.argv.index('--set-version')
+    sys.argv.pop(idx)
+    ver_string = sys.argv.pop(idx)
+
 
 setup(
     name='deepsea',
-    version=_get_deepsea_version(),
+    version='@VERSION@' if not ver_string else ver_string,
     package_dir={
         'deepsea': 'cli'
     },

--- a/srv/modules/runners/deepsea.py
+++ b/srv/modules/runners/deepsea.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+"""
+This runner implements helper functions for DeepSea in general
+"""
+
+from __future__ import absolute_import
+
+import re
+
+
+def version(**kwargs):
+    # pylint: disable=W0613
+    """
+    Returns the DeepSea version info currently installed
+    """
+    ver = "@VERSION@"
+    match = re.match(r'^([\d\.]+)(\+git\.(\d+).(\w+))?', ver)
+    if match:
+        return {
+            'full_version': ver,
+            'version': match.group(1),
+            'git_offset': match.group(3),
+            'git_hash': match.group(4)
+        }
+    return {
+        'full_version': None,
+        'version': None,
+        'git_offset': None,
+        'git_hash': None
+    }


### PR DESCRIPTION
This PR moves the source of the version number from the spec file to the file `version.txt`, which is also installed by the RPM and Makefile installation.

The tarball generation implemented in the Makefile is also changed to use the new version number location. The tarball generation, besides creating the tarball it also creates a deepsea spec file with a version number that is composed by:
 * the string inside `version.txt` file (DeepSea release number)
* the offset (number of commits since the last commit that changed the `version.txt` file)
 * the commit hash

Signed-off-by: Ricardo Dias <rdias@suse.com>