### PR TITLE
[backport] pyfakefs 3.3 removes support for python 2.6

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ commands =  py.test --tb=line -v --junitxml=junit-{envname}.xml {posargs}
 deps =
     {[base]deps}
     mock
-    pyfakefs
+    pyfakefs<3.3
     pytest
     salttesting
     configobj


### PR DESCRIPTION
Signed-off-by: Eric Jackson <ejackson@suse.com>
(cherry picked from commit 10738568b80a67eb37beed7945481cfba65c1f02)