### PR TITLE
[backport] If the return code is meant then result['retcode'] must be used, see …

### DIFF
--- a/srv/modules/runners/ui_iscsi.py
+++ b/srv/modules/runners/ui_iscsi.py
@@ -298,7 +298,7 @@ def status(**kwargs):
 def deploy(**kwargs):
     runner = salt.runner.RunnerClient(salt.config.client_config('/etc/salt/master'))
     result = runner.cmd('state.orch', ['ceph.stage.iscsi'], print_event=False)
-    return result['data']['retcode'] == 0
+    return result['retcode'] == 0
 
 
 def undeploy(**kwargs):


### PR DESCRIPTION
backport of #784 
…https://github.com/saltstack/salt/blob/2016.11/salt/runners/state.py#L68.

Signed-off-by: Volker Theile <vtheile@suse.com>
(cherry picked from commit 2b4a09545bf6fd8ea8f506b7b509e093ebc3a1b3)