### PR TITLE
[backport] stage 3: don't update ceph packages, only install

### DIFF
--- a/srv/salt/ceph/packages/default.sls
+++ b/srv/salt/ceph/packages/default.sls
@@ -1,8 +1,8 @@
 
 ceph:
-  pkg.latest:
+  pkg.installed:
     - pkgs:
       - ceph
-    - dist-upgrade: True
+    - refresh: True
     - fire_event: True
 

--- a/srv/salt/ceph/stage/deploy/default.sls
+++ b/srv/salt/ceph/stage/deploy/default.sls
@@ -41,6 +41,7 @@ packages:
     - tgt: 'I@cluster:ceph'
     - tgt_type: compound
     - sls: ceph.packages
+    - failhard: True
 
 configuration check:
   salt.state:


### PR DESCRIPTION
Signed-off-by: Jan Fajerski <jfajerski@suse.com>
(cherry picked from commit b76030976ce7c7437783eb72e23d23f18cbac91d)
  no conflict but moved the failhard from stage/3/core/default.sls to
  stage/3/default.sls

Fixes: #856 