### PR TITLE
Make modules & runners python2/3 compliant 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,6 @@ junit*.xml
 
 # ctag files
 tags
+
+# backup
+*.bak

--- a/.pylintrc
+++ b/.pylintrc
@@ -46,7 +46,7 @@ fileperms-default=0644
 fileperms-ignore-paths=setup.py,tests/runtests.py,tests/jenkins*.py,tests/saltsh.py,tests/buildpackage.py
 
 # Minimum Python Version To Enforce
-minimum-python-version = 2.7
+minimum-python-version = 3.4
 
 # Allowed 3rd-party package imports
 allowed-3rd-party-modules = msgpack,
@@ -54,6 +54,8 @@ allowed-3rd-party-modules = msgpack,
   yaml,
   jinja2,
   Crypto,
+  salt.ext.six.moves,
+  helper,
   requests,
   libcloud,
   zmq,
@@ -86,7 +88,9 @@ disable=W0142,
   W1202,
   E1320,
   E8402,
-  E8731
+  E8731, 
+  W1202,
+  W0141 
 #  E8121,
 #  E8122,
 #  E8123,

--- a/Makefile
+++ b/Makefile
@@ -34,10 +34,10 @@ version:
 setup.py:
 	sed "s/DEVVERSION/"$(VERSION)"/" setup.py.in > setup.py
 
-pyc: setup.py
-	find srv/ -name '*.py' -exec python -m py_compile {} \;
-	# deepsea-cli
-	python setup.py build
+pyc: 
+	#make sure to create bytecode with the correct version
+	find srv/ -name '*.py' -exec python3 -m py_compile {} \;
+	find cli/ -name '*.py' -exec python3 -m py_compile {} \;
 
 copy-files:
 	# salt-master config files
