### PR TITLE
Display '0 s' instead of 'N/A'

### DIFF
--- a/srv/salt/ceph/monitoring/grafana/files/ceph-cluster.json
+++ b/srv/salt/ceph/monitoring/grafana/files/ceph-cluster.json
@@ -1178,7 +1178,7 @@
             "valueMaps": [
               {
                 "op": "=",
-                "text": "N/A",
+                "text": "0 s",
                 "value": "null"
               }
             ],
@@ -2359,6 +2359,6 @@
     },
     "timezone": "browser",
     "title": "Ceph - Cluster",
-    "version": 12
+    "version": 13
   }
 }


### PR DESCRIPTION
Display '0 s' instead of 'N/A' in the 'Average Monitor Latency' widget on the 'Ceph - Cluster' dashboard if no data exists.

![auswahl_003](https://user-images.githubusercontent.com/1897962/34046675-27147af8-e1ae-11e7-8c85-760b3332de26.png)

Signed-off-by: Volker Theile <vtheile@suse.com>