### PR TITLE
[backport] Replace slspath with absolute file path.

### DIFF
--- a/srv/salt/ceph/monitoring/prometheus/exporters/ceph_rgw_exporter/default.sls
+++ b/srv/salt/ceph/monitoring/prometheus/exporters/ceph_rgw_exporter/default.sls
@@ -9,7 +9,7 @@ install_rgw_exporter:
     - user: prometheus
     - group: prometheus
     - mode: 755
-    - source: salt://{{ slspath }}/files/ceph_rgw.py
+    - source: salt://ceph/monitoring/prometheus/exporters/ceph_rgw_exporter/files/ceph_rgw.py
     - makedirs: True
 
 include:


### PR DESCRIPTION
backport of #815 

This adds the file instead of just changing it. The cause for it is that https://github.com/SUSE/DeepSea/pull/831 is not yet merged.

Signed-off-by: Volker Theile <vtheile@suse.com>
(cherry picked from commit ad01f5694154a1b63f16cf474eba47349c075e65)