### PR TITLE
[backport] Quash ceph-disk deprecation warning

### DIFF
--- a/srv/salt/_modules/cephinspector.py
+++ b/srv/salt/_modules/cephinspector.py
@@ -178,7 +178,8 @@ def get_ceph_disks_yml(**kwargs):
                                 {"format": "filestore",
                                  "journal": "/dev/bar"}}}}}
     """
-    ceph_disk_list = Popen("ceph-disk list --format=json", stdout=PIPE, stderr=PIPE, shell=True)
+    ceph_disk_list = Popen("PYTHONWARNINGS=ignore ceph-disk list --format=json",
+                           stdout=PIPE, stderr=PIPE, shell=True)
     out, err = ceph_disk_list.communicate()
     ceph_disks = {"ceph":
                   {"storage":

--- a/srv/salt/_modules/osd.py
+++ b/srv/salt/_modules/osd.py
@@ -1142,7 +1142,7 @@ class OSDCommands(object):
         cmd = ""
         args = ""
         if self.osd.device:
-            cmd = "ceph-disk -v prepare "
+            cmd = "PYTHONWARNINGS=ignore ceph-disk -v prepare "
 
             # Dmcrypt
             if self.osd.encryption == 'dmcrypt':
@@ -1182,7 +1182,7 @@ class OSDCommands(object):
                 prefix = ''
                 if 'nvme' in self.osd.device:
                     prefix = 'p'
-                cmd = "ceph-disk -v activate --mark-init systemd --mount "
+                cmd = "PYTHONWARNINGS=ignore ceph-disk -v activate --mark-init systemd --mount "
                 cmd += "{}{}{}".format(self.osd.device, prefix, self.osd_partition())
 
         log.info("activate: {}".format(cmd))

--- a/tests/unit/_modules/test_osd.py
+++ b/tests/unit/_modules/test_osd.py
@@ -1921,7 +1921,7 @@ class TestOSDCommands():
         osd_config = OSDConfig(**kwargs)
         obj = osdc_o(osd_config)
         ret = obj.activate()
-        assert ret == "ceph-disk -v activate --mark-init systemd --mount /dev/nvme0n1p1"
+        assert ret == "PYTHONWARNINGS=ignore ceph-disk -v activate --mark-init systemd --mount /dev/nvme0n1p1"
 
     @mock.patch('srv.salt._modules.osd.OSDCommands.osd_partition')
     def test_activate_2(self, osdp_mock, osdc_o):
@@ -1938,7 +1938,7 @@ class TestOSDCommands():
         osd_config = OSDConfig(**kwargs)
         obj = osdc_o(osd_config)
         ret = obj.activate()
-        assert ret == "ceph-disk -v activate --mark-init systemd --mount /dev/sdx1"
+        assert ret == "PYTHONWARNINGS=ignore ceph-disk -v activate --mark-init systemd --mount /dev/sdx1"
 
     def test_activate_3(self, osdc_o):
         """


### PR DESCRIPTION
As of luminous 12.2.2 ceph-disk will emit a "loud" (and potentially
disconcerting) warning, whenever it is invocated, unless PYTHONWARNINGS is set
to "ignore".

backport of #809 

Signed-off-by: Nathan Cutler <ncutler@suse.com>
(cherry picked from commit 59cc23039f7859707bd4a303cb36b644a63ab2f6)