### PR TITLE
pass role arg as kwargs to match process the requested role

### DIFF
--- a/srv/modules/runners/cephprocesses.py
+++ b/srv/modules/runners/cephprocesses.py
@@ -36,7 +36,7 @@ def help_():
 
 
 # pylint: disable=dangerous-default-value
-def check(cluster='ceph', roles=[], tolerate_down=0, verbose=True):
+def check(cluster='ceph', roles=[], tolerate_down=0, quiet=False):
     """
     Query the status of running processes for each role.  Also, verify that
     all minions assigned roles do respond.  Return False if any fail.
@@ -46,7 +46,7 @@ def check(cluster='ceph', roles=[], tolerate_down=0, verbose=True):
     if not roles:
         roles = _cached_roles(search)
 
-    status = _status(search, roles, verbose)
+    status = _status(search, roles, quiet)
 
     log.debug("roles: {}".format(pprint.pformat(roles)))
     log.debug("status: {}".format(pprint.pformat(status)))
@@ -97,7 +97,7 @@ def restart_required(role=None, cluster='ceph'):
     return restart
 
 
-def _status(search, roles, verbose):
+def _status(search, roles, quiet):
     """
     Return a structure of roles with module results
     """
@@ -113,6 +113,7 @@ def _status(search, roles, verbose):
         status[role] = local.cmd(role_search,
                                  'cephprocesses.check',
                                  kwarg={'roles': [role]},
+                                 quiet=quiet,
                                  expr_form="compound")
 
     sys.stdout = _stdout

--- a/srv/modules/runners/cephprocesses.py
+++ b/srv/modules/runners/cephprocesses.py
@@ -112,8 +112,7 @@ def _status(search, roles, verbose):
         role_search = search + " and I@roles:{}".format(role)
         status[role] = local.cmd(role_search,
                                  'cephprocesses.check',
-                                 roles=roles,
-                                 verbose=verbose,
+                                 kwarg={'roles': [role]},
                                  expr_form="compound")
 
     sys.stdout = _stdout


### PR DESCRIPTION
the signature of cephprocesses.check is 

``` python
def check(results=False, quiet=False, **kwargs):
```

You can call 

``` shell
salt-call cephprocesses.check roles=['mon']
```

because salt converts this as kwargs anyways. If you do that in a module context like before the commit, the params will be just silently ignored and _all_ roles for the requested _search_ pattern are checked.

instead we have to do:

``` python
kwarg={'roles': [role]}
```

note that `kwarg` is the right syntax although the signature actually asks for kwargs ->  see the [docs](https://docs.saltstack.com/en/latest/ref/clients/#localclient)

Signed-off-by: Joshua Schmid <jschmid@suse.de>