### PR TITLE
Rename deepsea.spec to deepsea.spec.in, prevent side effects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 setup.py
+deepsea.spec
 
 *.sw[pon]
 *~

--- a/Makefile
+++ b/Makefile
@@ -649,7 +649,7 @@ install: copy-files setup.py
 	python setup.py install --root=$(DESTDIR)/
 
 rpm: pyc tarball test
-	sed -i '/^Version:/s/[^ ]*$$/'$(VERSION)'/' deepsea.spec
+	sed '/^Version:/s/[^ ]*$$/'$(VERSION)'/' deepsea.spec.in > deepsea.spec
 	rpmbuild -bb deepsea.spec
 
 # Removing test dependency until resolved
@@ -658,7 +658,7 @@ tarball:
 	mkdir $(TEMPDIR)/deepsea-$(VERSION)
 	git archive HEAD | tar -x -C $(TEMPDIR)/deepsea-$(VERSION)
 	sed "s/DEVVERSION/"$(VERSION)"/" $(TEMPDIR)/deepsea-$(VERSION)/setup.py.in > $(TEMPDIR)/deepsea-$(VERSION)/setup.py
-	sed -i "s/DEVVERSION/"$(VERSION)"/" $(TEMPDIR)/deepsea-$(VERSION)/deepsea.spec
+	sed "s/DEVVERSION/"$(VERSION)"/" $(TEMPDIR)/deepsea-$(VERSION)/deepsea.spec.in > $(TEMPDIR)/deepsea-$(VERSION)/deepsea.spec
 	sed -i "s/DEVVERSION/"$(VERSION)"/" $(TEMPDIR)/deepsea-$(VERSION)/srv/modules/runners/deepsea.py
 	mkdir -p ~/rpmbuild/SOURCES
 	tar -cjf ~/rpmbuild/SOURCES/deepsea-$(VERSION).tar.bz2 -C $(TEMPDIR) .

--- a/deepsea.spec.in
+++ b/deepsea.spec.in
@@ -22,7 +22,7 @@
 # See also http://en.opensuse.org/openSUSE:Shared_library_packaging_policy
 
 Name:           deepsea
-Version:        0.9
+Version:        DEVVERSION
 Release:        0
 Summary:        Salt solution for deploying and managing Ceph
 


### PR DESCRIPTION
Changing the spec file in place via automation and making manual corrections is too error prone.  Separate the automated process from the manual one.

Signed-off-by: Eric Jackson <ejackson@suse.com>