@@ -67,10 +67,16 @@ copy-files:
 	install -d -m 755 $(DESTDIR)$(DOCDIR)/deepsea/pillar
 	install -m 644 doc/pillar/* $(DESTDIR)$(DOCDIR)/deepsea/pillar/
 	# stacky.py (included in salt 2016.3)
+	install -d -m 755 $(DESTDIR)/srv/modules/__pycache__
+	install -m 644 srv/modules/__pycache__/*.pyc $(DESTDIR)/srv/modules/__pycache__
 	install -d -m 755 $(DESTDIR)/srv/modules/pillar
+	install -d -m 755 $(DESTDIR)/srv/modules/pillar/__pycache__
+	install -m 644 srv/modules/pillar/__pycache__/*.pyc $(DESTDIR)/srv/modules/pillar/__pycache__
 	install -m 644 srv/modules/pillar/stack.py $(DESTDIR)/srv/modules/pillar/
 	# runners
 	install -d -m 755 $(DESTDIR)/srv/modules/runners
+	install -d -m 755 $(DESTDIR)/srv/modules/runners/__pycache__
+	install -m 644 srv/modules/runners/__pycache__/*.pyc $(DESTDIR)/srv/modules/runners/__pycache__
 	install -m 644 srv/modules/runners/*.py* $(DESTDIR)/srv/modules/runners/
 	sed -i "s/DEVVERSION/"$(VERSION)"/" $(DESTDIR)/srv/modules/runners/deepsea.py
 	# pillar
@@ -98,7 +104,13 @@ copy-files:
 	install -d -m 755 $(DESTDIR)/usr/share/man/man1
 	install -m 644 man/deepsea*.1 $(DESTDIR)/usr/share/man/man1
 	# modules
+	install -d -m 755 $(DESTDIR)/srv/__pycache__
+	install -m 644 srv/__pycache__/*.pyc $(DESTDIR)/srv/__pycache__
+	install -d -m 755 $(DESTDIR)/srv/salt/__pycache__
+	install -m 644 srv/salt/__pycache__/*.pyc $(DESTDIR)/srv/salt/__pycache__
 	install -d -m 755 $(DESTDIR)/srv/salt/_modules
+	install -d -m 755 $(DESTDIR)/srv/salt/_modules/__pycache__
+	install -m 644 srv/salt/_modules/__pycache__/*.pyc $(DESTDIR)/srv/salt/_modules/__pycache__
 	install -m 644 srv/salt/_modules/*.py* $(DESTDIR)/srv/salt/_modules/
 	# state files
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/admin
@@ -280,7 +292,9 @@ copy-files:
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/monitoring/prometheus/exporters/ceph_rgw_exporter/cron
 	install -m 644 srv/salt/ceph/monitoring/prometheus/exporters/ceph_rgw_exporter/cron/*.sls $(DESTDIR)/srv/salt/ceph/monitoring/prometheus/exporters/ceph_rgw_exporter/cron
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/monitoring/prometheus/exporters/ceph_rgw_exporter/files
-	install -m 644 srv/salt/ceph/monitoring/prometheus/exporters/ceph_rgw_exporter/files/* $(DESTDIR)/srv/salt/ceph/monitoring/prometheus/exporters/ceph_rgw_exporter/files
+	install -m 644 srv/salt/ceph/monitoring/prometheus/exporters/ceph_rgw_exporter/files/*.py $(DESTDIR)/srv/salt/ceph/monitoring/prometheus/exporters/ceph_rgw_exporter/files
+	install -d -m 755 $(DESTDIR)/srv/salt/ceph/monitoring/prometheus/exporters/ceph_rgw_exporter/files/__pycache__
+	install -m 644 srv/salt/ceph/monitoring/prometheus/exporters/ceph_rgw_exporter/files/__pycache__/*.pyc $(DESTDIR)/srv/salt/ceph/monitoring/prometheus/exporters/ceph_rgw_exporter/files/__pycache__
 	# state files - noout
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/noout
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/noout/set
@@ -737,20 +751,22 @@ copy-files:
 	-chown $(USER):$(GROUP) $(DESTDIR)/srv/salt/ceph/rgw/cache || true
 	-chown $(USER):$(GROUP) $(DESTDIR)/srv/salt/ceph/configuration/files/ceph.conf.checksum || true
 
-install: copy-files setup.py
+install-deps:
+	$(PKG_INSTALL) python3-setuptools python3-click
+
+install: setup.py pyc install-deps copy-files
 	sed -i '/^sharedsecret: /s!{{ shared_secret }}!'`cat /proc/sys/kernel/random/uuid`'!' $(DESTDIR)/etc/salt/master.d/sharedsecret.conf
 	chown $(USER):$(GROUP) $(DESTDIR)/etc/salt/master.d/*
 	echo "deepsea_minions: '*'" > /srv/pillar/ceph/deepsea_minions.sls
 	chown -R $(USER) /srv/pillar/ceph
 	sed -i '/^master_minion:/s!_REPLACE_ME_!'`cat /etc/salt/minion_id`'!' /srv/pillar/ceph/master_minion.sls
 	systemctl restart salt-master
-	$(PKG_INSTALL) salt-api python-ipaddress
+	$(PKG_INSTALL) salt-api
 	systemctl restart salt-api
 	# deepsea-cli
-	$(PKG_INSTALL) python-setuptools python-click
-	python setup.py install --root=$(DESTDIR)/
+	python3 setup.py install --root=$(DESTDIR)/
 
-rpm: pyc tarball test
+rpm: setup.py tarball test
 	sed '/^Version:/s/[^ ]*$$/'$(VERSION)'/' deepsea.spec.in > deepsea.spec
 	rpmbuild -bb deepsea.spec
 

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ version:
 setup.py:
 	sed "s/DEVVERSION/"$(VERSION)"/" setup.py.in > setup.py
 
-pyc: 
+pyc: setup.py 
 	#make sure to create bytecode with the correct version
 	find srv/ -name '*.py' -exec python3 -m py_compile {} \;
 	find cli/ -name '*.py' -exec python3 -m py_compile {} \;
@@ -754,7 +754,7 @@ copy-files:
 install-deps:
 	$(PKG_INSTALL) python3-setuptools python3-click
 
-install: setup.py pyc install-deps copy-files
+install: pyc install-deps copy-files
 	sed -i '/^sharedsecret: /s!{{ shared_secret }}!'`cat /proc/sys/kernel/random/uuid`'!' $(DESTDIR)/etc/salt/master.d/sharedsecret.conf
 	chown $(USER):$(GROUP) $(DESTDIR)/etc/salt/master.d/*
 	echo "deepsea_minions: '*'" > /srv/pillar/ceph/deepsea_minions.sls
@@ -766,7 +766,7 @@ install: setup.py pyc install-deps copy-files
 	# deepsea-cli
 	python3 setup.py install --root=$(DESTDIR)/
 
-rpm: setup.py tarball test
+rpm: tarball test
 	sed '/^Version:/s/[^ ]*$$/'$(VERSION)'/' deepsea.spec.in > deepsea.spec
 	rpmbuild -bb deepsea.spec
 

--- a/cli/monitor.py
+++ b/cli/monitor.py
@@ -16,6 +16,8 @@ from .salt_event import EventListener
 from .salt_event import NewJobEvent, NewRunnerEvent, RetJobEvent, RetRunnerEvent
 from .stage_parser import SLSParser, SaltRunner, SaltState, SaltModule, SaltBuiltIn, \
                           RenderingException
+from six.moves import range
+from functools import reduce
 
 
 # pylint: disable=C0111
@@ -240,7 +242,7 @@ class Stage(object):
             if self.current_step == 0 and curr_step.start_event is None:
                 # check for duplicates before starting step 1
                 for ex_step in self._dynamic_steps.values():
-                    if (ex_step.name == step.name and ex_step.targets.keys() == event.targets and
+                    if (ex_step.name == step.name and list(ex_step.targets.keys()) == event.targets and
                             ex_step.args_str == step.args_str):
                         # possible parsing generated duplicate
                         return None, None, None
@@ -660,7 +662,7 @@ class Monitor(threading.Thread):
                                 "on=%s",
                                 step.order,
                                 self._running_stage.total_steps(), step.name, step.args_str,
-                                step.targets.keys())
+                                list(step.targets.keys()))
                     self._fire_event('step_state_finished', step)
             else:
                 if not step.jid:
@@ -683,7 +685,7 @@ class Monitor(threading.Thread):
         if isinstance(step, Stage.TargetedStep):
             logger.info("Started State step: [%s/%s] name=%s(%s) on=%s", step.order,
                         self._running_stage.total_steps(), step.name, step.args_str,
-                        step.targets.keys())
+                        list(step.targets.keys()))
             self._fire_event('step_state_started', step)
         else:
             logger.info("Started Runner step: [%s/%s] name=%s(%s)", step.order,

--- a/cli/monitors/terminal_outputter.py
+++ b/cli/monitors/terminal_outputter.py
@@ -96,7 +96,7 @@ class SimplePrinter(MonitorListener):
                         PP.println("  {}:".format(minion))
                         ret_data = event.raw_event['data']['return']
                         if isinstance(ret_data, dict):
-                            ret_data = ret_data.values()
+                            ret_data = list(ret_data.values())
                         if isinstance(ret_data, list):
                             for substep in ret_data:
                                 if isinstance(substep, dict):

--- a/deepsea.spec.in
+++ b/deepsea.spec.in
@@ -32,15 +32,16 @@ Url:            https://github.com/suse/deepsea
 Source0:        %{name}-%{version}.tar.bz2
 
 BuildRequires:  salt-master
-BuildRequires:  python-setuptools
+BuildRequires:  python3-setuptools
 Requires:       salt-master
 Requires:       salt-minion
 Requires:       salt-api
-Requires:       python-ipaddress
-Requires:       python-netaddr
-Requires:       python-rados
-Requires:       python-setuptools
-Requires:       python-click
+Requires:       python3-netaddr
+Requires:       python3-rados
+Requires:       python3-setuptools
+Requires:       python3-configobj
+Requires:       python3-six
+Requires:       python3-click
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 BuildArch:      noarch
 
@@ -58,7 +59,7 @@ make DESTDIR=%{buildroot} pyc VERSION=%{version}
 make DESTDIR=%{buildroot} DOCDIR=%{_docdir} copy-files VERSION=%{version}
 %__rm -f %{buildroot}/%{_mandir}/man?/*.gz
 %__gzip %{buildroot}/%{_mandir}/man?/deepsea*
-python setup.py install --prefix=%{_prefix} --root=%{buildroot}
+python3 setup.py install --prefix=%{_prefix} --root=%{buildroot}
 
 %post
 if [ $1 -eq 1 ] ; then
@@ -78,19 +79,25 @@ systemctl try-restart salt-api > /dev/null 2>&1 || :
 %files
 %defattr(-,root,root,-)
 %{_bindir}/deepsea
-%{python_sitelib}/deepsea/
-%{python_sitelib}/deepsea-%{version}-py%{python_version}.egg-info
+%{python3_sitelib}/deepsea/
+%{python3_sitelib}/deepsea-%{version}-py%{python3_version}.egg-info
 /srv/modules/pillar/stack.py*
-%dir /srv/modules/runners
 %dir %attr(0755, salt, salt) /srv/pillar/ceph
 %dir %attr(0755, salt, salt) /srv/pillar/ceph/stack
 %dir %attr(0755, salt, salt) /srv/pillar/ceph/benchmarks
 %dir %attr(0755, salt, salt) /srv/pillar/ceph/benchmarks/collections
 %dir %attr(0755, salt, salt) /srv/pillar/ceph/benchmarks/fio
 %dir %attr(0755, salt, salt) /srv/pillar/ceph/benchmarks/templates
-%dir /srv/modules
-%dir /srv/modules/pillar
+%dir /srv/__pycache__
 %dir /srv/salt/_modules
+%dir /srv/salt/__pycache__
+%dir /srv/salt/_modules/__pycache__
+%dir /srv/modules
+%dir /srv/modules/__pycache__
+%dir /srv/modules/runners
+%dir /srv/modules/runners/__pycache__
+%dir /srv/modules/pillar
+%dir /srv/modules/pillar/__pycache__
 %dir %attr(0755, salt, salt) /srv/salt/ceph
 %dir /srv/salt/ceph/admin
 %dir %attr(0700, salt, salt) /srv/salt/ceph/admin/cache
@@ -177,6 +184,7 @@ systemctl try-restart salt-api > /dev/null 2>&1 || :
 %dir /srv/salt/ceph/monitoring/prometheus/exporters/ceph_rgw_exporter
 %dir /srv/salt/ceph/monitoring/prometheus/exporters/ceph_rgw_exporter/cron
 %dir /srv/salt/ceph/monitoring/prometheus/exporters/ceph_rgw_exporter/files
+%dir /srv/salt/ceph/monitoring/prometheus/exporters/ceph_rgw_exporter/files/__pycache__
 %dir /srv/salt/ceph/monitoring/prometheus/exporters/files
 %dir /srv/salt/ceph/monitoring/prometheus/files
 %dir /srv/salt/ceph/noout
@@ -399,6 +407,12 @@ systemctl try-restart salt-api > /dev/null 2>&1 || :
 %config(noreplace) %attr(-, salt, salt) /srv/pillar/ceph/master_minion.sls
 %config(noreplace) %attr(-, salt, salt) /srv/pillar/ceph/deepsea_minions.sls
 %config %attr(-, salt, salt) /srv/pillar/ceph/stack/stack.cfg
+%config /srv/modules/__pycache__/*.pyc
+%config /srv/modules/runners/__pycache__/*.pyc
+%config /srv/modules/pillar/__pycache__/*.pyc
+%config /srv/salt/_modules/__pycache__/*.pyc
+%config /srv/salt/__pycache__/*.pyc
+%config /srv/__pycache__/*.pyc
 /srv/salt/_modules/*.py*
 %config /srv/salt/ceph/admin/*.sls
 %config /srv/salt/ceph/admin/files/*.j2
@@ -479,7 +493,8 @@ systemctl try-restart salt-api > /dev/null 2>&1 || :
 %config /srv/salt/ceph/monitoring/prometheus/exporters/*.sls
 %config /srv/salt/ceph/monitoring/prometheus/exporters/ceph_rgw_exporter/*.sls
 %config /srv/salt/ceph/monitoring/prometheus/exporters/ceph_rgw_exporter/cron/*.sls
-%config /srv/salt/ceph/monitoring/prometheus/exporters/ceph_rgw_exporter/files/*
+%config /srv/salt/ceph/monitoring/prometheus/exporters/ceph_rgw_exporter/files/*.py
+%config /srv/salt/ceph/monitoring/prometheus/exporters/ceph_rgw_exporter/files/__pycache__/*.pyc
 %config /srv/salt/ceph/monitoring/prometheus/exporters/files/*
 %config /srv/salt/ceph/monitoring/prometheus/files/*.j2
 %config /srv/salt/ceph/noout/set/*.sls

--- a/qa/common/common.sh
+++ b/qa/common/common.sh
@@ -557,7 +557,7 @@ function ceph_health_test {
 function salt_api_test {
   echo "Salt API test: BEGIN"
   systemctl status salt-api.service
-  curl http://${SALT_MASTER}:8000/ | python -m json.tool
+  curl http://${SALT_MASTER}:8000/ | python3 -m json.tool
   echo "Salt API test: END"
 }
 

--- a/qa/common/nfs-ganesha.sh
+++ b/qa/common/nfs-ganesha.sh
@@ -150,7 +150,7 @@ function assert_success {
 }
 
 echo "nfs-ganesha PyNFS test script running as $(whoami) on $(hostname --fqdn)"
-zypper --non-interactive install --no-recommends krb5-devel python-devel
+zypper --non-interactive install --no-recommends krb5-devel python3-devel
 git clone --depth 1 https://github.com/supriti/Pynfs
 cd Pynfs
 ./setup.py build

--- a/srv/modules/pillar/stack.py
+++ b/srv/modules/pillar/stack.py
@@ -369,6 +369,7 @@ from functools import partial
 
 import yaml
 from jinja2 import FileSystemLoader, Environment, TemplateNotFound
+import six
 
 
 log = logging.getLogger(__name__)
@@ -384,11 +385,11 @@ def ext_pillar(minion_id, pillar, *args, **kwargs):
         'grains': partial(salt.utils.traverse_dict_and_list, __grains__),
         'opts': partial(salt.utils.traverse_dict_and_list, __opts__),
         }
-    for matcher, matchs in kwargs.iteritems():
+    for matcher, matchs in six.iteritems(kwargs):
         t, matcher = matcher.split(':', 1)
         if t not in traverse:
             raise Exception('Unknown traverse option "{0}", '
-                            'should be one of {1}'.format(t, traverse.keys()))
+                            'should be one of {1}'.format(t, list(traverse.keys())))
         cfgs = matchs.get(traverse[t](matcher, None), [])
         if not isinstance(cfgs, list):
             cfgs = [cfgs]
@@ -442,7 +443,7 @@ def _cleanup(obj):
     if obj:
         if isinstance(obj, dict):
             obj.pop('__', None)
-            for k, v in obj.iteritems():
+            for k, v in six.iteritems(obj):
                 obj[k] = _cleanup(v)
         elif isinstance(obj, list) and isinstance(obj[0], dict) \
                 and '__' in obj[0]:
@@ -458,7 +459,7 @@ def _merge_dict(stack, obj):
     if strategy == 'overwrite':
         return _cleanup(obj)
     else:
-        for k, v in obj.iteritems():
+        for k, v in six.iteritems(obj):
             if strategy == 'remove':
                 stack.pop(k, None)
                 continue

--- a/srv/modules/runners/advise.py
+++ b/srv/modules/runners/advise.py
@@ -8,7 +8,10 @@ and purpose but different functions.
 Note: a runner's output displays immediately unlike a module
 """
 
+from __future__ import print_function
+from __future__ import absolute_import
 import logging
+# pylint: disable=import-error,3rd-party-module-not-gated,redefined-builtin
 import salt.client
 
 log = logging.getLogger(__name__)
@@ -27,7 +30,7 @@ def help_():
              'salt-run advise.networks:\n\n'
              '    Passive message about public and cluster networks\n'
              '\n\n')
-    print usage
+    print(usage)
     return ""
 
 
@@ -61,7 +64,7 @@ def salt_upgrade():
         continue the upgrade.
         ***************************************************'''
 
-    print message
+    print(message)
     return message
 
 
@@ -76,7 +79,7 @@ def no_cluster_detected():
         setup DeepSea correctly and start the upgrade again.
         ***************************************************'''
 
-    print message
+    print(message)
     return message
 
 
@@ -91,8 +94,9 @@ def networks():
     bold = '\033[1m'
     endc = '\033[0m'
 
-    print "{:25}: {}{}{}".format('public network', bold, ", ".join(filter(None, public)), endc)
-    print "{:25}: {}{}{}".format('cluster network', bold, ", ".join(filter(None, cluster)), endc)
+    # pylint: disable=line-too-long
+    print("{:25}: {}{}{}".format('public network', bold, ", ".join([_f for _f in public if _f]), endc))
+    print("{:25}: {}{}{}".format('cluster network', bold, ", ".join([_f for _f in cluster if _f]), endc))
     return ""
 
 __func_alias__ = {

--- a/srv/modules/runners/cephprocesses.py
+++ b/srv/modules/runners/cephprocesses.py
@@ -7,10 +7,13 @@ upgrade is safe.  All expected processes are running.
 A secondary purpose is a utility to check the current state of all processes.
 """
 
+from __future__ import print_function
+from __future__ import absolute_import
 import pprint
 import os
 import sys
 import logging
+# pylint: disable=import-error,3rd-party-module-not-gated,redefined-builtin
 import salt.client
 import salt.utils
 import salt.utils.master
@@ -22,16 +25,16 @@ def help_():
     """
     Usage
     """
-    usage = ('salt-run cephprocesses.check:\n\n'
-             '    Checks the process status according to assigned role\n'
-             '\n\n'
-             'salt-run cephprocesses.mon:\n\n'
-             '    Query monitors to determine if Ceph cluster is active\n'
-             '\n\n'
-             'salt-run cephprocesses.wait:\n\n'
-             '    Wait for all processes to be up according to assigned roles\n'
-             '\n\n')
-    print usage
+    usage = ("""salt-run cephprocesses.check
+                   Checks the process status according to assigned role.
+
+                salt-run cephprocesses.mon
+                   Query monitors to determine if Ceph cluster is active.
+
+                salt-run cephprocesses.wait
+                   Wait for all processes to be up according to assigned roles.
+             """)
+    print(usage)
     return ""
 
 
@@ -91,7 +94,7 @@ def restart_required(role=None, cluster='ceph'):
     restart = local.cmd(role_search,
                         'cephprocesses.restart_required_lsof',
                         ["role={}".format(role)],
-                        expr_form="compound")
+                        tgt_type="compound")
 
     sys.stdout = _stdout
     return restart
@@ -114,7 +117,7 @@ def _status(search, roles, quiet):
                                  'cephprocesses.check',
                                  kwarg={'roles': [role]},
                                  quiet=quiet,
-                                 expr_form="compound")
+                                 tgt_type="compound")
 
     sys.stdout = _stdout
     log.debug(pprint.pformat(status))
@@ -141,7 +144,7 @@ def _cached_roles(search):
                 roles.setdefault(role, []).append(minion)
 
     log.debug(pprint.pformat(roles))
-    return roles.keys()
+    return list(roles.keys())
 
 
 def wait(cluster='ceph', **kwargs):
@@ -164,11 +167,11 @@ def wait(cluster='ceph', **kwargs):
                        'cephprocesses.wait',
                        ['timeout={}'.format(settings['timeout']),
                         'delay={}'.format(settings['delay'])],
-                       expr_form="compound")
+                       tgt_type="compound")
 
     sys.stdout = _stdout
     log.debug("status: {}".format(pprint.pformat(status)))
-    if False in status.values():
+    if False in list(status.values()):
         for minion in status:
             if status[minion] is False:
                 log.error("minion {} failed".format(minion))
@@ -183,8 +186,8 @@ def _timeout(cluster='ceph'):
     """
     local = salt.client.LocalClient()
     search = "I@cluster:{}".format(cluster)
-    virtual = local.cmd(search, 'grains.get', ['virtual'], expr_form="compound")
-    if 'physical' in virtual.values():
+    virtual = local.cmd(search, 'grains.get', ['virtual'], tgt_type="compound")
+    if 'physical' in list(virtual.values()):
         return 900
     else:
         return 120

--- a/srv/modules/runners/changed.py
+++ b/srv/modules/runners/changed.py
@@ -6,6 +6,8 @@ This runner is here to detect config changes in the
 various configuration files to control service restarts.
 """
 
+from __future__ import absolute_import
+from __future__ import print_function
 import os.path
 import hashlib
 import logging
@@ -58,9 +60,9 @@ class Config(object):
         local = salt.client.LocalClient()
         roles = []
         try:
-            roles = local.cmd("I@roles:master", 'pillar.get',
-                              ['rgw_configurations'],
-                              expr_form="compound").values()[0]
+            roles = list(local.cmd("I@roles:master", 'pillar.get',
+                                   ['rgw_configurations'],
+                                   tgt_type="compound").values())[0]
             log.debug("Querying pillar for rgw_configurations")
         # pylint: disable=bare-except
         except:
@@ -88,7 +90,7 @@ class Config(object):
                 log.debug("Checksum: {}".format(md5))
                 checksums += md5
         if checksums:
-            return hashlib.md5(checksums).hexdigest()
+            return hashlib.md5(checksums.encode('ascii')).hexdigest()
         log.debug(("No file found to generate a checksum from. Looked for "
                    "{}".format(self.service_conf_files)))
         if os.path.exists(self.checksum_file):
@@ -151,7 +153,7 @@ def help_():
              'salt-run changed.client:\n\n'
              '    Shortcuts for many services\n'
              '\n\n')
-    print usage
+    print(usage)
     return ""
 
 
@@ -172,7 +174,7 @@ def requires_conf_change(service, cluster='ceph'):
             search = 'I@cluster:{} and I@roles:{}'.format(cluster, service)
             local.cmd(search, 'grains.setval',
                       ["restart_{}".format(service), True],
-                      expr_form="compound")
+                      tgt_type="compound")
             return True
     return False
 

--- a/srv/modules/runners/deepsea_minions.py
+++ b/srv/modules/runners/deepsea_minions.py
@@ -9,9 +9,12 @@ those sites with existing Salt minions that should not be storage hosts, this
 variable can be customized to any Salt target.
 """
 
+from __future__ import absolute_import
+from __future__ import print_function
 import sys
 import os
 import logging
+# pylint: disable=import-error,3rd-party-module-not-gated,redefined-builtin
 import salt.client
 
 log = logging.getLogger(__name__)
@@ -42,7 +45,7 @@ class DeepseaMinions(object):
         # Relying on side effect - pylint: disable=unused-variable
         ret = self.local.cmd('*', 'saltutil.pillar_refresh')
         minions = self.local.cmd('*', 'pillar.get', ['deepsea_minions'],
-                                 expr_form="compound")
+                                 tgt_type="compound")
         sys.stdout = _stdout
         for minion in minions:
             if minions[minion]:
@@ -63,9 +66,9 @@ class DeepseaMinions(object):
             result = self.local.cmd(self.deepsea_minions,
                                     'pillar.get',
                                     ['id'],
-                                    expr_form="compound")
+                                    tgt_type="compound")
             sys.stdout = _stdout
-            return result.keys()
+            return list(result.keys())
         return []
 
 
@@ -79,7 +82,7 @@ def help_():
              'salt-run deepsea_minions.matches:\n\n'
              '    Returns an array of matched minions\n'
              '\n\n')
-    print usage
+    print(usage)
     return ""
 
 

--- a/srv/modules/runners/disengage.py
+++ b/srv/modules/runners/disengage.py
@@ -6,6 +6,8 @@ Some operations are inherently dangerous, but still necessary.  Allow
 the modification timestamp of a file to give a window in which to run.
 """
 
+from __future__ import absolute_import
+from __future__ import print_function
 import os
 import time
 
@@ -29,7 +31,7 @@ def help_():
              'salt-run disengage.check:\n\n'
              '    Check whether the timestamp is less than a minute old\n'
              '\n\n')
-    print usage
+    print(usage)
     return ""
 
 

--- a/srv/modules/runners/filequeue.py
+++ b/srv/modules/runners/filequeue.py
@@ -12,6 +12,8 @@ This runner will rely on file existence, creation and removal.  If a system
 is loaded, operations will block but eventually complete.
 """
 
+from __future__ import absolute_import
+from __future__ import print_function
 import time
 import logging
 import os
@@ -19,6 +21,7 @@ import glob
 
 import salt.loader
 import salt.utils.event
+import salt.ext.six as six
 
 log = logging.getLogger(__name__)
 
@@ -224,7 +227,7 @@ def _skip_dunder(settings):
     """
     Skip double underscore keys
     """
-    return {k: v for k, v in settings.iteritems() if not k.startswith('__')}
+    return {k: v for k, v in six.iteritems(settings) if not k.startswith('__')}
 
 
 def help_():
@@ -298,7 +301,7 @@ def help_():
              '        salt-run filequeue.vacant abc\n'
              '        salt-run filequeue.vacant abc queue=prep\n'
              '        salt-run filequeue.vacant item=abc queue=prep\n')
-    print usage
+    print(usage)
     return ""
 
 
@@ -341,7 +344,7 @@ def dequeue(**kwargs):
     log.debug("dequeue: kwargs = {}".format(_skip_dunder(kwargs)))
     filequeue = FileQueue(**kwargs)
     with Lock(filequeue.settings):
-        oldest = filequeue.items()[0]
+        oldest = list(filequeue.items())[0]
         filequeue.remove(oldest)
     return oldest
 
@@ -353,7 +356,7 @@ def pop(**kwargs):
     log.debug("pop: kwargs = {}".format(_skip_dunder(kwargs)))
     filequeue = FileQueue(**kwargs)
     with Lock(filequeue.settings):
-        newest = filequeue.items()[-1]
+        newest = list(filequeue.items())[-1]
         filequeue.remove(newest)
     return newest
 
@@ -376,7 +379,7 @@ def items(**kwargs):
     log.debug("items: kwargs = {}".format(_skip_dunder(kwargs)))
     filequeue = FileQueue(**kwargs)
     with Lock(filequeue.settings):
-        return "\n".join(filequeue.items())
+        return "\n".join(list(filequeue.items()))
 
 
 def empty(**kwargs):

--- a/srv/modules/runners/minions.py
+++ b/srv/modules/runners/minions.py
@@ -4,8 +4,11 @@
 Small collection of functions intended for all minions.
 """
 
+from __future__ import absolute_import
+from __future__ import print_function
 import time
 import logging
+# pylint: disable=import-error,3rd-party-module-not-gated,redefined-builtin
 import salt.key
 import salt.client
 import salt.utils
@@ -26,7 +29,7 @@ def help_():
              'salt-run minions.message content=message:\n\n'
              '    Logs a warning message\n'
              '\n\n')
-    print usage
+    print(usage)
     return ""
 
 
@@ -58,11 +61,11 @@ def ready(**kwargs):
             if settings['search']:
                 results = client.cmd(settings['search'], 'test.ping',
                                      timeout=__opts__['timeout'],
-                                     expr_form="compound")
+                                     tgt_type="compound")
             else:
                 results = client.cmd('*', 'test.ping', timeout=__opts__['timeout'])
         except SaltClientError as client_error:
-            print client_error
+            print(client_error)
             return ret
 
         actual = set(results.keys())
@@ -81,12 +84,12 @@ def ready(**kwargs):
             expected = set(key.list_keys()['minions'])
 
         if actual == expected:
-            log.warn("All minions are ready")
+            log.warning("All minions are ready")
             break
-        log.warn("Waiting on {}".format(",".join(list(expected - actual))))
+        log.warning("Waiting on {}".format(",".join(list(expected - actual))))
         if end_time:
             if end_time < time.time():
-                log.warn("Timeout reached")
+                log.warning("Timeout reached")
                 if settings['exception']:
                     msg = ("Timeout reached. "
                            "{} seems to be down.").format(",".join(list(expected - actual)))
@@ -101,7 +104,7 @@ def message(**kwargs):
     """
     Pass along a message
     """
-    log.warn("{}".format(kwargs['content']))
+    log.warning("{}".format(kwargs['content']))
     return ""
 
 __func_alias__ = {

--- a/srv/modules/runners/orderednodes.py
+++ b/srv/modules/runners/orderednodes.py
@@ -5,8 +5,11 @@
 Utilities that return preferred orders of minions
 """
 
+from __future__ import absolute_import
+from __future__ import print_function
 import sys
 import os
+# pylint: disable=import-error,3rd-party-module-not-gated,redefined-builtin
 import salt.client
 
 
@@ -19,7 +22,7 @@ def help_():
              'salt-run orderednodes.unique cluster=ceph:\n\n'
              '    Returns an array of sorted minions according to role\n'
              '\n\n')
-    print usage
+    print(usage)
     return ""
 
 
@@ -62,8 +65,8 @@ def unique(cluster='ceph', exclude=[]):
     roles = [role for role in roles if role not in exclude]
     for role in roles:
         nodes = client.cmd("I@roles:{} and {}".format(role, cluster_assignment),
-                           'pillar.get', ['roles'], expr_form="compound")
-        all_clients += nodes.keys()
+                           'pillar.get', ['roles'], tgt_type="compound")
+        all_clients += list(nodes.keys())
 
     sys.stdout = _stdout
     return _preserve_order_sorted(all_clients)

--- a/srv/modules/runners/proposal.py
+++ b/srv/modules/runners/proposal.py
@@ -4,12 +4,14 @@
 Generates the hardware profiles for a minion
 """
 from __future__ import absolute_import
+from __future__ import print_function
 import pprint
 from os.path import isdir, isfile
 import os
 # pylint: disable=redefined-builtin
 from sys import exit
 import logging
+# pylint: disable=import-error,3rd-party-module-not-gated,redefined-builtin
 import salt.client
 import yaml
 # pylint: disable=import-error
@@ -124,8 +126,8 @@ def _parse_args(kwargs):
               ' another name'))
         exit(-1)
     if args.get('encryption') != '' and args.get('encryption') != 'dmcrypt':
-        print(('ERROR: encryption{} is not supported. Currently only '
-               '"dmcrypt" is supported.').format(args.get('encryption')))
+        print((('ERROR: encryption{} is not supported. Currently only '
+               '"dmcrypt" is supported.').format(args.get('encryption'))))
         exit(-1)
 
     return args
@@ -137,13 +139,13 @@ def _propose(node, proposal, args):
     """
     profile = {}
     for device in proposal:
-        key, value = device.items()[0]
+        key, value = list(device.items())[0]
         dev_par = {}
         format_ = args.get('format')
         if isinstance(value, dict):
             assert format_ == 'bluestore'
             # pylint: disable=invalid-name
-            db, wal = value.items()[0]
+            db, wal = list(value.items())[0]
             dev_par['wal'] = wal
             dev_par['db'] = db
             dev_par['wal_size'] = args.get('wal-size')
@@ -187,7 +189,7 @@ def help_():
     """
     Usage
     """
-    print USAGE
+    print(USAGE)
 
 
 def test(**kwargs):
@@ -199,7 +201,7 @@ def test(**kwargs):
     local_client = salt.client.LocalClient()
 
     proposals = local_client.cmd(args['target'], 'proposal.test',
-                                 expr_form='compound', kwarg=args)
+                                 tgt_type='compound', kwarg=args)
 
     # determine which proposal to choose
     for node, proposal in proposals.items():
@@ -217,7 +219,7 @@ def peek(**kwargs):
     local_client = salt.client.LocalClient()
 
     proposals = local_client.cmd(args['target'], 'proposal.generate',
-                                 expr_form='compound', kwarg=args)
+                                 tgt_type='compound', kwarg=args)
 
     # determine which proposal to choose
     for node, proposal in proposals.items():
@@ -230,7 +232,7 @@ def _write_proposal(prop, profile_dir):
     """
     Save the proposal for a specific minion
     """
-    node, proposal = prop.items()[0]
+    node, proposal = list(prop.items())[0]
 
     # write out roles
     role_file = '{}/cluster/{}.sls'.format(profile_dir, node)
@@ -244,7 +246,7 @@ def _write_proposal(prop, profile_dir):
     profile_file = '{}/stack/default/ceph/minions/{}.yml'.format(profile_dir,
                                                                  node)
     if isfile(profile_file):
-        log.warn('not overwriting existing proposal {}'.format(node))
+        log.warning('not overwriting existing proposal {}'.format(node))
         return
 
     # write storage profile
@@ -291,7 +293,7 @@ def populate(**kwargs):
     local_client = salt.client.LocalClient()
 
     proposals = local_client.cmd(args['target'], 'proposal.generate',
-                                 expr_form='compound', kwarg=args)
+                                 tgt_type='compound', kwarg=args)
 
     # check if profile of 'name' exists
     profile_dir = '{}/profile-{}'.format(BASE_DIR, args['name'])

--- a/srv/modules/runners/push.py
+++ b/srv/modules/runners/push.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=modernize-parse-error,anomalous-backslash-in-string
+
 """
 This runner is the complement to the populate.proposals runner.
 
@@ -46,18 +47,22 @@ All files are overwritten in the destination tree /srv/pillar/ceph/stack/default
 
 """
 
+from __future__ import absolute_import
+from __future__ import print_function
 import os
 import errno
 import glob
 import logging
-import imp
 import re
 import shutil
+import sys
 import yaml
+sys.path.append('/srv/modules/pillar')
+# pylint: disable=import-error,3rd-party-module-not-gated,redefined-builtin,wrong-import-position
+from stack import _merge_dict
+import salt.ext.six as six
 
-CUR_FILE_PATH = os.path.dirname(os.path.realpath(__file__))
-STACK_PATH = os.path.abspath('{}/../pillar/stack.py'.format(CUR_FILE_PATH))
-STACK = imp.load_source('pillar.stack', STACK_PATH)
+
 log = logging.getLogger(__name__)
 
 
@@ -71,7 +76,7 @@ def help_():
              'salt-run push.convert:\n\n'
              '    Converts the hardware profiles from filestore to bluestore\n'
              '\n\n')
-    print usage
+    print(usage)
     return ""
 
 
@@ -295,7 +300,7 @@ def _migrate(yml, filename):
         for osd in yml['storage']['osds']:
             yml['ceph']['storage']['osds'][osd] = {'format': 'bluestore'}
         for entry in yml['storage']['data+journals']:
-            for osd, journal in entry.iteritems():
+            for osd, journal in six.iteritems(entry):
                 yml['ceph']['storage']['osds'][osd] = {'format': 'bluestore',
                                                        'wal': journal,
                                                        'db': journal}
@@ -360,7 +365,7 @@ def _merge(pathname, common):
         with open(filename, "r") as content:
             content = yaml.safe_load(content)
             # pylint: disable=protected-access
-            merged = STACK._merge_dict(merged, content)
+            merged = _merge_dict(merged, content)
     return merged
 
 

--- a/srv/modules/runners/ready.py
+++ b/srv/modules/runners/ready.py
@@ -7,8 +7,11 @@ a warning is more appropriate.
 
 """
 
+from __future__ import absolute_import
+from __future__ import print_function
 import logging
 from collections import OrderedDict
+# pylint: disable=import-error,3rd-party-module-not-gated,redefined-builtin
 import salt.client
 import salt.utils.error
 
@@ -52,7 +55,7 @@ class Checks(object):
         """
         contents = self.local.cmd(self.search, 'cmd.shell',
                                   ['/usr/sbin/iptables -S'],
-                                  expr_form="compound")
+                                  tgt_type="compound")
         for minion in contents:
             # Accept custom named chains
             if not contents[minion].startswith(("-P INPUT ACCEPT\n"
@@ -73,7 +76,7 @@ class Checks(object):
         contents = self.local.cmd(self.search, 'cmd.shell',
                                   [('/usr/sbin/apparmor_status --enabled '
                                     '2>/dev/null; echo $?')],
-                                  expr_form="compound")
+                                  tgt_type="compound")
         for minion in contents:
             if contents[minion] and int(contents[minion]) == 0:
                 msg = "enabled on minion {}".format(minion)
@@ -89,11 +92,11 @@ class Checks(object):
         Produce nicely colored output
         """
         for attr in self.passed.keys():
-            print "{:25}: {}{}{}{}".format(attr, Bcolors.BOLD, Bcolors.OKGREEN,
-                                           self.passed[attr], Bcolors.ENDC)
+            print("{:25}: {}{}{}{}".format(attr, Bcolors.BOLD, Bcolors.OKGREEN,
+                                           self.passed[attr], Bcolors.ENDC))
         for attr in self.warnings.keys():
-            print "{:25}: {}{}{}{}".format(attr, Bcolors.BOLD, Bcolors.WARNING,
-                                           self.warnings[attr], Bcolors.ENDC)
+            print("{:25}: {}{}{}{}".format(attr, Bcolors.BOLD, Bcolors.WARNING,
+                                           self.warnings[attr], Bcolors.ENDC))
 
 
 def help_():
@@ -105,7 +108,7 @@ def help_():
              'salt-run ready.check fail_on_warning=False:\n\n'
              '    Check for firewall and apparmor configurations\n'
              '\n\n')
-    print usage
+    print(usage)
     return ""
 
 

--- a/srv/modules/runners/remove.py
+++ b/srv/modules/runners/remove.py
@@ -4,7 +4,10 @@
 Runner to remove a single osd
 """
 
+from __future__ import absolute_import
+from __future__ import print_function
 import logging
+# pylint: disable=import-error,3rd-party-module-not-gated,redefined-builtin
 import salt.client
 import salt.runner
 
@@ -18,7 +21,7 @@ def help_():
     usage = ('salt-run remove.osd id:\n\n'
              '    Removes an OSD\n'
              '\n\n')
-    print usage
+    print(usage)
     return ""
 
 
@@ -41,7 +44,7 @@ def osd(id_, drain=False):
 
     local_cli = salt.client.LocalClient()
 
-    osds = local_cli.cmd('I@roles:storage', 'osd.list', expr_form='compound')
+    osds = local_cli.cmd('I@roles:storage', 'osd.list', tgt_type='compound')
 
     host = ''
     for _osd in osds:
@@ -52,9 +55,9 @@ def osd(id_, drain=False):
         log.error('No OSD with ID {} found...giving up'.format(id_))
         return False
 
-    master_minion = local_cli.cmd('I@roles:master', 'pillar.get',
-                                  ['master_minion'],
-                                  expr_form='compound').items()[0][1]
+    master_minion = list(local_cli.cmd('I@roles:master', 'pillar.get',
+                                       ['master_minion'],
+                                       tgt_type='compound').items())[0][1]
 
     if drain:
         log.info('Draining OSD {} now'.format(id_))

--- a/srv/modules/runners/rescinded.py
+++ b/srv/modules/runners/rescinded.py
@@ -8,7 +8,10 @@
 The collection of functions for OSDs that are no longer present.
 """
 
+from __future__ import absolute_import
+from __future__ import print_function
 import logging
+# pylint: disable=import-error,3rd-party-module-not-gated,redefined-builtin
 import salt.client
 
 log = logging.getLogger(__name__)
@@ -24,7 +27,7 @@ def help_():
              'salt-run rescinded.osds:\n\n'
              '    Returns the list of OSDs for minions that are no longer mounted\n'
              '\n\n')
-    print usage
+    print(usage)
     return ""
 
 
@@ -38,13 +41,13 @@ def ids(cluster, **kwargs):
     # Restrict search to this cluster
     search = "I@cluster:{}".format(cluster)
 
-    pillar_data = local.cmd(search, 'pillar.items', [], expr_form="compound")
+    pillar_data = local.cmd(search, 'pillar.items', [], tgt_type="compound")
     _ids = []
     for minion in pillar_data:
         if ('roles' in pillar_data[minion] and
             'storage' in pillar_data[minion]['roles']):
             continue
-        data = local.cmd(minion, 'osd.list', [], expr_form="glob")
+        data = local.cmd(minion, 'osd.list', [], tgt_type="glob")
         _ids.extend(data[minion])
     return _ids
 
@@ -56,7 +59,7 @@ def osds(cluster='ceph'):
     search = "I@cluster:{} and I@roles:storage".format(cluster)
 
     local = salt.client.LocalClient()
-    data = local.cmd(search, 'osd.rescinded', [], expr_form="compound")
+    data = local.cmd(search, 'osd.rescinded', [], tgt_type="compound")
     _ids = []
     for minion in data:
         if isinstance(data[minion], list):

--- a/srv/modules/runners/select.py
+++ b/srv/modules/runners/select.py
@@ -4,10 +4,13 @@
 The list of minions related to a Salt target is often needed for operations.
 """
 
+from __future__ import absolute_import
+from __future__ import print_function
 import logging
 import os
 import sys
 import re
+# pylint: disable=import-error,3rd-party-module-not-gated,redefined-builtin
 import salt.client
 
 log = logging.getLogger(__name__)
@@ -37,7 +40,7 @@ def help_():
              '    Returns an array of grain values that matches the pillar variable.\n'
              '    Defaults to role if variable is not found.\n'
              '\n\n')
-    print usage
+    print(usage)
     return ""
 
 
@@ -45,7 +48,7 @@ def _grain_host(client, minion):
     """
     Return the host grain for a given minion, for use a short hostname
     """
-    return client.cmd(minion, 'grains.item', ['host']).values()[0]['host']
+    return list(client.cmd(minion, 'grains.item', ['host']).values())[0]['host']
 
 
 def minions(host=False, **kwargs):
@@ -69,13 +72,13 @@ def minions(host=False, **kwargs):
     sys.stdout = open(os.devnull, 'w')
 
     local = salt.client.LocalClient()
-    _minions = local.cmd(search, 'pillar.get', ['id'], expr_form="compound")
+    _minions = local.cmd(search, 'pillar.get', ['id'], tgt_type="compound")
 
     sys.stdout = _stdout
 
     if host:
         return [_grain_host(local, k) for k in _minions.keys()]
-    return _minions.keys()
+    return list(_minions.keys())
 
 
 def one_minion(**kwargs):
@@ -108,7 +111,7 @@ def public_addresses(tuples=False, host=False, **kwargs):
     sys.stdout = open(os.devnull, 'w')
 
     local = salt.client.LocalClient()
-    result = local.cmd(search, 'public.address', [], expr_form="compound")
+    result = local.cmd(search, 'public.address', [], tgt_type="compound")
 
     sys.stdout = _stdout
 
@@ -145,7 +148,7 @@ def attr(host=False, **kwargs):
     sys.stdout = open(os.devnull, 'w')
 
     local = salt.client.LocalClient()
-    _minions = local.cmd(search, 'pillar.get', [attribute], expr_form="compound")
+    _minions = local.cmd(search, 'pillar.get', [attribute], tgt_type="compound")
 
     sys.stdout = _stdout
 
@@ -177,7 +180,7 @@ def from_(pillar, role, *args, **kwargs):
     local = salt.client.LocalClient()
     search = "I@roles:master"
     try:
-        roles = local.cmd(search, 'pillar.get', [pillar], expr_form="compound").values()[0]
+        roles = list(local.cmd(search, 'pillar.get', [pillar], tgt_type="compound").values())[0]
     # pylint: disable=bare-except
     except:
         roles = []
@@ -194,7 +197,7 @@ def from_(pillar, role, *args, **kwargs):
     for _role in roles:
         minion_list = minions(roles=_role)
         for minion in minion_list:
-            grains_result = local.cmd(minion, 'grains.item', list(args)).values()[0]
+            grains_result = list(local.cmd(minion, 'grains.item', list(args)).values())[0]
             small = [_role]
             for arg in list(args):
                 small.append(grains_result[arg])

--- a/srv/modules/runners/sharedsecret.py
+++ b/srv/modules/runners/sharedsecret.py
@@ -3,6 +3,8 @@
 """
 Display the sharedsecret for the Salt API
 """
+from __future__ import absolute_import
+from __future__ import print_function
 import os
 
 
@@ -13,7 +15,7 @@ def help_():
     usage = ('salt-run sharedsecret.show:\n\n'
              '    Shows the shared secret for the Salt API\n'
              '\n\n')
-    print usage
+    print(usage)
     return ""
 
 

--- a/srv/modules/runners/ui_ganesha.py
+++ b/srv/modules/runners/ui_ganesha.py
@@ -14,10 +14,13 @@ exports.
 """
 
 from __future__ import absolute_import
+from __future__ import print_function
 import json
 import os
-import salt.client
 import yaml
+# pylint: disable=import-error,3rd-party-module-not-gated,redefined-builtin
+from salt.ext.six.moves import range
+import salt.client
 
 
 class GaneshaConfParser(object):
@@ -269,7 +272,7 @@ class Ganesha(object):
         Wrapper for Salt module since multiple values may be returned
         """
         target = "I@roles:{}".format(role) if not minion else role
-        result = local_client.cmd(target, fun, args, expr_form="compound")
+        result = local_client.cmd(target, fun, args, tgt_type="compound")
         if minion:
             return result[role]
         return [val for _, val in result.items()] if only_vals else result
@@ -399,7 +402,7 @@ class Ganesha(object):
                                 Dumper=friendly_dumper,
                                 default_flow_style=False))
         # refresh pillar
-        local_client.cmd("I@roles:master", 'saltutils.pillar_refresh', [''], expr_form="compound")
+        local_client.cmd("I@roles:master", 'saltutils.pillar_refresh', [''], tgt_type="compound")
 
     @staticmethod
     def save_exports(exports):
@@ -519,7 +522,7 @@ def help_():
              'salt-run ui_ganesha.stop_exports:\n\n'
              '    Stops the ganesha service for each minion\n'
              '\n\n')
-    print usage
+    print(usage)
     return ""
 
 

--- a/srv/modules/runners/ui_iscsi.py
+++ b/srv/modules/runners/ui_iscsi.py
@@ -15,12 +15,15 @@ Guiding ideas:
   modules with Salt mines.
 """
 
+from __future__ import absolute_import
+from __future__ import print_function
 import logging
 import sys
 import os
 import json
 import urllib
 import yaml
+# pylint: disable=import-error,3rd-party-module-not-gated,redefined-builtin
 import salt.client
 import salt.utils.minions
 
@@ -61,7 +64,7 @@ class Iscsi(object):
         _stdout = sys.stdout
         sys.stdout = open(os.devnull, 'w')
 
-        igws = self.local.cmd("I@roles:igw", 'grains.get', ['ipv4'], expr_form="compound")
+        igws = self.local.cmd("I@roles:igw", 'grains.get', ['ipv4'], tgt_type="compound")
         sys.stdout = _stdout
         if wrapped:
             data = []
@@ -130,6 +133,7 @@ class Iscsi(object):
             # (ie. where the frontend is hosted on a different server than
             # salt-api) useless.
             if 'contenttype' in kwargs and not kwargs['contenttype']:
+                # pylint: disable=no-member
                 contents = urllib.unquote(kwargs['data'])
             else:
                 contents = kwargs['data']
@@ -160,7 +164,7 @@ class Iscsi(object):
                                 Dumper=self.friendly_dumper,
                                 default_flow_style=False))
         # refresh pillar
-        self.local.cmd("I@roles:master", 'saltutils.pillar_refresh', [''], expr_form="compound")
+        self.local.cmd("I@roles:master", 'saltutils.pillar_refresh', [''], tgt_type="compound")
 
     def canned_populate(self, canned):
         """
@@ -241,7 +245,7 @@ def help_():
              'salt-run ui_iscsi.undeploy:\n\n'
              '    Stops lrbd\n'
              '\n\n')
-    print usage
+    print(usage)
     return ""
 
 
@@ -296,8 +300,8 @@ def status(**kwargs):
     Check the systemd status of lrbd
     """
     local = salt.client.LocalClient()
-    _status = local.cmd('I@roles:igw', 'service.status', ['lrbd'], expr_form='compound')
-    _targets = local.cmd('I@roles:igw', 'iscsi.targets', [], expr_form='compound')
+    _status = local.cmd('I@roles:igw', 'service.status', ['lrbd'], tgt_type='compound')
+    _targets = local.cmd('I@roles:igw', 'iscsi.targets', [], tgt_type='compound')
     result = {}
     for minion in _status:
         result[minion] = {
@@ -366,7 +370,7 @@ def _deploy_in_minions(minions):
         target = 'L@{}'.format(','.join(minions))
     else:
         target = 'I@roles:igw'
-    state_res = local.cmd(target, 'state.apply', ['ceph.igw'], expr_form="compound")
+    state_res = local.cmd(target, 'state.apply', ['ceph.igw'], tgt_type="compound")
     for minion, states in state_res.items():
         result['minions'][minion] = _check_state_result(states)
         if not result['minions'][minion]:
@@ -403,7 +407,7 @@ def undeploy(**kwargs):
         target = 'L@{}'.format(','.join(minions))
     else:
         target = 'I@roles:igw'
-    results = local.cmd(target, 'service.stop', ['lrbd'], expr_form='compound')
+    results = local.cmd(target, 'service.stop', ['lrbd'], tgt_type='compound')
     return results
 
 

--- a/srv/modules/runners/ui_rgw.py
+++ b/srv/modules/runners/ui_rgw.py
@@ -11,10 +11,12 @@ is getting the credentials for an administrative user which is implemented
 here.
 """
 from __future__ import absolute_import
+from __future__ import print_function
 import logging
 import os
 import json
 import glob
+# pylint: disable=import-error,3rd-party-module-not-gated,redefined-builtin
 import salt.client
 import salt.utils.minions
 
@@ -118,7 +120,7 @@ def help_():
              'salt-run ui_rgw.token data:\n\n'
              '    Returns radosgw-token result from supplied data\n'
              '\n\n')
-    print usage
+    print(usage)
     return ""
 
 
@@ -161,7 +163,7 @@ def token(**kwargs):
                        ['radosgw-token --encode --ttype={} --access={} --secret={}'.format(ttype,
                                                                                            access,
                                                                                            secret)],
-                       expr_form="compound")
+                       tgt_type="compound")
     return _token
 
 __func_alias__ = {

--- a/srv/modules/runners/upgrade.py
+++ b/srv/modules/runners/upgrade.py
@@ -3,6 +3,9 @@
 """
 Verify that an automated upgrade is possible
 """
+from __future__ import absolute_import
+from __future__ import print_function
+# pylint: disable=import-error,3rd-party-module-not-gated,redefined-builtin
 import salt.client
 import salt.utils.error
 
@@ -31,7 +34,7 @@ class UpgradeValidation(object):
         Check for shared monitor and storage roles
         """
         search = "I@cluster:{}".format(self.cluster)
-        pillar_data = self.local.cmd(search, 'pillar.items', [], expr_form="compound")
+        pillar_data = self.local.cmd(search, 'pillar.items', [], tgt_type="compound")
         for host in pillar_data:
             if 'roles' in pillar_data[host]:
                 if ('storage' in pillar_data[host]['roles']
@@ -50,7 +53,7 @@ class UpgradeValidation(object):
         Check for shared master and storage role
         """
         search = "I@roles:master"
-        pillar_data = self.local.cmd(search, 'pillar.items', [], expr_form="compound")
+        pillar_data = self.local.cmd(search, 'pillar.items', [], tgt_type="compound")
         # in case of multimaster
         for host in pillar_data:
             if 'roles'in pillar_data[host]:
@@ -72,7 +75,7 @@ def help_():
     usage = ('salt-run upgrade.check:\n\n'
              '    Performs a series of checks to verify that upgrades are possible\n'
              '\n\n')
-    print usage
+    print(usage)
     return ""
 
 
@@ -85,7 +88,7 @@ def check():
     for chk in checks:
         ret, msg = chk()
         if not ret:
-            print msg
+            print(msg)
             return ret
     return ret
 

--- a/srv/salt/_modules/advise.py
+++ b/srv/salt/_modules/advise.py
@@ -22,7 +22,7 @@ def reboot(running, installed):
     log.info(message)
 
     proc = Popen(["/usr/bin/wall"], stdin=PIPE, stdout=PIPE, stderr=PIPE)
-    proc.communicate(input=message)
+    proc.communicate(input=message.encode('ascii'))
 
     return True
 

--- a/srv/salt/_modules/cephimages.py
+++ b/srv/salt/_modules/cephimages.py
@@ -5,6 +5,8 @@ List the rbd images
 
 from __future__ import absolute_import
 from subprocess import Popen, PIPE
+# pylint: disable=import-error
+from helper import _convert_out
 
 
 def list_():
@@ -14,10 +16,12 @@ def list_():
     images = {}
     proc = Popen(['rados', 'lspools'], stdout=PIPE, stderr=PIPE)
     for line in proc.stdout:
+        line = _convert_out(line)
         pool = line.rstrip('\n')
         cmd = ['/usr/bin/rbd', '-p', pool, 'ls']
         rbd_proc = Popen(cmd, stdout=PIPE, stderr=PIPE)
         for rbd_line in rbd_proc.stdout:
+            rbd_line = _convert_out(rbd_line)
             if pool not in images:
                 images[pool] = []
             images[pool].append(rbd_line.rstrip('\n'))

--- a/srv/salt/_modules/cephprocesses.py
+++ b/srv/salt/_modules/cephprocesses.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+
 """
 Operations for Ceph processes to roles
 """
@@ -12,6 +13,7 @@ import shlex
 # pylint: disable=import-error,3rd-party-module-not-gated
 from subprocess import Popen, PIPE
 import psutil
+from helper import _convert_out
 
 log = logging.getLogger(__name__)
 
@@ -140,7 +142,7 @@ def down(**kwargs):
     Based on check(), return True/False if all Ceph processes that are meant
     to be running on a node are down.
     """
-    return True if not check(True, True)['up'].values() else False
+    return True if not list(check(True, True)['up'].values()) else False
 
 
 def wait(**kwargs):
@@ -180,6 +182,7 @@ def _process_map():
                   stdin=proc1.stdout, stdout=PIPE, stderr=PIPE)
     proc1.stdout.close()
     stdout, _ = proc2.communicate()
+    stdout = _convert_out(stdout)
     for proc_l in stdout.split('\n'):
         proc = proc_l.split(' ')
         proc_info = {}
@@ -203,6 +206,7 @@ def zypper_ps(role, lsof_map):
     assert role
     proc1 = Popen(shlex.split('zypper ps -sss'), stdout=PIPE)
     stdout, _ = proc1.communicate()
+    stdout = _convert_out(stdout)
     processes_ = processes
     # adding instead of overwriting, eh?
     # radosgw is ceph-radosgw in zypper ps.
@@ -257,5 +261,4 @@ def _timeout():
     """
     if __grains__['virtual'] == 'physical':
         return 900
-    else:
-        return 120
+    return 120

--- a/srv/salt/_modules/deepsea.py
+++ b/srv/salt/_modules/deepsea.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=C0111
+# pylint: disable=import-error,3rd-party-module-not-gated,redefined-builtin
 
 from __future__ import absolute_import
 
@@ -60,8 +61,7 @@ def _render_state(state_name):
     except TypeError:
         if state_name.endswith('.init'):
             return None  # sls file does not exist
-        else:
-            return _render_state("{}.init".format(state_name))
+        return _render_state("{}.init".format(state_name))
     result = __salt__['slsutil.renderer']('/tmp/dest.sls')
 
     nresult = OrderedDict()
@@ -93,8 +93,7 @@ def render_sls(state_arg):
             content = _serialize_ordered_dict(content)
             result[state_name] = content
         return result
-    else:
-        return None
+    return None
 
 
 def user():
@@ -103,8 +102,7 @@ def user():
     """
     if __grains__.get('os_family', '') == 'Suse':
         return 'salt'
-    else:
-        return 'root'
+    return 'root'
 
 
 def group():
@@ -113,5 +111,4 @@ def group():
     """
     if __grains__.get('os_family', '') == 'Suse':
         return 'salt'
-    else:
-        return 'root'
+    return 'root'

--- a/srv/salt/_modules/fs.py
+++ b/srv/salt/_modules/fs.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=fixme
+
 """
 ------------------------------------------------------------------------------
 fs.py
@@ -14,36 +15,13 @@ import logging
 import os
 import tempfile
 import shutil
-import pprint
 import uuid
 import time
-from subprocess import Popen, PIPE
 # pylint: disable=import-error,3rd-party-module-not-gated
 import psutil
+from helper import _run
 
 log = logging.getLogger(__name__)
-
-# ------------------------------------------------------------------------------
-# Utility functions.
-# ------------------------------------------------------------------------------
-
-
-def _run(cmd):
-    """
-    NOTE: Taken from osd.py module.
-    """
-    log.info(cmd)
-    proc = Popen(cmd, stdout=PIPE, stderr=PIPE, shell=True)
-    proc.wait()
-    _stdout = proc.stdout.read().rstrip()
-    _stderr = proc.stdout.read().rstrip()
-    log.debug("return code: {}".format(proc.returncode))
-    log.debug(_stdout)
-    log.debug(_stderr)
-    log.debug(pprint.pformat(proc.stdout.read()))
-    log.debug(pprint.pformat(proc.stderr.read()))
-    # return proc.returncode, _stdout, _stderr
-    return proc.returncode, _stdout, _stderr
 
 
 def _systemctl_cmd_target(cmd, target):
@@ -135,7 +113,7 @@ def _ceph_is_down():
     omit_list = ['httpd-prefork', 'ganesha.nfsd', 'rpcbind', 'rpc.statd']
 
     while retries and not down:
-        running_procs = __salt__['cephprocesses.check'](results=True, quiet=True)['up'].keys()
+        running_procs = list(__salt__['cephprocesses.check'](results=True, quiet=True)['up'].keys())
         if not running_procs:
             down = True
         else:
@@ -636,7 +614,7 @@ def _chattr(op, path, attrs, rec, omit):
     omit = omit.split(',') if omit else []
 
     # Verify op.
-    if op not in supported_ops.keys():
+    if op not in list(supported_ops.keys()):
         log.error(("Unable to manipulate attrs for '{}': unsuppurted chattr op:"
                    "{}.".format(path, op)))
         rets[path] = False

--- a/srv/salt/_modules/ganesha.py
+++ b/srv/salt/_modules/ganesha.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+
 """
 Ganesha configuration and exports
 """
@@ -6,6 +7,7 @@ Ganesha configuration and exports
 from __future__ import absolute_import
 
 import logging
+# pylint: disable=import-error,3rd-party-module-not-gated,redefined-builtin
 from salt import client as SaltClient
 
 try:

--- a/srv/salt/_modules/helper.py
+++ b/srv/salt/_modules/helper.py
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -*-
+"""
+Helper module to reuse Popen and byte->str casting
+"""
+
+# pylint: disable=incompatible-py3-code
+import pprint
+
+import logging
+from subprocess import Popen, PIPE
+
+log = logging.getLogger(__name__)
+
+
+def _convert_out(out):
+    """
+    Since python3 most system calls return type(byte)
+    instead of type(str). We mostly use the output of
+    those subprocess calls to make a decisions, which
+    requires to manipulate and compare it.
+    """
+    if isinstance(out, bytes):
+        return out.decode('ascii')
+    elif isinstance(out, str):
+        return out
+    elif isinstance(out, int):
+        return out
+    elif isinstance(out, float):
+        return out
+    else:
+        raise Exception("""Could not detect the type of {output}. Got {type_out}""".
+                        format(output=out, type_out=type(out)))
+
+
+def _run(cmd, shell=False):
+    """
+    Generic function for running shell commands
+
+    shell=False vs shell=True
+    https://docs.python.org/2/library/subprocess.html#frequently-used-arguments
+    We have some places in the code where we'd have to split the cmd's manually
+    instead of relying on shlex.split or similar helpers.
+    For now I'll place a destinction between pre-split commands that are processed
+    on a per item level and entire strings that will be execcuted without extra
+    pre-escaping and security measurements.
+    """
+    if isinstance(cmd, str):
+        shell = True
+
+    log.info("executing: {cmd}".format(cmd=cmd))
+    proc = Popen(cmd, stdout=PIPE, stderr=PIPE, shell=shell)
+    _stdout = _convert_out(proc.stdout.read())
+    _stdout = _stdout.rstrip()
+
+    _stderr = _convert_out(proc.stdout.read())
+    _stderr = _stderr.rstrip()
+
+    _retcode = proc.wait()
+    log.debug("returncode of {cmd}: {rc}".format(cmd=cmd, rc=_retcode))
+
+    log.debug("""stdout of {cmd}:
+{out}""".format(cmd=cmd, out=pprint.pformat(_stdout)))
+    log.debug("""stderr of {cmd}:
+{out}""".format(cmd=cmd, out=pprint.pformat(_stderr)))
+    return _retcode, _stdout, _stderr

--- a/srv/salt/_modules/iscsi.py
+++ b/srv/salt/_modules/iscsi.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+
 """
 iSCSI execution module
 

--- a/srv/salt/_modules/keyring.py
+++ b/srv/salt/_modules/keyring.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+
 """
 Keyring collection of operations
 """
@@ -8,6 +9,8 @@ import os
 import struct
 import base64
 import time
+# pylint: disable=import-error,3rd-party-module-not-gated,redefined-builtin
+from helper import _convert_out
 
 
 def secret(filename):
@@ -34,7 +37,8 @@ def gen_secret():
     """
     key = os.urandom(16)
     header = struct.pack('<hiih', 1, int(time.time()), 0, len(key))
-    return base64.b64encode(header + key)
+    keyring = base64.b64encode(header + key)
+    return _convert_out(keyring)
 
 
 # pylint: disable=too-many-return-statements

--- a/srv/salt/_modules/mon.py
+++ b/srv/salt/_modules/mon.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+
 """
 The need for this module is that the roles show the intended state and not
 the current state.  Once the admin unassigns the monitor role, the pillar
@@ -9,6 +10,7 @@ from __future__ import absolute_import
 import json
 import logging
 # pylint: disable=import-error,3rd-party-module-not-gated
+import salt.ext.six as six
 import rados
 # pylint: disable=incompatible-py3-code
 log = logging.getLogger(__name__)
@@ -73,7 +75,7 @@ def _skip_dunder(settings):
     """
     Skip double underscore keys
     """
-    return {k: v for k, v in settings.iteritems() if not k.startswith('__')}
+    return {k: v for k, v in six.iteritems(settings) if not k.startswith('__')}
 
 __func_alias__ = {
                  'list_': 'list',

--- a/srv/salt/_modules/openattic.py
+++ b/srv/salt/_modules/openattic.py
@@ -1,16 +1,27 @@
 # -*- coding: utf-8 -*-
+
 """
 OpenATTIC configuration operations
 """
 
 from __future__ import absolute_import
 import os
+import logging
 from shutil import copyfile
 # pylint: disable=import-error,3rd-party-module-not-gated
 import configobj
-import salt.utils
 
-from salt.exceptions import CommandExecutionError
+log = logging.getLogger(__name__)
+
+try:
+    import salt.utils
+except ImportError:
+    logging.error("Could not import salt.util")
+
+try:
+    from salt.exceptions import CommandExecutionError
+except ImportError:
+    logging.error("Could not import salt.util")
 
 
 def _write_config_file(config_file, config):

--- a/srv/salt/_modules/proposal.py
+++ b/srv/salt/_modules/proposal.py
@@ -1,12 +1,14 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=fixme
+
 """
 Generates hardware profiles for Ceph storage nodes
 """
 
 from __future__ import absolute_import
-# pylint: disable=import-error
+# pylint: disable=import-error, redefined-builtin,3rd-party-module-not-gated
 import logging
+from salt.ext.six.moves import range
 import cephdisks
 # pylint: disable=incompatible-py3-code
 log = logging.getLogger(__name__)
@@ -32,13 +34,13 @@ class Proposal(object):
         self._parse_args(kwargs)
         # we differentiate 3 kinds of drives for now
         self.nvme = [disk for disk in disks if disk['Driver'] ==
-                     self.NVME_DRIVER and disk['rotational'] is '0']
+                     self.NVME_DRIVER and disk['rotational'] == '0']
         self.ssd = [disk for disk in disks if disk['Driver'] !=
-                    self.NVME_DRIVER and disk['rotational'] is '0']
-        self.spinner = [disk for disk in disks if disk['rotational'] is '1']
-        log.warn(self.nvme)
-        log.warn(self.ssd)
-        log.warn(self.spinner)
+                    self.NVME_DRIVER and disk['rotational'] == '0']
+        self.spinner = [disk for disk in disks if disk['rotational'] == '1']
+        log.warning(self.nvme)
+        log.warning(self.ssd)
+        log.warning(self.spinner)
 
     def _parse_args(self, kwargs):
         """
@@ -98,7 +100,7 @@ class Proposal(object):
 
         # uncertain how hacky this is. This branch is taken if any 2 out of
         # there lists are empty
-        if sum([not self.nvme, not self.ssd, not self.spinner]) is 2:
+        if sum([not self.nvme, not self.ssd, not self.spinner]) == 2:
             log.debug('found only one type of disks...proposing standalone')
             return proposals
 

--- a/srv/salt/_modules/public.py
+++ b/srv/salt/_modules/public.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=visually-indented-line-with-same-indent-as-next-logical-line
+
 """
 Functions related to the public network
 """

--- a/srv/salt/_modules/purge.py
+++ b/srv/salt/_modules/purge.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+
 """
 Cleanup related operations for resetting the Salt environment and removing
 a Ceph cluster

--- a/srv/salt/_modules/retry.py
+++ b/srv/salt/_modules/retry.py
@@ -1,14 +1,20 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=modernize-parse-error
+
 """
 Salt does not provide retry functionality.  (This may become obsolete with
 newer versions of Salt.)
 """
 
+from __future__ import absolute_import
+from __future__ import print_function
 import sys
 from subprocess import Popen, PIPE
 import time
 import logging
+# pylint: disable=import-error,3rd-party-module-not-gated,redefined-builtin
+from salt.ext.six.moves import range
+from helper import _convert_out
 
 
 log = logging.getLogger(__name__)
@@ -30,19 +36,21 @@ def cmd(**kwargs):
         proc = Popen(_cmd, stdout=PIPE, stderr=PIPE, shell=True)
         proc.wait()
         for line in proc.stdout:
-            print line
+            line = _convert_out(line)
+            print(line)
         for line in proc.stderr:
+            line = _convert_out(line)
             sys.stderr.write(line)
         if proc.returncode != 0:
             if attempt < retry:
                 wait_time = sleep * attempt
-                log.warn("Waiting {} seconds to try {} again".format(wait_time, _cmd))
+                log.warning("Waiting {} seconds to try {} again".format(wait_time, _cmd))
                 time.sleep(wait_time)
             continue
         else:
             return
 
-    log.warn("command {} failed {} retries".format(_cmd, retry))
+    log.warning("command {} failed {} retries".format(_cmd, retry))
     raise RuntimeError("cmd {} failed {} retries".format(_cmd, retry))
 
 
@@ -66,17 +74,17 @@ def pkill(**kwargs):
         proc = Popen(_cmd, stdout=PIPE, stderr=PIPE, shell=True)
         proc.wait()
         for line in proc.stdout:
-            print line
+            print(line)
         for line in proc.stderr:
             sys.stderr.write(line)
         if proc.returncode == 0:
             if attempt < retry:
                 wait_time = sleep * attempt
-                log.warn("Waiting {} seconds to try {} again".format(wait_time, _cmd))
+                log.warning("Waiting {} seconds to try {} again".format(wait_time, _cmd))
                 time.sleep(wait_time)
             continue
         else:
             return
 
-    log.warn("command {} failed {} retries".format(_cmd, retry))
+    log.warning("command {} failed {} retries".format(_cmd, retry))
     raise RuntimeError("cmd {} failed {} retries".format(_cmd, retry))

--- a/srv/salt/_modules/wait.py
+++ b/srv/salt/_modules/wait.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+
 """
 Heath related checks for Ceph
 """
@@ -8,6 +9,7 @@ import json
 import time
 import logging
 # pylint: disable=import-error,3rd-party-module-not-gated
+import salt.ext.six as six
 import rados
 # pylint: disable=incompatible-py3-code
 log = logging.getLogger(__name__)
@@ -89,9 +91,8 @@ class HealthCheck(object):
         if settings['negate']:
             log.debug("status != {}".format(settings['status']))
             return current != settings['status']
-        else:
-            log.debug("status == {}".format(settings['status']))
-            return current == settings['status']
+        log.debug("status == {}".format(settings['status']))
+        return current == settings['status']
 
     def just(self):
         """
@@ -129,4 +130,4 @@ def _skip_dunder(settings):
     """
     Skip double underscore keys
     """
-    return {k: v for k, v in settings.iteritems() if not k.startswith('__')}
+    return {k: v for k, v in six.iteritems(settings) if not k.startswith('__')}

--- a/srv/salt/_modules/zypper_locks.py
+++ b/srv/salt/_modules/zypper_locks.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=modernize-parse-error
+
 """
 Normally, this would not be needed.  The logic for detecting zypper locks
 is in the zypper.py module.  However, that module has had other issues
@@ -7,10 +8,14 @@ resulting in stack traces.  The workaround is to specify the zypper command
 directly and this module is then necessary.
 """
 
+from __future__ import absolute_import
+from __future__ import print_function
 import sys
 from subprocess import Popen, PIPE
 import time
 import logging
+# pylint: disable=import-error,3rd-party-module-not-gated,redefined-builtin
+from helper import _convert_out
 
 
 log = logging.getLogger(__name__)
@@ -31,14 +36,16 @@ def ready(**kwargs):
         proc = Popen(cmd, stdout=PIPE, stderr=PIPE, shell=True)
         proc.wait()
         for line in proc.stdout:
-            print line
+            line = _convert_out(line)
+            print(line)
         for line in proc.stderr:
+            line = _convert_out(line)
             sys.stderr.write(line)
         if proc.returncode != 0:
             wait_time = sleep
-            log.warn("Locked - Waiting {} seconds".format(wait_time))
+            log.warning("Locked - Waiting {} seconds".format(wait_time))
             time.sleep(wait_time)
             continue
         else:
-            log.warn("Unlocked")
+            log.warning("Unlocked")
             return

--- a/srv/salt/ceph/packages/common/default.sls
+++ b/srv/salt/ceph/packages/common/default.sls
@@ -8,8 +8,8 @@ stage prep dependencies suse:
       - lsscsi
       - pciutils
       - gptfdisk
-      - python-boto
-      - python-rados
+      - python3-boto
+      - python3-rados
       - iperf
       - lsof
     - fire_event: True
@@ -23,8 +23,8 @@ stage prep dependencies ubuntu:
       - lsscsi
       - pciutils
       - gdisk
-      - python-boto
-      - python-rados
+      - python3-boto
+      - python3-rados
       - iperf
     - fire_event: True
     - refresh: True
@@ -46,12 +46,11 @@ stage prep dependencies CentOS:
       - lsscsi
       - pciutils
       - gdisk
-      - python-boto
-      - python-rados
+      - python3-boto
+      - python3-rados
       - iperf3
       - lshw
       - hwinfo
-      - python-ipaddress
       - python-netaddr
     - fire_event: True
     - refresh: True

--- a/srv/salt/ceph/rescind/rgw/monitoring/default.sls
+++ b/srv/salt/ceph/rescind/rgw/monitoring/default.sls
@@ -12,6 +12,6 @@ remove_rgw_exporter:
 
 uninstall_package:
   pkg.removed:
-    - name: python-prometheus-client
+    - name: python3-prometheus-client
 
 {% endif %}

--- a/srv/salt/ceph/rgw/buckets/default.sls
+++ b/srv/salt/ceph/rgw/buckets/default.sls
@@ -2,7 +2,7 @@
 install rgw:
   pkg.installed:
     - pkgs:
-      - python-boto
+      - python3-boto
     - refresh: True
 
 {% for user in salt['rgw.users'](contains="demo") %}

--- a/srv/salt/ceph/rgw/users/default.sls
+++ b/srv/salt/ceph/rgw/users/default.sls
@@ -3,7 +3,7 @@ install rgw:
   pkg.installed:
     - pkgs:
       - ceph-radosgw
-      - python-boto
+      - python3-boto
     - refresh: True
 
 add users:

--- a/srv/salt/ceph/stage/iscsi/default.sls
+++ b/srv/salt/ceph/stage/iscsi/default.sls
@@ -1,4 +1,9 @@
+{# The lrbd utility has not been updated for python3 and targetcli-fb #}
+{# Additionally, the kernel module target_core_rbd has not been ported yet. #}
 
-include:
-  - .core
-  - ...restart.igw.lax
+#include:
+#  - .core
+#  - ...restart.igw.lax
+
+iscsi disabled:
+  test.nop

--- a/srv/salt/ceph/stage/prep/minion/default-no-update-no-reboot.sls
+++ b/srv/salt/ceph/stage/prep/minion/default-no-update-no-reboot.sls
@@ -9,6 +9,7 @@ common packages:
     - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
     - tgt_type: compound
     - sls: ceph.packages.common
+    - failhard: True
 
 sync:
   salt.state:

--- a/srv/salt/ceph/stage/prep/minion/default-no-update-reboot.sls
+++ b/srv/salt/ceph/stage/prep/minion/default-no-update-reboot.sls
@@ -9,6 +9,7 @@ common packages:
     - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
     - tgt_type: compound
     - sls: ceph.packages.common
+    - failhard: True
 
 sync:
   salt.state:

--- a/srv/salt/ceph/stage/prep/minion/default-update-no-reboot.sls
+++ b/srv/salt/ceph/stage/prep/minion/default-update-no-reboot.sls
@@ -9,6 +9,7 @@ common packages:
     - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
     - tgt_type: compound
     - sls: ceph.packages.common
+    - failhard: True
 
 sync:
   salt.state:

--- a/srv/salt/ceph/stage/prep/minion/default.sls
+++ b/srv/salt/ceph/stage/prep/minion/default.sls
@@ -9,6 +9,7 @@ common packages:
     - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
     - tgt_type: compound
     - sls: ceph.packages.common
+    - failhard: True
 
 sync:
   salt.state:

--- a/tests/unit/_modules/test_cephdisks.py
+++ b/tests/unit/_modules/test_cephdisks.py
@@ -1,5 +1,7 @@
 import pytest
-from srv.salt._modules import cephdisks
+import sys
+sys.path.insert(0, 'srv/salt/_modules')
+from srv.salt._modules import cephdisks, helper
 from mock import MagicMock, patch, mock_open, mock
 from tests.unit.helper.output import OutputHelper
 
@@ -47,7 +49,7 @@ class TestHardwareDetections():
         Given we do not have that tool installed or privileges. 
         And explicitly tell `which` so.
         """
-        with pytest.raises(StandardError):
+        with pytest.raises(Exception):
             hwd._which('notthere', failhard=True)
 
     def test_which_failure_raise(self, hwd):
@@ -55,7 +57,7 @@ class TestHardwareDetections():
         Given we do not have that tool installed or privileges.
         And don't explicitly tell `which` so.
         """
-        with pytest.raises(StandardError):
+        with pytest.raises(Exception):
             hwd._which('notthere')
 
     def test_which_failure_raise_param_error(self, hwd):
@@ -63,7 +65,7 @@ class TestHardwareDetections():
         Given we do not have that tool installed or privileges.
         And tell which the wrong type(argument).
         """
-        with pytest.raises(StandardError):
+        with pytest.raises(Exception):
             hwd._which('notthere', 'StringTrue')
 
     def test_is_rotational(self, hwd):

--- a/tests/unit/_modules/test_openattic.py
+++ b/tests/unit/_modules/test_openattic.py
@@ -5,6 +5,8 @@ import os
 from pyfakefs import fake_filesystem_unittest
 from mock import MagicMock, patch, mock
 
+import sys
+sys.path.insert(0, 'srv/salt/_modules')
 from srv.salt._modules import openattic
 from salt.exceptions import CommandExecutionError
 

--- a/tests/unit/_modules/test_packagemanager.py
+++ b/tests/unit/_modules/test_packagemanager.py
@@ -1,5 +1,9 @@
 import pytest
 from srv.salt._modules.packagemanager import PackageManager, Zypper, Apt
+from srv.salt._modules import packagemanager as pm
+import sys
+sys.path.insert(0, 'srv/salt/_modules')
+from srv.salt._modules.helper import _run
 from mock import MagicMock, patch, mock
 
 
@@ -8,49 +12,44 @@ class TestPackageManager():
     This class contains a set of functions that test srv.salt._modules.packagemanager
     '''
 
-    @mock.patch('srv.salt._modules.packagemanager.linux_distribution')
-    def test_PackageManager_opensuse(self, dist_return):
+    def test_PackageManager_opensuse(self):
         """
         Test Packagemanager assignments based on `patform` mocks.
         """
-        dist_return.return_value = ('opensuse', 42.1, 'x86_64')
+        pm.__grains__ = {'os': 'opensuse'}
         ret = PackageManager()
         assert isinstance(ret.pm, Zypper) is True
 
-    @mock.patch('srv.salt._modules.packagemanager.linux_distribution')
-    def test_PackageManager_suse(self, dist_return):
+    def test_PackageManager_suse(self):
         """
         Test Packagemanager assignments based on `patform` mocks.
         """
-        dist_return.return_value = ('SUSE', '12.2', 'x86_64')
+        pm.__grains__ = {'os': 'suse'}
         ret = PackageManager()
         assert isinstance(ret.pm, Zypper) is True
 
-    @mock.patch('srv.salt._modules.packagemanager.linux_distribution')
-    def test_PackageManager_debian(self, dist_return):
+    def test_PackageManager_debian(self):
         """
         Test Packagemanager assignments based on `patform` mocks.
         """
-        dist_return.return_value = ('debian', '8', 'x86_64')
+        pm.__grains__ = {'os': 'debian'}
         ret = PackageManager()
         assert isinstance(ret.pm, Apt) is True
 
-    @mock.patch('srv.salt._modules.packagemanager.linux_distribution')
-    def test_PackageManager_ubuntu(self, dist_return):
+    def test_PackageManager_ubuntu(self):
         """
         Test Packagemanager assignments based on `patform` mocks.
         """
-        dist_return.return_value = ('ubuntu', '23', 'x86_64')
+        pm.__grains__ = {'os': 'ubuntu'}
         ret = PackageManager()
         assert isinstance(ret.pm, Apt) is True
 
-    @mock.patch('srv.salt._modules.packagemanager.linux_distribution')
     @mock.patch('srv.salt._modules.packagemanager.Popen')
-    def test_not_implemented(self, po, dist_return):
+    def test_not_implemented(self, po):
         """
         Your platform is not supported
         """
-        dist_return.return_value = ('ScientificLinux', '42.2', 'x86_64')
+        pm.__grains__ = {'os': 'UnknownOS'}
         with pytest.raises(ValueError) as excinfo:
             PackageManager()
         excinfo.match('Failed to detect PackageManager for OS.*')
@@ -63,12 +62,9 @@ class TestZypper():
         """
         Fixture to always get Zypper.
         """
-        self.linux_dist = patch('srv.salt._modules.packagemanager.linux_distribution')
-        self.lnx_dist_object = self.linux_dist.start()
-        self.lnx_dist_object.return_value = ('opensuse', '42.2', 'x86_64')
+        pm.__grains__ = {'os': 'suse'}
         args = {'debug': False, 'kernel': False, 'reboot': False}
         yield PackageManager(**args).pm
-        self.linux_dist.stop()
 
     @mock.patch('srv.salt._modules.packagemanager.Popen')
     def test__refresh(self, po, zypp):
@@ -256,13 +252,9 @@ class TestApt():
         """
         Fixture to always get Apt.
         """
-        self.linux_dist = patch('srv.salt._modules.packagemanager.linux_distribution')
-        self.lnx_dist_object = self.linux_dist.start()
-        self.lnx_dist_object.return_value = ('ubuntu', '42.2', 'x86_64')
-        # Test all permutations of :debug :kernel and :reboot
+        pm.__grains__ = {'os': 'ubuntu'}
         args = {'debug': False, 'kernel': False, 'reboot': False}
         yield PackageManager(**args).pm
-        self.linux_dist.stop()
 
     @mock.patch('srv.salt._modules.packagemanager.Popen')
     def test__refresh(self, po, apt):

--- a/tests/unit/_modules/test_proposal.py
+++ b/tests/unit/_modules/test_proposal.py
@@ -4,6 +4,7 @@ import pytest
 import sys
 sys.path.insert(0, 'srv/salt/_modules')
 from srv.salt._modules import proposal
+from srv.salt._modules import helper
 from tests.unit.helper.output import OutputHelper
 
 

--- a/tests/unit/_modules/test_rgw.py
+++ b/tests/unit/_modules/test_rgw.py
@@ -1,6 +1,8 @@
 import pytest
 import salt.client
 import os
+import sys
+sys.path.insert(0, 'srv/salt/_modules')
 from pyfakefs import fake_filesystem, fake_filesystem_glob
 
 from mock import patch, MagicMock

--- a/tests/unit/_modules/test_validate.py
+++ b/tests/unit/_modules/test_validate.py
@@ -1,5 +1,7 @@
 import pytest
 import salt.client
+import sys
+sys.path.insert(0, 'srv/salt/_modules')
 
 from mock import patch, MagicMock
 from srv.modules.runners import validate

--- a/tests/unit/runners/test_push.py
+++ b/tests/unit/runners/test_push.py
@@ -1,6 +1,8 @@
 from pyfakefs import fake_filesystem as fake_fs
 from pyfakefs import fake_filesystem_glob as fake_glob
 from mock import patch, mock_open, MagicMock
+import sys
+sys.path.insert(0, 'srv/modules/pillar')
 from srv.modules.runners import push
 
 fs = fake_fs.FakeFilesystem()


### PR DESCRIPTION
Trying to achieve python2 and python3 compliance in all our modules/runners (including the stack.py) by leveraging python's 2to3 tool (with human supervision) and custom changes with a bit of refactoring.

All major changes and their root-causes have been documented in #781 

Known bugs:

* the cli currently fails to parse the sls files.
* after a automated reboot minions betimes drop out early
* probably some code in rgw which I have missed due to insufficient testing hardware (multiple rgw)