### PR TITLE
[backport] ui_iscsi: support individual management of iSCSI gateways

### DIFF
--- a/srv/modules/runners/ui_iscsi.py
+++ b/srv/modules/runners/ui_iscsi.py
@@ -295,10 +295,73 @@ def status(**kwargs):
     return result
 
 
+def _check_state_result(states):
+    """
+    Given the result of a state apply of a single minion, check if
+    all states were successful or not.
+
+    Returns True if all states were successful, and False otherwise
+    """
+    for _, state in states.items():
+        if not state['result']:
+            return False
+    return True
+
+
+def _deploy_in_minions(minions):
+    """
+    Deploys the lrbd configurations in the respective iSCSI gateways specified in
+    the parameter minions.
+    """
+    result = {'success': True, 'minions': {}}
+
+    # First step import lrbd.conf to Ceph pool, any igw minion can do this
+    runner = salt.runner.RunnerClient(__opts__)
+    imp_minion = runner.cmd('select.one_minion', kwarg={'cluster': 'ceph', 'roles': 'igw'})
+    local = salt.client.LocalClient()
+    state_res = local.cmd(imp_minion, 'state.apply', ['ceph.igw.import'])
+    if not _check_state_result(state_res[imp_minion]):
+        result['success'] = False
+        result['message'] = 'Error applying lrbd.conf.'
+        return result
+
+    # Second step restart lrbd services
+    hostnames = [k for k, _ in interfaces().items()]
+    _minions = []
+    for minion in minions:
+        if minion in hostnames:
+            _minions.append(minion)
+            continue
+        for fqdn in hostnames:
+            if fqdn.startswith(minion) and fqdn[len(minion)] == '.':
+                _minions.append(fqdn)
+                break
+
+    local = salt.client.LocalClient()
+    if minions:
+        target = 'L@{}'.format(','.join(_minions))
+    else:
+        target = 'I@roles:igw'
+    state_res = local.cmd(target, 'state.apply', ['ceph.igw'], expr_form="compound")
+    for minion, states in state_res.items():
+        result['minions'][minion] = _check_state_result(states)
+        if not result['minions'][minion]:
+            result['success'] = False
+
+    if not result['success']:
+        result['message'] = 'Some minions failed to restart the lrbd service.'
+    return result
+
+
 def deploy(**kwargs):
-    runner = salt.runner.RunnerClient(salt.config.client_config('/etc/salt/master'))
-    result = runner.cmd('state.orch', ['ceph.stage.iscsi'], print_event=False)
-    return result['retcode'] == 0
+    """
+    Run iscsi orchestration
+    """
+    if 'minions' in kwargs and kwargs['minions']:
+        minions = kwargs['minions'].split(',')
+    else:
+        minions = []
+    return _deploy_in_minions(minions)
 
 
 def undeploy(**kwargs):

--- a/srv/modules/runners/ui_iscsi.py
+++ b/srv/modules/runners/ui_iscsi.py
@@ -288,10 +288,16 @@ def images(**kwargs):
 
 def status(**kwargs):
     local = salt.client.LocalClient()
-    status = local.cmd('I@roles:igw', 'service.status', ['lrbd'], expr_form='compound')
-    result = True
-    for _, v in status.iteritems():
-        result = result and v
+    _status = local.cmd('I@roles:igw', 'service.status', ['lrbd'], expr_form='compound')
+    _targets = local.cmd('I@roles:igw', 'iscsi.targets', [], expr_form='compound')
+    result = {}
+    for minion in _status:
+        result[minion] = {
+            'active': _status[minion],
+            'targets': _targets[minion]
+        }
+        if not result[minion]['active']:
+            result[minion]['message'] = 'lrbd service is not running'
     return result
 
 

--- a/srv/salt/_modules/iscsi.py
+++ b/srv/salt/_modules/iscsi.py
@@ -1,0 +1,87 @@
+# -*- coding: utf-8 -*-
+"""
+iSCSI execution module
+
+This module allows to query information about iSCSI targets served by a gateway
+"""
+
+from __future__ import absolute_import
+
+import glob
+import os
+
+__virtualname__ = 'iscsi'
+
+__iscsi_path__ = '/sys/kernel/config/target/iscsi'
+
+
+def _local_network_addresses():
+    """
+    Returns the network addresses of this minion
+    """
+    interfaces = __grains__['ip_interfaces']
+    result = []
+    for _, addresses in interfaces.items():
+        result.extend(addresses)
+    return result
+
+
+def _read_bool(file_path):
+    """
+    Reads an int value from a file and converts it into a bool value
+    """
+    with open(file_path, 'r') as file_d:
+        return bool(int(file_d.read()))
+
+
+def _read_int(file_path):
+    """
+    Reads an int value from a file and returns it
+    """
+    with open(file_path, 'r') as file_d:
+        return int(file_d.read())
+
+
+def targets():
+    """
+    Retrieves the information of the iSCSI targets currently deployed in this gateway
+    """
+    if not os.path.exists(__iscsi_path__):
+        return {}
+
+    local_addresses = _local_network_addresses()
+
+    result = {}
+    for target_path in glob.glob('{}/iqn.*'.format(__iscsi_path__)):
+        target_id = target_path.replace('{}/'.format(__iscsi_path__), '')
+        result[target_id] = {}
+        for tpg_path in glob.glob('{}/tpgt_*'.format(target_path)):
+            for portal_path in glob.glob('{}/np/*'.format(tpg_path)):
+                portal_id = portal_path.replace('{}/np/'.format(tpg_path), '')
+                portal_id = portal_id[:portal_id.find(':')]
+
+                if portal_id not in local_addresses:
+                    break
+
+                if 'enabled' not in result[target_id]:
+                    result[target_id]['enabled'] = True
+                enabled = _read_bool('{}/enable'.format(tpg_path))
+                result[target_id]['enabled'] = result[target_id]['enabled'] and enabled
+                if not result[target_id]['enabled']:
+                    result[target_id]['message'] = 'Target is not enabled. Please review ' \
+                                                    'its configuration'
+        if 'enabled' not in result[target_id]:
+            result[target_id]['enabled'] = False
+            result[target_id]['message'] = 'No portals defined for target'
+
+        result[target_id]['sessions'] = _read_int('{}/fabric_statistics/iscsi_instance/sessions'
+                                                  .format(target_path))
+
+    return result
+
+
+def __virtual__():
+    """
+    Salt module virtual function
+    """
+    return __virtualname__


### PR DESCRIPTION
backport of #807 

### all 3 commits resulted in conflicts, please review with care ###

This PR introduces the support for deploying and undeploying the lrbd iSCSI configuration on individual iSCSI gateways.

It also enhances the status information retrieved from each gateway.