### PR TITLE
Install correct python-boto for new distros

### DIFF
--- a/srv/salt/ceph/packages/common/default.sls
+++ b/srv/salt/ceph/packages/common/default.sls
@@ -1,4 +1,5 @@
 {% set os = salt['grains.get']('os') %}
+{% set osmajorrelease = salt['grains.get']('osmajorrelease') %}
 
 {% if os == 'SUSE' %}
 
@@ -8,7 +9,11 @@ stage prep dependencies suse:
       - lsscsi
       - pciutils
       - gptfdisk
+{% if osmajorrelease|int > 12 and osmajorrelease|int != 42 %}
+      - python2-boto
+{% else %}
       - python-boto
+{% endif %}
       - python-rados
       - iperf
       - lsof
@@ -46,7 +51,11 @@ stage prep dependencies CentOS:
       - lsscsi
       - pciutils
       - gdisk
+{% if osmajorrelease|int > 6 %}
+      - python2-boto
+{% else %}
       - python-boto
+{% endif %}
       - python-rados
       - iperf3
       - lshw

--- a/srv/salt/ceph/rgw/buckets/default.sls
+++ b/srv/salt/ceph/rgw/buckets/default.sls
@@ -1,8 +1,14 @@
+{% set os = salt['grains.get']('os') %}
+{% set osmajorrelease = salt['grains.get']('osmajorrelease') %}
 
 install rgw:
   pkg.installed:
     - pkgs:
+{% if ( osmajorrelease|int > 12 and osmajorrelease|int != 42 ) or ( os == 'CentOS' and osmajorrelease|int > 6 ) %}
+      - python2-boto
+{% else %}
       - python-boto
+{% endif %}
     - refresh: True
 
 {% for user in salt['rgw.users'](contains="demo") %}

--- a/srv/salt/ceph/rgw/users/default.sls
+++ b/srv/salt/ceph/rgw/users/default.sls
@@ -1,9 +1,15 @@
+{% set os = salt['grains.get']('os') %}
+{% set osmajorrelease = salt['grains.get']('osmajorrelease') %}
 
 install rgw:
   pkg.installed:
     - pkgs:
       - ceph-radosgw
+{% if ( osmajorrelease|int > 12 and osmajorrelease|int != 42 ) or ( os == 'CentOS' and osmajorrelease|int > 6 ) %}
+      - python2-boto
+{% else %}
       - python-boto
+{% endif %}
     - refresh: True
 
 add users:


### PR DESCRIPTION
for new distros python-boto is split to python2-boto and
python3-boto, need to be fixed later when switching to 3.x
closes #840 

Proposed workaround for bug #840 