### PR TITLE
Block device benchmark module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -385,6 +385,9 @@ copy-files:
 	install -m 644 srv/salt/ceph/rbd/benchmarks/*.sls $(DESTDIR)/srv/salt/ceph/rbd/benchmarks/
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/rbd/benchmarks/files
 	install -m 644 srv/salt/ceph/rbd/benchmarks/files/keyring.j2 $(DESTDIR)/srv/salt/ceph/rbd/benchmarks/files/
+	# state files - benchmark-blockdev
+	install -d -m 755 $(DESTDIR)/srv/salt/ceph/benchmarks/blockdev/
+	install -m 644 srv/salt/ceph/benchmarks/blockdev/*.sls $(DESTDIR)/srv/salt/ceph/benchmarks/blockdev/
 	# state files - reactor
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/reactor
 	install -m 644 srv/salt/ceph/reactor/*.sls $(DESTDIR)/srv/salt/ceph/reactor/

--- a/deepsea.spec.in
+++ b/deepsea.spec.in
@@ -97,6 +97,7 @@ systemctl try-restart salt-api > /dev/null 2>&1 || :
 %dir /srv/salt/ceph/admin/files
 %dir /srv/salt/ceph/admin/key
 %dir /srv/salt/ceph/benchmarks
+%dir /srv/salt/ceph/benchmarks/blockdev
 %dir /srv/salt/ceph/cephfs
 %dir /srv/salt/ceph/cephfs/benchmarks
 %dir /srv/salt/ceph/cephfs/benchmarks/files
@@ -389,6 +390,7 @@ systemctl try-restart salt-api > /dev/null 2>&1 || :
 %config /srv/salt/ceph/admin/files/*.j2
 %config /srv/salt/ceph/admin/key/*.sls
 %config /srv/salt/ceph/benchmarks/*.sls
+%config /srv/salt/ceph/benchmarks/blockdev/*.sls
 %config /srv/salt/ceph/cephfs/benchmarks/*.sls
 %config /srv/salt/ceph/cephfs/benchmarks/files/keyring.j2
 %config /srv/salt/ceph/salt-api/*.sls

--- a/srv/modules/runners/populate.py
+++ b/srv/modules/runners/populate.py
@@ -548,7 +548,8 @@ class CephRoles(object):
         """
         Allows admins to target non-Ceph minions
         """
-        roles = [ 'client-cephfs', 'client-radosgw', 'client-iscsi', 'client-nfs', 'benchmark-rbd'  ]
+        roles = [ 'client-cephfs', 'client-radosgw', 'client-iscsi',
+                  'client-nfs', 'benchmark-rbd', 'benchmark-blockdev' ]
         self.available_roles.extend(roles)
 
         for role in roles:

--- a/srv/pillar/ceph/benchmarks/collections/default.yml
+++ b/srv/pillar/ceph/benchmarks/collections/default.yml
@@ -3,3 +3,5 @@ fs:
   - fio/rw_many_files.yml
 rbd:
   - fio/base_rbd.yml
+blockdev:
+  - fio/blockdev_krbd.yml

--- a/srv/pillar/ceph/benchmarks/fio/blockdev_krbd.yml
+++ b/srv/pillar/ceph/benchmarks/fio/blockdev_krbd.yml
@@ -1,0 +1,12 @@
+template: blockdev_krbd.j2
+# size in bytes, as it's multiplied by worker_index for offset
+# i.e. total blockdev size must be >= size * number_of_workers
+# 1024 * 1024 * 1024
+size: 1073741824
+nrfiles: 1
+blocksizes:
+  - 4m
+number_of_workers: 4
+worker_stagger_delay: 0
+operations:
+  - rw

--- a/srv/pillar/ceph/benchmarks/templates/blockdev_krbd.j2
+++ b/srv/pillar/ceph/benchmarks/templates/blockdev_krbd.j2
@@ -1,0 +1,17 @@
+[global]
+ioengine=psync
+filename=/dev/rbd0
+
+{% for op in operations %}
+{% for bs in blocksizes %}
+{% for worker in range(0, number_of_workers) %}
+[worker{{ worker }}_{{ bs }}_{{ op }}]
+  rw={{ op }}
+  blocksize={{ bs }}
+  startdelay={{ worker_stagger_delay * loop.index0 }}
+  offset={{ loop.index0 * size }}
+  size={{ size }}
+
+{% endfor %}
+{% endfor %}
+{% endfor %}

--- a/srv/salt/_modules/cephprocesses.py
+++ b/srv/salt/_modules/cephprocesses.py
@@ -36,6 +36,7 @@ processes = {'mon': ['ceph-mon'],
              'client-iscsi': [],
              'client-nfs': [],
              'client-radosgw': [],
+             'benchmark-blockdev': [],
              'master': []}
 
 

--- a/srv/salt/ceph/benchmarks/blockdev.sls
+++ b/srv/salt/ceph/benchmarks/blockdev.sls
@@ -1,0 +1,35 @@
+# This benchmark runs fio against a local block device on the given
+# node. This can be used for both iSCSI initiator and krbd client
+# benchmarks, assuming the iSCSI login or rbd map is performed manually
+# beforehand.
+# TODO Support per-client block devices
+
+prep master:
+  salt.state:
+    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - sls: ceph.benchmarks.blockdev.prepare_master
+
+prep clients:
+  salt.state:
+    - tgt: "I@roles:benchmark-blockdev and I@cluster:ceph"
+    - tgt_type: compound
+    - sls:
+      - ceph.benchmarks.blockdev.prepare_clients
+
+run fio:
+  salt.runner:
+    - name: benchmark.blockdev
+    - log_dir: {{ salt['pillar.get']('benchmark:log-file-directory') }}
+    - job_dir: {{ salt['pillar.get']('benchmark:job-file-directory') }}
+    - default_collection: {{ salt['pillar.get']('benchmark:default-collection') }}
+    - client_glob : "I@roles:benchmark-blockdev and I@cluster:ceph"
+    # work_dir not used by blockdev bench, as it's not mounted
+
+cleanup clients:
+  salt.state:
+    - tgt: "I@roles:benchmark-blockdev and I@cluster:ceph"
+    - tgt_type: compound
+    - sls:
+      - ceph.benchmarks.blockdev.cleanup_clients
+
+# no cleanup for master needed

--- a/srv/salt/ceph/benchmarks/blockdev/cleanup_clients.sls
+++ b/srv/salt/ceph/benchmarks/blockdev/cleanup_clients.sls
@@ -1,0 +1,2 @@
+include:
+  - ceph.tools.fio.cleanup

--- a/srv/salt/ceph/benchmarks/blockdev/prepare_clients.sls
+++ b/srv/salt/ceph/benchmarks/blockdev/prepare_clients.sls
@@ -1,0 +1,2 @@
+include:
+  - ceph.tools.fio.fio_service

--- a/srv/salt/ceph/benchmarks/blockdev/prepare_master.sls
+++ b/srv/salt/ceph/benchmarks/blockdev/prepare_master.sls
@@ -1,0 +1,3 @@
+include:
+  - ceph.tools.fio.fio
+  - ceph.tools.benchmarks.master_dirs


### PR DESCRIPTION
@jan--f you probably have something to say about the srv/salt/ceph/benchmarks/blockdev/ path usage ;-) . I still think it makes sense to nest all of the benchmark backend files under the parent _benchmarks_ path, would you be open to using separate subdirectories per module here?