### PR TITLE
[backport] qa: health-ok.sh: liberally accept both --encrypted and --encryption

### DIFF
--- a/qa/suites/basic/health-ok.sh
+++ b/qa/suites/basic/health-ok.sh
@@ -36,7 +36,7 @@ function usage {
     exit 1
 }
 
-TEMP=$(getopt -o h --long "cli" \
+TEMP=$(getopt -o h --long "cli,encrypted,encryption" \
      -n 'health-ok.sh' -- "$@")
 
 if [ $? != 0 ] ; then echo "Terminating..." >&2 ; exit 1 ; fi
@@ -50,7 +50,7 @@ ENCRYPTION=""
 while true ; do
     case "$1" in
         --cli) CLI="cli" ; shift ;;
-        --encrypted) ENCRYPTION="encryption" ; shift ;;
+        --encrypted|--encryption) ENCRYPTION="encryption" ; shift ;;
         -h|--help) usage ;;    # does not return
         --) shift ; break ;;
         *) echo "Internal error" ; exit 1 ;;


### PR DESCRIPTION
The usage() function says it should be "--encryption" but we were
only accepting "--encrypted".

Actually, we were not even doing that effectively - this commit also makes
the needed adjustment to --long option we are sending to getopt.

Signed-off-by: Nathan Cutler <ncutler@suse.com>
(cherry picked from commit 6faa1a7f83c2e6f734637b3d2c2ce4facdab65a3)