### PR TITLE
[backport] qa: show deepsea RPM version in case deepsea was installed from RPM

### DIFF
--- a/qa/common/common.sh
+++ b/qa/common/common.sh
@@ -30,6 +30,9 @@ rpm -q salt-api
 # show deepsea RPM version in case deepsea was installed from RPM
 rpm -q deepsea || true
 
+# show deepsea RPM version in case deepsea was installed from RPM
+rpm -q deepsea || true
+
 # set deepsea_minions to * - see https://github.com/SUSE/DeepSea/pull/526
 # (otherwise we would have to set deepsea grain on all minions)
 echo "deepsea_minions: '*'" > /srv/pillar/ceph/deepsea_minions.sls


### PR DESCRIPTION
Signed-off-by: Nathan Cutler <ncutler@suse.com>
(cherry picked from commit 289c996adff9c75672a890679c26c8dd188ee875)