### PR TITLE
fix rpm-checks for: 'directories not owned by a package'

### DIFF
--- a/deepsea.spec
+++ b/deepsea.spec
@@ -258,13 +258,21 @@ systemctl try-restart salt-api > /dev/null 2>&1 || :
 %dir /srv/salt/ceph/rescind/openattic/keyring
 %dir /srv/salt/ceph/restart
 %dir /srv/salt/ceph/restart/osd
+%dir /srv/salt/ceph/restart/osd/lax
 %dir /srv/salt/ceph/restart/mon
+%dir /srv/salt/ceph/restart/mon/lax
 %dir /srv/salt/ceph/restart/mgr
+%dir /srv/salt/ceph/restart/mgr/lax
 %dir /srv/salt/ceph/restart/rgw
+%dir /srv/salt/ceph/restart/rgw/lax
 %dir /srv/salt/ceph/restart/igw
+%dir /srv/salt/ceph/restart/igw/lax
 %dir /srv/salt/ceph/restart/mds
+%dir /srv/salt/ceph/restart/mds/lax
 %dir /srv/salt/ceph/restart/ganesha
+%dir /srv/salt/ceph/restart/ganesha/lax
 %dir /srv/salt/ceph/restart/openattic
+%dir /srv/salt/ceph/restart/openattic/lax
 %dir /srv/salt/ceph/rgw
 %dir %attr(0700, salt, salt) /srv/salt/ceph/rgw/cache
 %dir /srv/salt/ceph/rgw/files


### PR DESCRIPTION
fixes rpm-checks

> [   52s] deepsea-0.8+git.55.f8e460793-2.6.1.noarch.rpm: directories not owned by a package:
> [   52s]  - /srv/salt/ceph/restart/ganesha/lax
> [   52s]  - /srv/salt/ceph/restart/igw/lax
> [   52s]  - /srv/salt/ceph/restart/mds/lax
> [   52s]  - /srv/salt/ceph/restart/mgr/lax
> [   52s]  - /srv/salt/ceph/restart/mon/lax
> [   52s]  - /srv/salt/ceph/restart/openattic/lax
> [   52s]  - /srv/salt/ceph/restart/osd/lax
> [   52s]  - /srv/salt/ceph/restart/rgw/lax
> 

Signed-off-by: Joshua Schmid <jschmid@suse.de>