### PR TITLE
[backport] "NaN ns" in Dashboard (bsc1065590)

### DIFF
--- a/srv/salt/ceph/monitoring/grafana/files/ceph-cluster.json
+++ b/srv/salt/ceph/monitoring/grafana/files/ceph-cluster.json
@@ -1020,8 +1020,8 @@
             "valueMaps": [
               {
                 "op": "=",
-                "text": "N/A",
-                "value": "null"
+                "text": "0 s",
+                "value": "0"
               }
             ],
             "valueName": "avg"
@@ -1098,8 +1098,8 @@
             "valueMaps": [
               {
                 "op": "=",
-                "text": "N/A",
-                "value": "null"
+                "text": "0 s",
+                "value": "0"
               }
             ],
             "valueName": "avg"


### PR DESCRIPTION
To fix this issue a mapping for "0" => "0 s" is added. The other solution to set the decimal precision to 1 seems not to work, the widget still shows 'xxx s' for example instead of 'xxx.y s' as usual.

backport of #764 
Signed-off-by: Volker Theile <vtheile@suse.com>
(cherry picked from commit 1b860c90cac13a0189cda43361a1e6d619646a1a)