### PR TITLE
Refactor Prometheus RGW exporter

### DIFF
--- a/srv/salt/ceph/monitoring/grafana/files/ceph-rgw-users.json
+++ b/srv/salt/ceph/monitoring/grafana/files/ceph-rgw-users.json
@@ -19,6 +19,12 @@
         "id": "prometheus",
         "name": "Prometheus",
         "version": "1.0.0"
+      },
+      {
+        "type": "panel",
+        "id": "singlestat",
+        "name": "Singlestat",
+        "version": ""
       }
     ],
     "annotations": {
@@ -38,6 +44,82 @@
         "height": 231,
         "panels": [
           {
+            "cacheTimeout": null,
+            "colorBackground": false,
+            "colorValue": false,
+            "colors": [
+              "rgba(245, 54, 54, 0.9)",
+              "rgba(237, 129, 40, 0.89)",
+              "rgba(50, 172, 45, 0.97)"
+            ],
+            "datasource": "Prometheus",
+            "format": "none",
+            "gauge": {
+              "maxValue": 100,
+              "minValue": 0,
+              "show": false,
+              "thresholdLabels": false,
+              "thresholdMarkers": true
+            },
+            "id": 12,
+            "interval": null,
+            "links": [],
+            "mappingType": 1,
+            "mappingTypes": [
+              {
+                "name": "value to text",
+                "value": 1
+              },
+              {
+                "name": "range to text",
+                "value": 2
+              }
+            ],
+            "maxDataPoints": 100,
+            "nullPointMode": "connected",
+            "nullText": null,
+            "postfix": "",
+            "postfixFontSize": "50%",
+            "prefix": "",
+            "prefixFontSize": "50%",
+            "rangeMaps": [
+              {
+                "from": "null",
+                "text": "N/A",
+                "to": "null"
+              }
+            ],
+            "span": 4,
+            "sparkline": {
+              "fillColor": "rgba(31, 118, 189, 0.18)",
+              "full": false,
+              "lineColor": "rgb(31, 120, 193)",
+              "show": false
+            },
+            "tableColumn": "",
+            "targets": [
+              {
+                "expr": "count by (owner)(ceph_rgw_bucket_stats_num_objects{owner='$owner'})",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "refId": "A",
+                "step": 600
+              }
+            ],
+            "thresholds": "",
+            "title": "Number of buckets",
+            "type": "singlestat",
+            "valueFontSize": "80%",
+            "valueMaps": [
+              {
+                "op": "=",
+                "text": "N/A",
+                "value": "null"
+              }
+            ],
+            "valueName": "avg"
+          },
+          {
             "aliasColors": {},
             "bars": false,
             "dashLength": 10,
@@ -48,18 +130,18 @@
             "height": "230px",
             "id": 4,
             "legend": {
-              "alignAsTable": false,
-              "avg": false,
-              "current": false,
+              "alignAsTable": true,
+              "avg": true,
+              "current": true,
               "hideEmpty": false,
               "hideZero": false,
-              "max": false,
-              "min": false,
+              "max": true,
+              "min": true,
               "rightSide": false,
-              "show": false,
+              "show": true,
               "sideWidth": null,
               "total": false,
-              "values": false
+              "values": true
             },
             "lines": true,
             "linewidth": 2,
@@ -71,18 +153,18 @@
             "renderer": "flot",
             "seriesOverrides": [],
             "spaceLength": 10,
-            "span": 6,
+            "span": 4,
             "stack": false,
             "steppedLine": true,
             "targets": [
               {
-                "expr": "sort_desc(sum by (owner)(ceph_rgw_bucket_stats_num_objects{owner='$owner'}))",
+                "expr": "sum by (owner)(ceph_rgw_bucket_stats_num_objects{owner='$owner'})",
                 "format": "time_series",
                 "interval": "$interval",
                 "intervalFactor": 1,
                 "legendFormat": "{{owner}}",
                 "refId": "A",
-                "step": 60
+                "step": 120
               }
             ],
             "thresholds": [],
@@ -132,18 +214,18 @@
             "height": "230px",
             "id": 9,
             "legend": {
-              "alignAsTable": false,
-              "avg": false,
-              "current": false,
+              "alignAsTable": true,
+              "avg": true,
+              "current": true,
               "hideEmpty": false,
               "hideZero": false,
-              "max": false,
-              "min": false,
+              "max": true,
+              "min": true,
               "rightSide": false,
-              "show": false,
+              "show": true,
               "sideWidth": null,
               "total": false,
-              "values": false
+              "values": true
             },
             "lines": true,
             "linewidth": 2,
@@ -155,18 +237,18 @@
             "renderer": "flot",
             "seriesOverrides": [],
             "spaceLength": 10,
-            "span": 6,
+            "span": 4,
             "stack": false,
             "steppedLine": true,
             "targets": [
               {
-                "expr": "sort_desc(sum by (owner)(ceph_rgw_bucket_stats_size_actual{owner='$owner'}))",
+                "expr": "sum by (owner)(ceph_rgw_bucket_stats_size_actual{owner='$owner'})",
                 "format": "time_series",
                 "interval": "$interval",
                 "intervalFactor": 1,
                 "legendFormat": "{{owner}}",
                 "refId": "A",
-                "step": 60
+                "step": 120
               }
             ],
             "thresholds": [],
@@ -205,197 +287,6 @@
                 "show": false
               }
             ]
-          },
-          {
-            "aliasColors": {},
-            "bars": false,
-            "dashLength": 10,
-            "dashes": false,
-            "datasource": "Prometheus",
-            "decimals": null,
-            "fill": 1,
-            "height": "230px",
-            "id": 8,
-            "legend": {
-              "alignAsTable": false,
-              "avg": false,
-              "current": false,
-              "hideEmpty": false,
-              "hideZero": false,
-              "max": false,
-              "min": false,
-              "rightSide": false,
-              "show": true,
-              "sideWidth": null,
-              "total": false,
-              "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [],
-            "spaceLength": 10,
-            "span": 6,
-            "stack": false,
-            "steppedLine": true,
-            "targets": [
-              {
-                "expr": "sum(ceph_rgw_user_usage_ops_total{owner='$owner'})",
-                "format": "time_series",
-                "hide": false,
-                "interval": "$interval",
-                "intervalFactor": 1,
-                "legendFormat": "Total",
-                "metric": "",
-                "refId": "A",
-                "step": 60
-              },
-              {
-                "expr": "sum(ceph_rgw_user_usage_successful_ops_total{owner='$owner'})",
-                "format": "time_series",
-                "interval": "$interval",
-                "intervalFactor": 1,
-                "legendFormat": "Successful",
-                "metric": "",
-                "refId": "B",
-                "step": 60
-              }
-            ],
-            "thresholds": [],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "Operations",
-            "tooltip": {
-              "shared": true,
-              "sort": 0,
-              "value_type": "individual"
-            },
-            "type": "graph",
-            "xaxis": {
-              "buckets": null,
-              "mode": "time",
-              "name": null,
-              "show": true,
-              "values": []
-            },
-            "yaxes": [
-              {
-                "format": "none",
-                "label": null,
-                "logBase": 1,
-                "max": null,
-                "min": "0",
-                "show": true
-              },
-              {
-                "format": "bytes",
-                "label": null,
-                "logBase": 1,
-                "max": null,
-                "min": null,
-                "show": false
-              }
-            ]
-          },
-          {
-            "aliasColors": {},
-            "bars": false,
-            "dashLength": 10,
-            "dashes": false,
-            "datasource": "Prometheus",
-            "decimals": null,
-            "fill": 1,
-            "height": "230px",
-            "id": 5,
-            "legend": {
-              "alignAsTable": false,
-              "avg": false,
-              "current": false,
-              "hideEmpty": false,
-              "hideZero": false,
-              "max": false,
-              "min": false,
-              "rightSide": false,
-              "show": true,
-              "sideWidth": null,
-              "total": false,
-              "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [],
-            "spaceLength": 10,
-            "span": 6,
-            "stack": false,
-            "steppedLine": true,
-            "targets": [
-              {
-                "expr": "sum(ceph_rgw_user_usage_sent_bytes_total{owner='$owner'})",
-                "format": "time_series",
-                "interval": "$interval",
-                "intervalFactor": 1,
-                "legendFormat": "Bytes sent",
-                "metric": "",
-                "refId": "C",
-                "step": 60
-              },
-              {
-                "expr": "sum(ceph_rgw_user_usage_received_bytes_total{owner='$owner'})",
-                "format": "time_series",
-                "interval": "$interval",
-                "intervalFactor": 1,
-                "legendFormat": "Bytes received",
-                "metric": "",
-                "refId": "D",
-                "step": 60
-              }
-            ],
-            "thresholds": [],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "Bandwidth",
-            "tooltip": {
-              "shared": true,
-              "sort": 0,
-              "value_type": "individual"
-            },
-            "type": "graph",
-            "xaxis": {
-              "buckets": null,
-              "mode": "time",
-              "name": null,
-              "show": true,
-              "values": []
-            },
-            "yaxes": [
-              {
-                "format": "bytes",
-                "label": null,
-                "logBase": 1,
-                "max": null,
-                "min": "0",
-                "show": true
-              },
-              {
-                "format": "bytes",
-                "label": null,
-                "logBase": 1,
-                "max": null,
-                "min": null,
-                "show": false
-              }
-            ]
           }
         ],
         "repeat": null,
@@ -420,18 +311,18 @@
             "height": "230px",
             "id": 10,
             "legend": {
-              "alignAsTable": false,
-              "avg": false,
-              "current": false,
+              "alignAsTable": true,
+              "avg": true,
+              "current": true,
               "hideEmpty": false,
               "hideZero": false,
-              "max": false,
-              "min": false,
+              "max": true,
+              "min": true,
               "rightSide": false,
-              "show": false,
+              "show": true,
               "sideWidth": null,
               "total": false,
-              "values": false
+              "values": true
             },
             "lines": true,
             "linewidth": 2,
@@ -448,7 +339,7 @@
             "steppedLine": true,
             "targets": [
               {
-                "expr": "sort_desc(sum by (owner)(ceph_rgw_bucket_stats_num_objects{owner='$owner',bucket='$bucket'}))",
+                "expr": "sum by (owner)(ceph_rgw_bucket_stats_num_objects{owner='$owner',bucket='$bucket'})",
                 "format": "time_series",
                 "interval": "$interval",
                 "intervalFactor": 1,
@@ -504,18 +395,18 @@
             "height": "230px",
             "id": 11,
             "legend": {
-              "alignAsTable": false,
-              "avg": false,
-              "current": false,
+              "alignAsTable": true,
+              "avg": true,
+              "current": true,
               "hideEmpty": false,
               "hideZero": false,
-              "max": false,
-              "min": false,
+              "max": true,
+              "min": true,
               "rightSide": false,
-              "show": false,
+              "show": true,
               "sideWidth": null,
               "total": false,
-              "values": false
+              "values": true
             },
             "lines": true,
             "linewidth": 2,
@@ -532,7 +423,7 @@
             "steppedLine": true,
             "targets": [
               {
-                "expr": "sort_desc(sum by (owner)(ceph_rgw_bucket_stats_size_actual{owner='$owner',bucket='$bucket'}))",
+                "expr": "sum by (owner)(ceph_rgw_bucket_stats_size_actual{owner='$owner',bucket='$bucket'})",
                 "format": "time_series",
                 "interval": "$interval",
                 "intervalFactor": 1,
@@ -577,197 +468,6 @@
                 "show": false
               }
             ]
-          },
-          {
-            "aliasColors": {},
-            "bars": false,
-            "dashLength": 10,
-            "dashes": false,
-            "datasource": "Prometheus",
-            "decimals": null,
-            "fill": 1,
-            "height": "230px",
-            "id": 6,
-            "legend": {
-              "alignAsTable": false,
-              "avg": false,
-              "current": false,
-              "hideEmpty": false,
-              "hideZero": false,
-              "max": false,
-              "min": false,
-              "rightSide": false,
-              "show": true,
-              "sideWidth": null,
-              "total": false,
-              "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [],
-            "spaceLength": 10,
-            "span": 6,
-            "stack": false,
-            "steppedLine": true,
-            "targets": [
-              {
-                "expr": "sum(ceph_rgw_user_usage_ops_total{owner='$owner',bucket='$bucket'})",
-                "format": "time_series",
-                "hide": false,
-                "interval": "$interval",
-                "intervalFactor": 1,
-                "legendFormat": "Total",
-                "metric": "",
-                "refId": "A",
-                "step": 60
-              },
-              {
-                "expr": "sum(ceph_rgw_user_usage_successful_ops_total{owner='$owner',bucket='$bucket'})",
-                "format": "time_series",
-                "interval": "$interval",
-                "intervalFactor": 1,
-                "legendFormat": "Successful",
-                "metric": "",
-                "refId": "B",
-                "step": 60
-              }
-            ],
-            "thresholds": [],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "Operations",
-            "tooltip": {
-              "shared": true,
-              "sort": 0,
-              "value_type": "individual"
-            },
-            "type": "graph",
-            "xaxis": {
-              "buckets": null,
-              "mode": "time",
-              "name": null,
-              "show": true,
-              "values": []
-            },
-            "yaxes": [
-              {
-                "format": "none",
-                "label": null,
-                "logBase": 1,
-                "max": null,
-                "min": "0",
-                "show": true
-              },
-              {
-                "format": "bytes",
-                "label": null,
-                "logBase": 1,
-                "max": null,
-                "min": null,
-                "show": false
-              }
-            ]
-          },
-          {
-            "aliasColors": {},
-            "bars": false,
-            "dashLength": 10,
-            "dashes": false,
-            "datasource": "Prometheus",
-            "decimals": null,
-            "fill": 1,
-            "height": "230px",
-            "id": 7,
-            "legend": {
-              "alignAsTable": false,
-              "avg": false,
-              "current": false,
-              "hideEmpty": false,
-              "hideZero": false,
-              "max": false,
-              "min": false,
-              "rightSide": false,
-              "show": true,
-              "sideWidth": null,
-              "total": false,
-              "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [],
-            "spaceLength": 10,
-            "span": 6,
-            "stack": false,
-            "steppedLine": true,
-            "targets": [
-              {
-                "expr": "sum(ceph_rgw_user_usage_sent_bytes_total{owner='$owner',bucket='$bucket'})",
-                "format": "time_series",
-                "interval": "$interval",
-                "intervalFactor": 1,
-                "legendFormat": "Bytes sent",
-                "metric": "",
-                "refId": "C",
-                "step": 60
-              },
-              {
-                "expr": "sum(ceph_rgw_user_usage_received_bytes_total{owner='$owner',bucket='$bucket'})",
-                "format": "time_series",
-                "interval": "$interval",
-                "intervalFactor": 1,
-                "legendFormat": "Bytes received",
-                "metric": "",
-                "refId": "D",
-                "step": 60
-              }
-            ],
-            "thresholds": [],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "Bandwidth",
-            "tooltip": {
-              "shared": true,
-              "sort": 0,
-              "value_type": "individual"
-            },
-            "type": "graph",
-            "xaxis": {
-              "buckets": null,
-              "mode": "time",
-              "name": null,
-              "show": true,
-              "values": []
-            },
-            "yaxes": [
-              {
-                "format": "bytes",
-                "label": null,
-                "logBase": 1,
-                "max": null,
-                "min": "0",
-                "show": true
-              },
-              {
-                "format": "bytes",
-                "label": null,
-                "logBase": 1,
-                "max": null,
-                "min": null,
-                "show": false
-              }
-            ]
           }
         ],
         "repeat": null,
@@ -775,209 +475,6 @@
         "repeatRowId": null,
         "showTitle": true,
         "title": "Bucket: $bucket",
-        "titleSize": "h6"
-      },
-      {
-        "collapse": false,
-        "height": 253,
-        "panels": [
-          {
-            "aliasColors": {},
-            "bars": false,
-            "dashLength": 10,
-            "dashes": false,
-            "datasource": "Prometheus",
-            "decimals": null,
-            "fill": 1,
-            "height": "230px",
-            "id": 1,
-            "legend": {
-              "alignAsTable": false,
-              "avg": false,
-              "current": false,
-              "hideEmpty": false,
-              "hideZero": false,
-              "max": false,
-              "min": false,
-              "rightSide": false,
-              "show": true,
-              "sideWidth": null,
-              "total": false,
-              "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [],
-            "spaceLength": 10,
-            "span": 6,
-            "stack": false,
-            "steppedLine": true,
-            "targets": [
-              {
-                "expr": "ceph_rgw_user_usage_ops_total{owner='$owner',bucket='$bucket',category='$category'}",
-                "format": "time_series",
-                "hide": false,
-                "interval": "$interval",
-                "intervalFactor": 1,
-                "legendFormat": "Total",
-                "metric": "",
-                "refId": "A",
-                "step": 60
-              },
-              {
-                "expr": "ceph_rgw_user_usage_successful_ops_total{owner='$owner',bucket='$bucket',category='$category'}",
-                "format": "time_series",
-                "interval": "$interval",
-                "intervalFactor": 1,
-                "legendFormat": "Successful",
-                "metric": "",
-                "refId": "B",
-                "step": 60
-              }
-            ],
-            "thresholds": [],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "Operations",
-            "tooltip": {
-              "shared": true,
-              "sort": 0,
-              "value_type": "individual"
-            },
-            "type": "graph",
-            "xaxis": {
-              "buckets": null,
-              "mode": "time",
-              "name": null,
-              "show": true,
-              "values": []
-            },
-            "yaxes": [
-              {
-                "format": "none",
-                "label": null,
-                "logBase": 1,
-                "max": null,
-                "min": "0",
-                "show": true
-              },
-              {
-                "format": "bytes",
-                "label": null,
-                "logBase": 1,
-                "max": null,
-                "min": null,
-                "show": false
-              }
-            ]
-          },
-          {
-            "aliasColors": {},
-            "bars": false,
-            "dashLength": 10,
-            "dashes": false,
-            "datasource": "Prometheus",
-            "decimals": null,
-            "fill": 1,
-            "height": "230px",
-            "id": 2,
-            "legend": {
-              "alignAsTable": false,
-              "avg": false,
-              "current": false,
-              "hideEmpty": false,
-              "hideZero": false,
-              "max": false,
-              "min": false,
-              "rightSide": false,
-              "show": true,
-              "sideWidth": null,
-              "total": false,
-              "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [],
-            "spaceLength": 10,
-            "span": 6,
-            "stack": false,
-            "steppedLine": true,
-            "targets": [
-              {
-                "expr": "ceph_rgw_user_usage_sent_bytes_total{owner='$owner',bucket='$bucket',category='$category'}",
-                "format": "time_series",
-                "interval": "$interval",
-                "intervalFactor": 1,
-                "legendFormat": "Bytes sent",
-                "metric": "",
-                "refId": "C",
-                "step": 60
-              },
-              {
-                "expr": "ceph_rgw_user_usage_received_bytes_total{owner='$owner',bucket='$bucket',category='$category'}",
-                "format": "time_series",
-                "interval": "$interval",
-                "intervalFactor": 1,
-                "legendFormat": "Bytes received",
-                "metric": "",
-                "refId": "D",
-                "step": 60
-              }
-            ],
-            "thresholds": [],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "Bandwidth",
-            "tooltip": {
-              "shared": true,
-              "sort": 0,
-              "value_type": "individual"
-            },
-            "type": "graph",
-            "xaxis": {
-              "buckets": null,
-              "mode": "time",
-              "name": null,
-              "show": true,
-              "values": []
-            },
-            "yaxes": [
-              {
-                "format": "bytes",
-                "label": null,
-                "logBase": 1,
-                "max": null,
-                "min": "0",
-                "show": true
-              },
-              {
-                "format": "bytes",
-                "label": null,
-                "logBase": 1,
-                "max": null,
-                "min": null,
-                "show": false
-              }
-            ]
-          }
-        ],
-        "repeat": null,
-        "repeatIteration": null,
-        "repeatRowId": null,
-        "showTitle": true,
-        "title": "Bucket: $bucket, Category: $category",
         "titleSize": "h6"
       }
     ],
@@ -1097,26 +594,6 @@
           "query": "label_values(ceph_rgw_user_usage_ops_total{owner='$owner'}, bucket)",
           "refresh": 1,
           "regex": "/.+/",
-          "sort": 1,
-          "tagValuesQuery": "",
-          "tags": [],
-          "tagsQuery": "",
-          "type": "query",
-          "useTags": false
-        },
-        {
-          "allValue": null,
-          "current": {},
-          "datasource": "Prometheus",
-          "hide": 0,
-          "includeAll": false,
-          "label": "Category",
-          "multi": false,
-          "name": "category",
-          "options": [],
-          "query": "label_values(ceph_rgw_user_usage_ops_total, category)",
-          "refresh": 1,
-          "regex": "^(?!set_attrs$).+",
           "sort": 1,
           "tagValuesQuery": "",
           "tags": [],

--- a/srv/salt/ceph/monitoring/grafana/files/ceph-rgw-users.json
+++ b/srv/salt/ceph/monitoring/grafana/files/ceph-rgw-users.json
@@ -6,7 +6,7 @@
         "type": "grafana",
         "id": "grafana",
         "name": "Grafana",
-        "version": "4.1.0"
+        "version": "4.5.1"
       },
       {
         "type": "panel",
@@ -40,6 +40,8 @@
           {
             "aliasColors": {},
             "bars": false,
+            "dashLength": 10,
+            "dashes": false,
             "datasource": "Prometheus",
             "decimals": null,
             "fill": 1,
@@ -54,7 +56,7 @@
               "max": false,
               "min": false,
               "rightSide": false,
-              "show": true,
+              "show": false,
               "sideWidth": null,
               "total": false,
               "values": false
@@ -68,34 +70,25 @@
             "points": false,
             "renderer": "flot",
             "seriesOverrides": [],
+            "spaceLength": 10,
             "span": 6,
             "stack": false,
             "steppedLine": true,
             "targets": [
               {
-                "expr": "sum(ceph_rgw_user_usage_ops_total{owner='$owner'})",
-                "hide": false,
+                "expr": "sort_desc(sum by (owner)(ceph_rgw_bucket_stats_num_objects{owner='$owner'}))",
+                "format": "time_series",
                 "interval": "$interval",
                 "intervalFactor": 1,
-                "legendFormat": "Total",
-                "metric": "",
+                "legendFormat": "{{owner}}",
                 "refId": "A",
-                "step": 60
-              },
-              {
-                "expr": "sum(ceph_rgw_user_usage_successful_ops_total{owner='$owner'})",
-                "interval": "$interval",
-                "intervalFactor": 1,
-                "legendFormat": "Successful",
-                "metric": "",
-                "refId": "B",
                 "step": 60
               }
             ],
             "thresholds": [],
             "timeFrom": null,
             "timeShift": null,
-            "title": "Overall operations",
+            "title": "Objects in buckets",
             "tooltip": {
               "shared": true,
               "sort": 0,
@@ -103,6 +96,7 @@
             },
             "type": "graph",
             "xaxis": {
+              "buckets": null,
               "mode": "time",
               "name": null,
               "show": true,
@@ -130,6 +124,189 @@
           {
             "aliasColors": {},
             "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "Prometheus",
+            "decimals": null,
+            "fill": 1,
+            "height": "230px",
+            "id": 9,
+            "legend": {
+              "alignAsTable": false,
+              "avg": false,
+              "current": false,
+              "hideEmpty": false,
+              "hideZero": false,
+              "max": false,
+              "min": false,
+              "rightSide": false,
+              "show": false,
+              "sideWidth": null,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 6,
+            "stack": false,
+            "steppedLine": true,
+            "targets": [
+              {
+                "expr": "sort_desc(sum by (owner)(ceph_rgw_bucket_stats_size_actual{owner='$owner'}))",
+                "format": "time_series",
+                "interval": "$interval",
+                "intervalFactor": 1,
+                "legendFormat": "{{owner}}",
+                "refId": "A",
+                "step": 60
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Buckets size",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "decimals": 0,
+                "format": "bytes",
+                "label": "",
+                "logBase": 1,
+                "max": null,
+                "min": "0",
+                "show": true
+              },
+              {
+                "format": "bytes",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": false
+              }
+            ]
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "Prometheus",
+            "decimals": null,
+            "fill": 1,
+            "height": "230px",
+            "id": 8,
+            "legend": {
+              "alignAsTable": false,
+              "avg": false,
+              "current": false,
+              "hideEmpty": false,
+              "hideZero": false,
+              "max": false,
+              "min": false,
+              "rightSide": false,
+              "show": true,
+              "sideWidth": null,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 6,
+            "stack": false,
+            "steppedLine": true,
+            "targets": [
+              {
+                "expr": "sum(ceph_rgw_user_usage_ops_total{owner='$owner'})",
+                "format": "time_series",
+                "hide": false,
+                "interval": "$interval",
+                "intervalFactor": 1,
+                "legendFormat": "Total",
+                "metric": "",
+                "refId": "A",
+                "step": 60
+              },
+              {
+                "expr": "sum(ceph_rgw_user_usage_successful_ops_total{owner='$owner'})",
+                "format": "time_series",
+                "interval": "$interval",
+                "intervalFactor": 1,
+                "legendFormat": "Successful",
+                "metric": "",
+                "refId": "B",
+                "step": 60
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Operations",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "none",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": "0",
+                "show": true
+              },
+              {
+                "format": "bytes",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": false
+              }
+            ]
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
             "datasource": "Prometheus",
             "decimals": null,
             "fill": 1,
@@ -158,12 +335,14 @@
             "points": false,
             "renderer": "flot",
             "seriesOverrides": [],
+            "spaceLength": 10,
             "span": 6,
             "stack": false,
             "steppedLine": true,
             "targets": [
               {
                 "expr": "sum(ceph_rgw_user_usage_sent_bytes_total{owner='$owner'})",
+                "format": "time_series",
                 "interval": "$interval",
                 "intervalFactor": 1,
                 "legendFormat": "Bytes sent",
@@ -173,6 +352,7 @@
               },
               {
                 "expr": "sum(ceph_rgw_user_usage_received_bytes_total{owner='$owner'})",
+                "format": "time_series",
                 "interval": "$interval",
                 "intervalFactor": 1,
                 "legendFormat": "Bytes received",
@@ -184,7 +364,7 @@
             "thresholds": [],
             "timeFrom": null,
             "timeShift": null,
-            "title": "Overall bandwidth",
+            "title": "Bandwidth",
             "tooltip": {
               "shared": true,
               "sort": 0,
@@ -192,6 +372,7 @@
             },
             "type": "graph",
             "xaxis": {
+              "buckets": null,
               "mode": "time",
               "name": null,
               "show": true,
@@ -220,7 +401,7 @@
         "repeat": null,
         "repeatIteration": null,
         "repeatRowId": null,
-        "showTitle": false,
+        "showTitle": true,
         "title": "Overall",
         "titleSize": "h6"
       },
@@ -231,6 +412,177 @@
           {
             "aliasColors": {},
             "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "Prometheus",
+            "decimals": null,
+            "fill": 1,
+            "height": "230px",
+            "id": 10,
+            "legend": {
+              "alignAsTable": false,
+              "avg": false,
+              "current": false,
+              "hideEmpty": false,
+              "hideZero": false,
+              "max": false,
+              "min": false,
+              "rightSide": false,
+              "show": false,
+              "sideWidth": null,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 6,
+            "stack": false,
+            "steppedLine": true,
+            "targets": [
+              {
+                "expr": "sort_desc(sum by (owner)(ceph_rgw_bucket_stats_num_objects{owner='$owner',bucket='$bucket'}))",
+                "format": "time_series",
+                "interval": "$interval",
+                "intervalFactor": 1,
+                "legendFormat": "{{owner}}",
+                "refId": "A",
+                "step": 60
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Objects in bucket",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "none",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": "0",
+                "show": true
+              },
+              {
+                "format": "bytes",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": false
+              }
+            ]
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "Prometheus",
+            "decimals": null,
+            "fill": 1,
+            "height": "230px",
+            "id": 11,
+            "legend": {
+              "alignAsTable": false,
+              "avg": false,
+              "current": false,
+              "hideEmpty": false,
+              "hideZero": false,
+              "max": false,
+              "min": false,
+              "rightSide": false,
+              "show": false,
+              "sideWidth": null,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 6,
+            "stack": false,
+            "steppedLine": true,
+            "targets": [
+              {
+                "expr": "sort_desc(sum by (owner)(ceph_rgw_bucket_stats_size_actual{owner='$owner',bucket='$bucket'}))",
+                "format": "time_series",
+                "interval": "$interval",
+                "intervalFactor": 1,
+                "legendFormat": "{{owner}}",
+                "refId": "A",
+                "step": 60
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Bucket size",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "decimals": 0,
+                "format": "bytes",
+                "label": "",
+                "logBase": 1,
+                "max": null,
+                "min": "0",
+                "show": true
+              },
+              {
+                "format": "bytes",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": false
+              }
+            ]
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
             "datasource": "Prometheus",
             "decimals": null,
             "fill": 1,
@@ -259,12 +611,14 @@
             "points": false,
             "renderer": "flot",
             "seriesOverrides": [],
+            "spaceLength": 10,
             "span": 6,
             "stack": false,
             "steppedLine": true,
             "targets": [
               {
                 "expr": "sum(ceph_rgw_user_usage_ops_total{owner='$owner',bucket='$bucket'})",
+                "format": "time_series",
                 "hide": false,
                 "interval": "$interval",
                 "intervalFactor": 1,
@@ -275,6 +629,7 @@
               },
               {
                 "expr": "sum(ceph_rgw_user_usage_successful_ops_total{owner='$owner',bucket='$bucket'})",
+                "format": "time_series",
                 "interval": "$interval",
                 "intervalFactor": 1,
                 "legendFormat": "Successful",
@@ -294,6 +649,7 @@
             },
             "type": "graph",
             "xaxis": {
+              "buckets": null,
               "mode": "time",
               "name": null,
               "show": true,
@@ -321,6 +677,8 @@
           {
             "aliasColors": {},
             "bars": false,
+            "dashLength": 10,
+            "dashes": false,
             "datasource": "Prometheus",
             "decimals": null,
             "fill": 1,
@@ -349,12 +707,14 @@
             "points": false,
             "renderer": "flot",
             "seriesOverrides": [],
+            "spaceLength": 10,
             "span": 6,
             "stack": false,
             "steppedLine": true,
             "targets": [
               {
                 "expr": "sum(ceph_rgw_user_usage_sent_bytes_total{owner='$owner',bucket='$bucket'})",
+                "format": "time_series",
                 "interval": "$interval",
                 "intervalFactor": 1,
                 "legendFormat": "Bytes sent",
@@ -364,6 +724,7 @@
               },
               {
                 "expr": "sum(ceph_rgw_user_usage_received_bytes_total{owner='$owner',bucket='$bucket'})",
+                "format": "time_series",
                 "interval": "$interval",
                 "intervalFactor": 1,
                 "legendFormat": "Bytes received",
@@ -383,6 +744,7 @@
             },
             "type": "graph",
             "xaxis": {
+              "buckets": null,
               "mode": "time",
               "name": null,
               "show": true,
@@ -422,6 +784,8 @@
           {
             "aliasColors": {},
             "bars": false,
+            "dashLength": 10,
+            "dashes": false,
             "datasource": "Prometheus",
             "decimals": null,
             "fill": 1,
@@ -450,12 +814,14 @@
             "points": false,
             "renderer": "flot",
             "seriesOverrides": [],
+            "spaceLength": 10,
             "span": 6,
             "stack": false,
             "steppedLine": true,
             "targets": [
               {
                 "expr": "ceph_rgw_user_usage_ops_total{owner='$owner',bucket='$bucket',category='$category'}",
+                "format": "time_series",
                 "hide": false,
                 "interval": "$interval",
                 "intervalFactor": 1,
@@ -466,6 +832,7 @@
               },
               {
                 "expr": "ceph_rgw_user_usage_successful_ops_total{owner='$owner',bucket='$bucket',category='$category'}",
+                "format": "time_series",
                 "interval": "$interval",
                 "intervalFactor": 1,
                 "legendFormat": "Successful",
@@ -485,6 +852,7 @@
             },
             "type": "graph",
             "xaxis": {
+              "buckets": null,
               "mode": "time",
               "name": null,
               "show": true,
@@ -512,6 +880,8 @@
           {
             "aliasColors": {},
             "bars": false,
+            "dashLength": 10,
+            "dashes": false,
             "datasource": "Prometheus",
             "decimals": null,
             "fill": 1,
@@ -540,12 +910,14 @@
             "points": false,
             "renderer": "flot",
             "seriesOverrides": [],
+            "spaceLength": 10,
             "span": 6,
             "stack": false,
             "steppedLine": true,
             "targets": [
               {
                 "expr": "ceph_rgw_user_usage_sent_bytes_total{owner='$owner',bucket='$bucket',category='$category'}",
+                "format": "time_series",
                 "interval": "$interval",
                 "intervalFactor": 1,
                 "legendFormat": "Bytes sent",
@@ -555,6 +927,7 @@
               },
               {
                 "expr": "ceph_rgw_user_usage_received_bytes_total{owner='$owner',bucket='$bucket',category='$category'}",
+                "format": "time_series",
                 "interval": "$interval",
                 "intervalFactor": 1,
                 "legendFormat": "Bytes received",
@@ -574,6 +947,7 @@
             },
             "type": "graph",
             "xaxis": {
+              "buckets": null,
               "mode": "time",
               "name": null,
               "show": true,
@@ -783,6 +1157,6 @@
     },
     "timezone": "browser",
     "title": "Ceph - Object Gateway users",
-    "version": 4
+    "version": 6
   }
 }

--- a/srv/salt/ceph/monitoring/grafana/files/ceph-rgw.json
+++ b/srv/salt/ceph/monitoring/grafana/files/ceph-rgw.json
@@ -54,12 +54,12 @@
             "id": 1,
             "legend": {
               "alignAsTable": true,
-              "avg": false,
+              "avg": true,
               "current": true,
               "hideEmpty": false,
               "hideZero": false,
-              "max": false,
-              "min": false,
+              "max": true,
+              "min": true,
               "rightSide": false,
               "show": true,
               "total": false,
@@ -81,6 +81,7 @@
             "targets": [
               {
                 "expr": "ceph_rgw_user_count",
+                "format": "time_series",
                 "interval": "$interval",
                 "intervalFactor": 1,
                 "legendFormat": "Total",
@@ -160,6 +161,7 @@
             "targets": [
               {
                 "expr": "ceph_rgw_bucket_count",
+                "format": "time_series",
                 "interval": "$interval",
                 "intervalFactor": 1,
                 "legendFormat": "Total",
@@ -422,216 +424,6 @@
             "timeFrom": "1h",
             "timeShift": null,
             "title": "Top 10 - Objects in bucket",
-            "transform": "timeseries_aggregations",
-            "type": "table"
-          },
-          {
-            "columns": [
-              {
-                "text": "Current",
-                "value": "current"
-              }
-            ],
-            "datasource": "Prometheus",
-            "filterNull": false,
-            "fontSize": "100%",
-            "hideTimeOverride": true,
-            "id": 6,
-            "links": [],
-            "pageSize": null,
-            "scroll": true,
-            "showHeader": true,
-            "sort": {
-              "col": 1,
-              "desc": true
-            },
-            "span": 3,
-            "styles": [
-              {
-                "alias": "Owner",
-                "colorMode": null,
-                "colors": [
-                  "rgba(245, 54, 54, 0.9)",
-                  "rgba(237, 129, 40, 0.89)",
-                  "rgba(50, 172, 45, 0.97)"
-                ],
-                "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                "decimals": 2,
-                "pattern": "Metric",
-                "thresholds": [],
-                "type": "string",
-                "unit": "short"
-              },
-              {
-                "alias": "Total",
-                "colorMode": null,
-                "colors": [
-                  "rgba(245, 54, 54, 0.9)",
-                  "rgba(237, 129, 40, 0.89)",
-                  "rgba(50, 172, 45, 0.97)"
-                ],
-                "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                "decimals": 0,
-                "pattern": "Current",
-                "thresholds": [],
-                "type": "number",
-                "unit": "none"
-              }
-            ],
-            "targets": [
-              {
-                "expr": "sort_desc(topk(10, sum(ceph_rgw_user_usage_ops_total) by (owner)))",
-                "format": "time_series",
-                "interval": "$interval",
-                "intervalFactor": 1,
-                "legendFormat": "{{owner}}",
-                "refId": "A",
-                "step": 60
-              }
-            ],
-            "timeFrom": "1h",
-            "timeShift": null,
-            "title": "Top 10 - Operations",
-            "transform": "timeseries_aggregations",
-            "type": "table"
-          },
-          {
-            "columns": [
-              {
-                "text": "Current",
-                "value": "current"
-              }
-            ],
-            "datasource": "Prometheus",
-            "filterNull": false,
-            "fontSize": "100%",
-            "hideTimeOverride": true,
-            "id": 4,
-            "links": [],
-            "pageSize": null,
-            "scroll": true,
-            "showHeader": true,
-            "sort": {
-              "col": 1,
-              "desc": true
-            },
-            "span": 3,
-            "styles": [
-              {
-                "alias": "Owner",
-                "colorMode": null,
-                "colors": [
-                  "rgba(245, 54, 54, 0.9)",
-                  "rgba(237, 129, 40, 0.89)",
-                  "rgba(50, 172, 45, 0.97)"
-                ],
-                "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                "decimals": 2,
-                "pattern": "Metric",
-                "thresholds": [],
-                "type": "string",
-                "unit": "short"
-              },
-              {
-                "alias": "Total",
-                "colorMode": null,
-                "colors": [
-                  "rgba(245, 54, 54, 0.9)",
-                  "rgba(237, 129, 40, 0.89)",
-                  "rgba(50, 172, 45, 0.97)"
-                ],
-                "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                "decimals": 0,
-                "pattern": "Current",
-                "thresholds": [],
-                "type": "number",
-                "unit": "bytes"
-              }
-            ],
-            "targets": [
-              {
-                "expr": "sort_desc(topk(10, sum(ceph_rgw_user_usage_sent_bytes_total) by (owner)))",
-                "format": "time_series",
-                "interval": "$interval",
-                "intervalFactor": 1,
-                "legendFormat": "{{owner}}",
-                "refId": "A",
-                "step": 60
-              }
-            ],
-            "timeFrom": "1h",
-            "timeShift": null,
-            "title": "Top 10 - Bandwidth (Sent)",
-            "transform": "timeseries_aggregations",
-            "type": "table"
-          },
-          {
-            "columns": [
-              {
-                "text": "Current",
-                "value": "current"
-              }
-            ],
-            "datasource": "Prometheus",
-            "filterNull": false,
-            "fontSize": "100%",
-            "hideTimeOverride": true,
-            "id": 5,
-            "links": [],
-            "pageSize": null,
-            "scroll": true,
-            "showHeader": true,
-            "sort": {
-              "col": 1,
-              "desc": true
-            },
-            "span": 3,
-            "styles": [
-              {
-                "alias": "Owner",
-                "colorMode": null,
-                "colors": [
-                  "rgba(245, 54, 54, 0.9)",
-                  "rgba(237, 129, 40, 0.89)",
-                  "rgba(50, 172, 45, 0.97)"
-                ],
-                "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                "decimals": 2,
-                "pattern": "Metric",
-                "thresholds": [],
-                "type": "string",
-                "unit": "short"
-              },
-              {
-                "alias": "Total",
-                "colorMode": null,
-                "colors": [
-                  "rgba(245, 54, 54, 0.9)",
-                  "rgba(237, 129, 40, 0.89)",
-                  "rgba(50, 172, 45, 0.97)"
-                ],
-                "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                "decimals": 0,
-                "pattern": "Current",
-                "thresholds": [],
-                "type": "number",
-                "unit": "bytes"
-              }
-            ],
-            "targets": [
-              {
-                "expr": "sort_desc(topk(10, sum(ceph_rgw_user_usage_received_bytes_total) by (owner)))",
-                "format": "time_series",
-                "interval": "$interval",
-                "intervalFactor": 1,
-                "legendFormat": "{{owner}}",
-                "refId": "A",
-                "step": 60
-              }
-            ],
-            "timeFrom": "1h",
-            "timeShift": null,
-            "title": "Top 10 - Bandwidth (Received)",
             "transform": "timeseries_aggregations",
             "type": "table"
           }

--- a/srv/salt/ceph/monitoring/grafana/files/ceph-rgw.json
+++ b/srv/salt/ceph/monitoring/grafana/files/ceph-rgw.json
@@ -6,7 +6,7 @@
         "type": "grafana",
         "id": "grafana",
         "name": "Grafana",
-        "version": "4.1.0"
+        "version": "4.5.1"
       },
       {
         "type": "panel",
@@ -46,6 +46,8 @@
           {
             "aliasColors": {},
             "bars": false,
+            "dashLength": 10,
+            "dashes": false,
             "datasource": "Prometheus",
             "decimals": 0,
             "fill": 1,
@@ -72,6 +74,7 @@
             "points": false,
             "renderer": "flot",
             "seriesOverrides": [],
+            "spaceLength": 10,
             "span": 6,
             "stack": false,
             "steppedLine": true,
@@ -96,6 +99,7 @@
             },
             "type": "graph",
             "xaxis": {
+              "buckets": null,
               "mode": "time",
               "name": null,
               "show": true,
@@ -123,6 +127,8 @@
           {
             "aliasColors": {},
             "bars": false,
+            "dashLength": 10,
+            "dashes": false,
             "datasource": "Prometheus",
             "decimals": 0,
             "fill": 1,
@@ -147,6 +153,7 @@
             "points": false,
             "renderer": "flot",
             "seriesOverrides": [],
+            "spaceLength": 10,
             "span": 6,
             "stack": false,
             "steppedLine": true,
@@ -171,6 +178,7 @@
             },
             "type": "graph",
             "xaxis": {
+              "buckets": null,
               "mode": "time",
               "name": null,
               "show": true,
@@ -230,14 +238,31 @@
             "span": 3,
             "styles": [
               {
+                "alias": "Owner",
                 "colorMode": null,
                 "colors": [
                   "rgba(245, 54, 54, 0.9)",
                   "rgba(237, 129, 40, 0.89)",
                   "rgba(50, 172, 45, 0.97)"
                 ],
-                "decimals": 0,
-                "pattern": "/.*/",
+                "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                "decimals": 2,
+                "pattern": "Metric",
+                "thresholds": [],
+                "type": "string",
+                "unit": "short"
+              },
+              {
+                "alias": "Total",
+                "colorMode": null,
+                "colors": [
+                  "rgba(245, 54, 54, 0.9)",
+                  "rgba(237, 129, 40, 0.89)",
+                  "rgba(50, 172, 45, 0.97)"
+                ],
+                "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                "decimals": null,
+                "pattern": "Current",
                 "thresholds": [],
                 "type": "number",
                 "unit": "none"
@@ -245,7 +270,8 @@
             ],
             "targets": [
               {
-                "expr": "sort_desc(count by(owner)(sum by (owner,bucket)(ceph_rgw_user_usage_ops_total)))",
+                "expr": "sort_desc(count by(owner)(sum by (owner,bucket)(ceph_rgw_bucket_stats_size_utilized)))",
+                "format": "time_series",
                 "interval": "$interval",
                 "intervalFactor": 1,
                 "legendFormat": "{{owner}}",
@@ -255,7 +281,147 @@
             ],
             "timeFrom": "1h",
             "timeShift": null,
-            "title": "Top 10 - Buckets",
+            "title": "Top 10 - Buckets per user",
+            "transform": "timeseries_aggregations",
+            "type": "table"
+          },
+          {
+            "columns": [
+              {
+                "text": "Current",
+                "value": "current"
+              }
+            ],
+            "datasource": "Prometheus",
+            "filterNull": false,
+            "fontSize": "100%",
+            "hideTimeOverride": true,
+            "id": 7,
+            "links": [],
+            "pageSize": null,
+            "scroll": true,
+            "showHeader": true,
+            "sort": {
+              "col": 1,
+              "desc": true
+            },
+            "span": 3,
+            "styles": [
+              {
+                "alias": "Bucket",
+                "colorMode": null,
+                "colors": [
+                  "rgba(245, 54, 54, 0.9)",
+                  "rgba(237, 129, 40, 0.89)",
+                  "rgba(50, 172, 45, 0.97)"
+                ],
+                "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                "decimals": 2,
+                "pattern": "Metric",
+                "thresholds": [],
+                "type": "string",
+                "unit": "short"
+              },
+              {
+                "alias": "Total",
+                "colorMode": null,
+                "colors": [
+                  "rgba(245, 54, 54, 0.9)",
+                  "rgba(237, 129, 40, 0.89)",
+                  "rgba(50, 172, 45, 0.97)"
+                ],
+                "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                "decimals": 0,
+                "pattern": "Current",
+                "thresholds": [],
+                "type": "number",
+                "unit": "bytes"
+              }
+            ],
+            "targets": [
+              {
+                "expr": "sort_desc(topk(10, ceph_rgw_bucket_stats_size_actual))",
+                "format": "time_series",
+                "interval": "$interval",
+                "intervalFactor": 1,
+                "legendFormat": "{{bucket}}",
+                "refId": "A",
+                "step": 60
+              }
+            ],
+            "timeFrom": "1h",
+            "timeShift": null,
+            "title": "Top 10 - Bucket size",
+            "transform": "timeseries_aggregations",
+            "type": "table"
+          },
+          {
+            "columns": [
+              {
+                "text": "Current",
+                "value": "current"
+              }
+            ],
+            "datasource": "Prometheus",
+            "filterNull": false,
+            "fontSize": "100%",
+            "hideTimeOverride": true,
+            "id": 8,
+            "links": [],
+            "pageSize": null,
+            "scroll": true,
+            "showHeader": true,
+            "sort": {
+              "col": 1,
+              "desc": true
+            },
+            "span": 3,
+            "styles": [
+              {
+                "alias": "Bucket",
+                "colorMode": null,
+                "colors": [
+                  "rgba(245, 54, 54, 0.9)",
+                  "rgba(237, 129, 40, 0.89)",
+                  "rgba(50, 172, 45, 0.97)"
+                ],
+                "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                "decimals": 2,
+                "pattern": "Metric",
+                "thresholds": [],
+                "type": "string",
+                "unit": "short"
+              },
+              {
+                "alias": "Total",
+                "colorMode": null,
+                "colors": [
+                  "rgba(245, 54, 54, 0.9)",
+                  "rgba(237, 129, 40, 0.89)",
+                  "rgba(50, 172, 45, 0.97)"
+                ],
+                "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                "decimals": 0,
+                "pattern": "Current",
+                "thresholds": [],
+                "type": "number",
+                "unit": "none"
+              }
+            ],
+            "targets": [
+              {
+                "expr": "sort_desc(topk(10, ceph_rgw_bucket_stats_num_objects  ))",
+                "format": "time_series",
+                "interval": "$interval",
+                "intervalFactor": 1,
+                "legendFormat": "{{bucket}}",
+                "refId": "A",
+                "step": 60
+              }
+            ],
+            "timeFrom": "1h",
+            "timeShift": null,
+            "title": "Top 10 - Objects in bucket",
             "transform": "timeseries_aggregations",
             "type": "table"
           },
@@ -282,14 +448,31 @@
             "span": 3,
             "styles": [
               {
+                "alias": "Owner",
                 "colorMode": null,
                 "colors": [
                   "rgba(245, 54, 54, 0.9)",
                   "rgba(237, 129, 40, 0.89)",
                   "rgba(50, 172, 45, 0.97)"
                 ],
+                "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                "decimals": 2,
+                "pattern": "Metric",
+                "thresholds": [],
+                "type": "string",
+                "unit": "short"
+              },
+              {
+                "alias": "Total",
+                "colorMode": null,
+                "colors": [
+                  "rgba(245, 54, 54, 0.9)",
+                  "rgba(237, 129, 40, 0.89)",
+                  "rgba(50, 172, 45, 0.97)"
+                ],
+                "dateFormat": "YYYY-MM-DD HH:mm:ss",
                 "decimals": 0,
-                "pattern": "/.*/",
+                "pattern": "Current",
                 "thresholds": [],
                 "type": "number",
                 "unit": "none"
@@ -298,6 +481,7 @@
             "targets": [
               {
                 "expr": "sort_desc(topk(10, sum(ceph_rgw_user_usage_ops_total) by (owner)))",
+                "format": "time_series",
                 "interval": "$interval",
                 "intervalFactor": 1,
                 "legendFormat": "{{owner}}",
@@ -334,14 +518,31 @@
             "span": 3,
             "styles": [
               {
+                "alias": "Owner",
                 "colorMode": null,
                 "colors": [
                   "rgba(245, 54, 54, 0.9)",
                   "rgba(237, 129, 40, 0.89)",
                   "rgba(50, 172, 45, 0.97)"
                 ],
+                "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                "decimals": 2,
+                "pattern": "Metric",
+                "thresholds": [],
+                "type": "string",
+                "unit": "short"
+              },
+              {
+                "alias": "Total",
+                "colorMode": null,
+                "colors": [
+                  "rgba(245, 54, 54, 0.9)",
+                  "rgba(237, 129, 40, 0.89)",
+                  "rgba(50, 172, 45, 0.97)"
+                ],
+                "dateFormat": "YYYY-MM-DD HH:mm:ss",
                 "decimals": 0,
-                "pattern": "/.*/",
+                "pattern": "Current",
                 "thresholds": [],
                 "type": "number",
                 "unit": "bytes"
@@ -350,6 +551,7 @@
             "targets": [
               {
                 "expr": "sort_desc(topk(10, sum(ceph_rgw_user_usage_sent_bytes_total) by (owner)))",
+                "format": "time_series",
                 "interval": "$interval",
                 "intervalFactor": 1,
                 "legendFormat": "{{owner}}",
@@ -386,22 +588,40 @@
             "span": 3,
             "styles": [
               {
+                "alias": "Owner",
                 "colorMode": null,
                 "colors": [
                   "rgba(245, 54, 54, 0.9)",
                   "rgba(237, 129, 40, 0.89)",
                   "rgba(50, 172, 45, 0.97)"
                 ],
+                "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                "decimals": 2,
+                "pattern": "Metric",
+                "thresholds": [],
+                "type": "string",
+                "unit": "short"
+              },
+              {
+                "alias": "Total",
+                "colorMode": null,
+                "colors": [
+                  "rgba(245, 54, 54, 0.9)",
+                  "rgba(237, 129, 40, 0.89)",
+                  "rgba(50, 172, 45, 0.97)"
+                ],
+                "dateFormat": "YYYY-MM-DD HH:mm:ss",
                 "decimals": 0,
-                "pattern": "/.*/",
+                "pattern": "Current",
                 "thresholds": [],
                 "type": "number",
-                "unit": "decbytes"
+                "unit": "bytes"
               }
             ],
             "targets": [
               {
                 "expr": "sort_desc(topk(10, sum(ceph_rgw_user_usage_received_bytes_total) by (owner)))",
+                "format": "time_series",
                 "interval": "$interval",
                 "intervalFactor": 1,
                 "legendFormat": "{{owner}}",
@@ -540,6 +760,6 @@
     },
     "timezone": "browser",
     "title": "Ceph - Object Gateway",
-    "version": 3
+    "version": 4
   }
 }

--- a/srv/salt/ceph/monitoring/prometheus/exporters/ceph_rgw_exporter/cron/default-disable-bucket-metrics.sls
+++ b/srv/salt/ceph/monitoring/prometheus/exporters/ceph_rgw_exporter/cron/default-disable-bucket-metrics.sls
@@ -6,6 +6,6 @@ remove_rgw_exporter_cron_job:
 
 install_rgw_exporter_cron_job:
   cron.present:
-    - name: '/var/lib/prometheus/node-exporter/ceph_rgw.py --disable-usage-metrics > /var/lib/prometheus/node-exporter/ceph_rgw.prom 2> /dev/null'
+    - name: '/var/lib/prometheus/node-exporter/ceph_rgw.py --disable-bucket-metrics > /var/lib/prometheus/node-exporter/ceph_rgw.prom 2> /dev/null'
     - minute: '*/5'
     - identifier: 'Prometheus rgw_exporter cron job'

--- a/srv/salt/ceph/monitoring/prometheus/exporters/ceph_rgw_exporter/files/ceph_rgw.py
+++ b/srv/salt/ceph/monitoring/prometheus/exporters/ceph_rgw_exporter/files/ceph_rgw.py
@@ -11,11 +11,9 @@ import sys
 import syslog
 
 class CephRgwCollector(object):
-    def __init__(self, name, disable_bucket_metrics, disable_usage_metrics,
-            disable_user_metrics):
+    def __init__(self, name, disable_bucket_metrics, disable_user_metrics):
         self.name = name
         self.disable_bucket_metrics = disable_bucket_metrics
-        self.disable_usage_metrics = disable_usage_metrics
         self.disable_user_metrics = disable_user_metrics
 
     def _exec_rgw_admin(self, args):
@@ -36,9 +34,6 @@ class CephRgwCollector(object):
 
     def _collect_bucket_stats(self):
         return self._exec_rgw_admin(['bucket', 'stats'])
-
-    def _collect_usage_data(self):
-        return self._exec_rgw_admin(['usage', 'show', '--show-log-sum=false'])
 
     def _init_metrics(self):
         self._metrics = {}
@@ -69,26 +64,6 @@ class CephRgwCollector(object):
                 labels=["bucket", "owner"])
         })
 
-    def _init_usage_metrics(self):
-        self._metrics.update({
-            'ops': prometheus_client.core.CounterMetricFamily(
-                'ceph_rgw_user_usage_ops_total',
-                'Number of operations',
-                labels=["bucket", "owner", "category"]),
-            'successful_ops': prometheus_client.core.CounterMetricFamily(
-                'ceph_rgw_user_usage_successful_ops_total',
-                'Number of successful operations',
-                labels=["bucket", "owner", "category"]),
-            'bytes_sent': prometheus_client.core.CounterMetricFamily(
-                'ceph_rgw_user_usage_sent_bytes_total',
-                'Number of bytes sent by the RADOS Gateway',
-                labels=["bucket", "owner", "category"]),
-            'bytes_received': prometheus_client.core.CounterMetricFamily(
-                'ceph_rgw_user_usage_received_bytes_total',
-                'Number of bytes received by the RADOS Gateway',
-                labels=["bucket", "owner", "category"])
-        })
-
     def _add_user_metrics(self, count):
         self._metrics['user_count'].add_metric([], count)
 
@@ -110,24 +85,6 @@ class CephRgwCollector(object):
                 bucket['bucket'], bucket['owner']],
                 bucket['usage']['rgw.main']['num_objects'])
 
-    def _add_usage_metrics(self, data):
-        if 'entries' in data:
-            for entry in data['entries']:
-                for bucket in entry['buckets']:
-                    for category in bucket['categories']:
-                        self._metrics['ops'].add_metric([
-                            bucket['bucket'], bucket['owner'],
-                            category['category']], category['ops'])
-                        self._metrics['successful_ops'].add_metric([
-                            bucket['bucket'], bucket['owner'],
-                            category['category']], category['successful_ops'])
-                        self._metrics['bytes_sent'].add_metric([
-                            bucket['bucket'], bucket['owner'],
-                            category['category']], category['bytes_sent'])
-                        self._metrics['bytes_received'].add_metric([
-                            bucket['bucket'], bucket['owner'],
-                            category['category']], category['bytes_received'])
-
     def collect(self):
         self._init_metrics()
         # Process number of users.
@@ -140,11 +97,6 @@ class CephRgwCollector(object):
             self._init_bucket_metrics()
             data = self._collect_bucket_stats()
             self._add_bucket_metrics(data)
-        # Process the usage statistics.
-        if not self.disable_usage_metrics:
-            self._init_usage_metrics()
-            data = self._collect_usage_data()
-            self._add_usage_metrics(data)
         for metric in self._metrics.values():
             yield metric
 
@@ -161,10 +113,6 @@ def parse_args():
         required=False)
     parser.add_argument(
         '--disable-bucket-metrics',
-        action='store_true',
-        required=False)
-    parser.add_argument(
-        '--disable-usage-metrics',
         action='store_true',
         required=False)
     return parser.parse_args()


### PR DESCRIPTION
Collect and display bucket statistics, e.g. actual size, utilized size and number of objects in Grafana.

This PR uses `radosgw-admin bucket stats` to collect bucket statistics like:
- Number of buckets
- Actual bucket size
- Utilized (compressed) bucket size
- Number of objects in bucket

The following widgets have been added in the 'Ceph - Object Gateway' dashboard:
- Top 10 - Buckets per user
- Top 10 - Bucket size
- Top 10 - Objects in bucket

![screenshot02](https://user-images.githubusercontent.com/1897962/33655632-e4b85e9a-da73-11e7-848a-1df9515dad3d.png)

The following widgets have been added in the 'Ceph - Object Gateway users' dashboard:
- Number of buckets
- Objects in bucket (Overall, per bucket)
- Bucket size (Overall, per bucket)

![screenshot01](https://user-images.githubusercontent.com/1897962/33655631-e4a05cdc-da73-11e7-8f17-5daca4b55e5a.png)

Additionally the very expensive metrics collected via 'radosgw-admin usage show' have been completely removed.

The following widgets have been removed in the 'Ceph - Object Gateway' dashboard:
- Top 10 - Operations
- Top 10 - Bandwidth (Sent)
- Top 10 - Bandwidth (Received)

The new dashboard:
![screenshot_new_02](https://user-images.githubusercontent.com/1897962/33827824-fbf7e3b0-de69-11e7-8aed-42837ecc2102.png)

The following widgets have been removed in the 'Ceph - Object Gateway users' dashboard:
- Operations (Overall, per bucket, per bucket + category)
- Bandwidth (Overall, per bucket, per bucket + category)

The new dashboard:
![auswahl_001](https://user-images.githubusercontent.com/1897962/33829638-6538dfa8-de71-11e7-9cc1-2b3e7dfaf0b0.png)

Signed-off-by: Volker Theile <vtheile@suse.com>