### PR TITLE
allow indipendent service checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -594,6 +594,24 @@ copy-files:
 	# state files - check processes
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/processes
 	install -m 644 srv/salt/ceph/processes/*.sls $(DESTDIR)/srv/salt/ceph/processes/
+	install -d -m 755 $(DESTDIR)/srv/salt/ceph/processes/admin
+	install -m 644 srv/salt/ceph/processes/admin/*.sls $(DESTDIR)/srv/salt/ceph/processes/admin
+	install -d -m 755 $(DESTDIR)/srv/salt/ceph/processes/rgw
+	install -m 644 srv/salt/ceph/processes/rgw/*.sls $(DESTDIR)/srv/salt/ceph/processes/rgw
+	install -d -m 755 $(DESTDIR)/srv/salt/ceph/processes/osd
+	install -m 644 srv/salt/ceph/processes/osd/*.sls $(DESTDIR)/srv/salt/ceph/processes/osd
+	install -d -m 755 $(DESTDIR)/srv/salt/ceph/processes/openattic
+	install -m 644 srv/salt/ceph/processes/openattic/*.sls $(DESTDIR)/srv/salt/ceph/processes/openattic
+	install -d -m 755 $(DESTDIR)/srv/salt/ceph/processes/mon
+	install -m 644 srv/salt/ceph/processes/mon/*.sls $(DESTDIR)/srv/salt/ceph/processes/mon
+	install -d -m 755 $(DESTDIR)/srv/salt/ceph/processes/mgr
+	install -m 644 srv/salt/ceph/processes/mgr/*.sls $(DESTDIR)/srv/salt/ceph/processes/mgr
+	install -d -m 755 $(DESTDIR)/srv/salt/ceph/processes/mds
+	install -m 644 srv/salt/ceph/processes/mds/*.sls $(DESTDIR)/srv/salt/ceph/processes/mds
+	install -d -m 755 $(DESTDIR)/srv/salt/ceph/processes/ganesha
+	install -m 644 srv/salt/ceph/processes/ganesha/*.sls $(DESTDIR)/srv/salt/ceph/processes/ganesha
+	install -d -m 755 $(DESTDIR)/srv/salt/ceph/processes/igw
+	install -m 644 srv/salt/ceph/processes/igw/*.sls $(DESTDIR)/srv/salt/ceph/processes/igw
 	# state files - warning
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/warning
 	install -m 644 srv/salt/ceph/warning/*.sls $(DESTDIR)/srv/salt/ceph/warning/

--- a/deepsea.spec.in
+++ b/deepsea.spec.in
@@ -346,6 +346,15 @@ systemctl try-restart salt-api > /dev/null 2>&1 || :
 %dir /srv/salt/ceph/warning
 %dir /srv/salt/ceph/warning/noout
 %dir /srv/salt/ceph/processes
+%dir /srv/salt/ceph/processes/admin
+%dir /srv/salt/ceph/processes/ganesha
+%dir /srv/salt/ceph/processes/igw
+%dir /srv/salt/ceph/processes/mds
+%dir /srv/salt/ceph/processes/mgr
+%dir /srv/salt/ceph/processes/mon
+%dir /srv/salt/ceph/processes/openattic
+%dir /srv/salt/ceph/processes/osd
+%dir /srv/salt/ceph/processes/rgw
 %{_mandir}/man7/deepsea*.7.gz
 %{_mandir}/man5/deepsea*.5.gz
 %{_mandir}/man1/deepsea*.1.gz
@@ -597,6 +606,15 @@ systemctl try-restart salt-api > /dev/null 2>&1 || :
 %config /srv/salt/ceph/warning/*.sls
 %config /srv/salt/ceph/warning/noout/*.sls
 %config /srv/salt/ceph/processes/*.sls
+%config /srv/salt/ceph/processes/admin/*.sls
+%config /srv/salt/ceph/processes/ganesha/*.sls
+%config /srv/salt/ceph/processes/igw/*.sls
+%config /srv/salt/ceph/processes/mds/*.sls
+%config /srv/salt/ceph/processes/mgr/*.sls
+%config /srv/salt/ceph/processes/mon/*.sls
+%config /srv/salt/ceph/processes/openattic/*.sls
+%config /srv/salt/ceph/processes/osd/*.sls
+%config /srv/salt/ceph/processes/rgw/*.sls
 %dir %{_libexecdir}/deepsea
 %dir %attr(-, root, root) %{_docdir}/%{name}
 %{_docdir}/%{name}/*

--- a/srv/salt/_modules/cephprocesses.py
+++ b/srv/salt/_modules/cephprocesses.py
@@ -131,7 +131,7 @@ def wait(**kwargs):
     end_time = time.time() + settings['timeout']
     current_delay = settings['delay']
     while end_time > time.time():
-        if check():
+        if check(**kwargs):
             log.debug("Services are up")
             return True
         time.sleep(current_delay)

--- a/srv/salt/ceph/processes/admin/default.sls
+++ b/srv/salt/ceph/processes/admin/default.sls
@@ -1,5 +1,8 @@
-wait for all processes:
+wait for admin processes:
   module.run:
     - name: cephprocesses.wait
+    - kwargs:
+        'roles':
+          - admin
     - fire_event: True
     - failhard: True

--- a/srv/salt/ceph/processes/admin/init.sls
+++ b/srv/salt/ceph/processes/admin/init.sls
@@ -1,0 +1,3 @@
+include:
+  - .{{ salt['pillar.get']('cephprocesses_method_admin', 'default') }}
+

--- a/srv/salt/ceph/processes/ganesha/default.sls
+++ b/srv/salt/ceph/processes/ganesha/default.sls
@@ -1,5 +1,8 @@
-wait for all processes:
+wait for ganesha processes:
   module.run:
     - name: cephprocesses.wait
+    - kwargs:
+        'roles':
+          - ganesha
     - fire_event: True
     - failhard: True

--- a/srv/salt/ceph/processes/ganesha/init.sls
+++ b/srv/salt/ceph/processes/ganesha/init.sls
@@ -1,0 +1,3 @@
+include:
+  - .{{ salt['pillar.get']('cephprocesses_method_ganesha', 'default') }}
+

--- a/srv/salt/ceph/processes/igw/default.sls
+++ b/srv/salt/ceph/processes/igw/default.sls
@@ -1,5 +1,8 @@
-wait for all processes:
+wait for igw processes:
   module.run:
     - name: cephprocesses.wait
+    - kwargs:
+        'roles': 
+          - igw
     - fire_event: True
     - failhard: True

--- a/srv/salt/ceph/processes/igw/init.sls
+++ b/srv/salt/ceph/processes/igw/init.sls
@@ -1,0 +1,3 @@
+include:
+  - .{{ salt['pillar.get']('cephprocesses_method_igw', 'default') }}
+

--- a/srv/salt/ceph/processes/mds/default.sls
+++ b/srv/salt/ceph/processes/mds/default.sls
@@ -1,5 +1,8 @@
-wait for all processes:
+wait for mds processes:
   module.run:
     - name: cephprocesses.wait
+    - kwargs:
+        'roles': 
+          - mds
     - fire_event: True
     - failhard: True

--- a/srv/salt/ceph/processes/mds/init.sls
+++ b/srv/salt/ceph/processes/mds/init.sls
@@ -1,0 +1,3 @@
+include:
+  - .{{ salt['pillar.get']('cephprocesses_method_mds', 'default') }}
+

--- a/srv/salt/ceph/processes/mgr/default.sls
+++ b/srv/salt/ceph/processes/mgr/default.sls
@@ -1,5 +1,8 @@
-wait for all processes:
+wait for mgr processes:
   module.run:
     - name: cephprocesses.wait
+    - kwargs:
+        'roles': 
+          - mgr
     - fire_event: True
     - failhard: True

--- a/srv/salt/ceph/processes/mgr/init.sls
+++ b/srv/salt/ceph/processes/mgr/init.sls
@@ -1,0 +1,3 @@
+include:
+  - .{{ salt['pillar.get']('cephprocesses_method_mgr', 'default') }}
+

--- a/srv/salt/ceph/processes/mon/default.sls
+++ b/srv/salt/ceph/processes/mon/default.sls
@@ -1,5 +1,8 @@
-wait for all processes:
+wait for mon processes:
   module.run:
     - name: cephprocesses.wait
+    - kwargs:
+        'roles': 
+          - mon
     - fire_event: True
     - failhard: True

--- a/srv/salt/ceph/processes/mon/init.sls
+++ b/srv/salt/ceph/processes/mon/init.sls
@@ -1,0 +1,3 @@
+include:
+  - .{{ salt['pillar.get']('cephprocesses_method_mon', 'default') }}
+

--- a/srv/salt/ceph/processes/openattic/default.sls
+++ b/srv/salt/ceph/processes/openattic/default.sls
@@ -1,5 +1,8 @@
-wait for all processes:
+wait for openattic processes:
   module.run:
     - name: cephprocesses.wait
+    - kwargs:
+        'roles': 
+          - openattic
     - fire_event: True
     - failhard: True

--- a/srv/salt/ceph/processes/openattic/init.sls
+++ b/srv/salt/ceph/processes/openattic/init.sls
@@ -1,0 +1,3 @@
+include:
+  - .{{ salt['pillar.get']('cephprocesses_method_openattic', 'default') }}
+

--- a/srv/salt/ceph/processes/osd/default.sls
+++ b/srv/salt/ceph/processes/osd/default.sls
@@ -1,5 +1,8 @@
-wait for all processes:
+wait for osd processes:
   module.run:
     - name: cephprocesses.wait
+    - kwargs:
+        'roles': 
+          - storage
     - fire_event: True
     - failhard: True

--- a/srv/salt/ceph/processes/osd/init.sls
+++ b/srv/salt/ceph/processes/osd/init.sls
@@ -1,0 +1,3 @@
+include:
+  - .{{ salt['pillar.get']('cephprocesses_method_osd', 'default') }}
+

--- a/srv/salt/ceph/processes/rgw/default.sls
+++ b/srv/salt/ceph/processes/rgw/default.sls
@@ -1,5 +1,8 @@
-wait for all processes:
+wait for rgw processes:
   module.run:
     - name: cephprocesses.wait
+    - kwargs:
+        'roles': 
+          - rgw
     - fire_event: True
     - failhard: True

--- a/srv/salt/ceph/processes/rgw/init.sls
+++ b/srv/salt/ceph/processes/rgw/init.sls
@@ -1,0 +1,3 @@
+include:
+  - .{{ salt['pillar.get']('cephprocesses_method_rgw', 'default') }}
+

--- a/srv/salt/ceph/restart/ganesha/lax/default.sls
+++ b/srv/salt/ceph/restart/ganesha/lax/default.sls
@@ -7,11 +7,11 @@
         - sls: ceph.wait
         - failhard: True
 
-    check if ganehsa processes are still running on {{ host }}:
+    check if ganesha processes are still running on {{ host }}:
       salt.state:
         - tgt: 'I@roles:ganesha'
         - tgt_type: compound
-        - sls: ceph.processes
+        - sls: ceph.processes.ganesha
         - failhard: True
 
     restarting ganesha on {{ host }}:

--- a/srv/salt/ceph/restart/igw/lax/default.sls
+++ b/srv/salt/ceph/restart/igw/lax/default.sls
@@ -11,7 +11,7 @@
       salt.state:
         - tgt: 'I@roles:igw'
         - tgt_type: compound
-        - sls: ceph.processes
+        - sls: ceph.processes.igw
         - failhard: True
 
     restarting igw on {{ host }}:

--- a/srv/salt/ceph/restart/mds/lax/default.sls
+++ b/srv/salt/ceph/restart/mds/lax/default.sls
@@ -11,7 +11,7 @@
       salt.state:
         - tgt: 'I@roles:mds'
         - tgt_type: compound
-        - sls: ceph.processes
+        - sls: ceph.processes.mds
         - failhard: True
 
     restarting mds on {{ host }}:

--- a/srv/salt/ceph/restart/mgr/lax/default.sls
+++ b/srv/salt/ceph/restart/mgr/lax/default.sls
@@ -11,7 +11,7 @@
       salt.state:
         - tgt: 'I@roles:mgr'
         - tgt_type: compound
-        - sls: ceph.processes
+        - sls: ceph.processes.mgr
         - failhard: True
 
     restarting mgr on {{ host }}:

--- a/srv/salt/ceph/restart/mon/lax/default.sls
+++ b/srv/salt/ceph/restart/mon/lax/default.sls
@@ -11,7 +11,7 @@
       salt.state:
         - tgt: 'I@roles:mon'
         - tgt_type: compound
-        - sls: ceph.processes
+        - sls: ceph.processes.mon
         - failhard: True
 
     restarting mons on {{ host }}:

--- a/srv/salt/ceph/restart/openattic/lax/default.sls
+++ b/srv/salt/ceph/restart/openattic/lax/default.sls
@@ -11,7 +11,7 @@
       salt.state:
         - tgt: 'I@roles:openattic'
         - tgt_type: compound
-        - sls: ceph.processes
+        - sls: ceph.processes.openattic
         - failhard: True
 
     restarting openattic on {{ host }}:

--- a/srv/salt/ceph/restart/osd/lax/default.sls
+++ b/srv/salt/ceph/restart/osd/lax/default.sls
@@ -11,7 +11,7 @@
       salt.state:
         - tgt: 'I@roles:storage'
         - tgt_type: compound
-        - sls: ceph.processes
+        - sls: ceph.processes.osd
         - failhard: True
 
     restarting osds on {{ host }}:

--- a/srv/salt/ceph/restart/rgw/lax/default.sls
+++ b/srv/salt/ceph/restart/rgw/lax/default.sls
@@ -11,7 +11,7 @@
       salt.state:
         - tgt: 'I@roles:rgw'
         - tgt_type: compound
-        - sls: ceph.processes
+        - sls: ceph.processes.rgw
         - failhard: True
 
     restarting rgw on {{ host }}:


### PR DESCRIPTION
Fixes regression:

With https://github.com/SUSE/DeepSea/pull/841 we added restart of individual 'core' services right after the deployment finished. We tried to reduce the noise and crosschecks by targeting only the respective roles.
i.e. only target roles:mon  when you check for running services after restarting mons, instead of doing the full roundtrip and check services on all cluster nodes.

One problem in an initial deployment still persists. When you happen to have a node which holds two roles, one being a core (osd,mon,mgr) and the other being a non-core (i.e. rgw) cephprocesses.check performs on the node and checks for _all_ defined roles for that node. As you haven't executed stage.4 yet the rgw role is _defined_ for the node but not yet _deployed_ which is treated as a failure, hence the stage is aborted.
This doesn't lead to a  complete failure because the restart mechanism is executed _after_ the cluster is deplolyed, but isn't nice nevertheless. The easy-to-fix workaround is to just run stage.4 right after.

With this PR I added a 'ceph.processes.$role' which checks _only_ for the role specified.

'ceph.processes' keeps it's current behavior.

Signed-off-by: Joshua Schmid <jschmid@suse.de>