### PR TITLE
qa: pre-create pools before running Stage 4

### DIFF
--- a/qa/common/json.sh
+++ b/qa/common/json.sh
@@ -1,5 +1,6 @@
 #
-# This file is part of the DeepSea integration test suite
+# This file is part of the DeepSea integration test suite.
+# It contains various cluster introspection functions.
 #
 
 function json_total_nodes {
@@ -15,4 +16,9 @@ function _json_nodes_of_role_x {
 function json_storage_nodes {
   # number of storage nodes in the cluster
   _json_nodes_of_role_x storage
+}
+
+function json_total_osds {
+  # total number of OSDs in the cluster
+  ceph osd ls --format json | jq '. | length'
 }

--- a/qa/suites/basic/health-igw.sh
+++ b/qa/suites/basic/health-igw.sh
@@ -67,6 +67,7 @@ run_stage_2 "$CLI"
 ceph_conf_small_cluster
 run_stage_3 "$CLI"
 ceph_cluster_status
+create_all_pools_at_once iscsi-images
 run_stage_4 "$CLI"
 ceph_cluster_status
 ceph_health_test

--- a/qa/suites/basic/health-mds.sh
+++ b/qa/suites/basic/health-mds.sh
@@ -67,6 +67,7 @@ run_stage_2 "$CLI"
 ceph_conf_small_cluster
 run_stage_3 "$CLI"
 ceph_cluster_status
+create_all_pools_at_once cephfs_data cephfs_metadata
 run_stage_4 "$CLI"
 ceph_cluster_status
 ceph_health_test

--- a/qa/suites/basic/health-nfs-ganesha.sh
+++ b/qa/suites/basic/health-nfs-ganesha.sh
@@ -90,6 +90,9 @@ run_stage_2 "$CLI"
 ceph_conf_small_cluster
 run_stage_3 "$CLI"
 ceph_cluster_status
+if [ "$FSAL" = "cephfs" -o "$FSAL" = "both" ] ; then
+  create_all_pools_at_once cephfs_data cephfs_metadata
+fi
 nfs_ganesha_no_root_squash
 run_stage_4 "$CLI"
 ceph_cluster_status

--- a/qa/suites/basic/health-openattic.sh
+++ b/qa/suites/basic/health-openattic.sh
@@ -20,6 +20,7 @@
 set -ex
 BASEDIR=$(pwd)
 source $BASEDIR/common/common.sh
+source $BASEDIR/common/nfs-ganesha.sh
 
 function usage {
     set +x
@@ -72,11 +73,14 @@ ceph_conf_small_cluster
 run_stage_3 "$CLI"
 ceph_cluster_status
 create_all_pools_at_once iscsi-images cephfs_data cephfs_metadata
+nfs_ganesha_no_root_squash
 run_stage_4 "$CLI"
 ceph_cluster_status
+ceph_health_test
+nfs_ganesha_cat_config_file
+nfs_ganesha_debug_log
 rgw_curl_test
 rgw_user_and_bucket_list
-ceph_health_test
 ceph_version_test
 run_stage_0 "$CLI"
 

--- a/qa/suites/basic/health-openattic.sh
+++ b/qa/suites/basic/health-openattic.sh
@@ -71,6 +71,7 @@ run_stage_2 "$CLI"
 ceph_conf_small_cluster
 run_stage_3 "$CLI"
 ceph_cluster_status
+create_all_pools_at_once iscsi-images cephfs_data cephfs_metadata
 run_stage_4 "$CLI"
 ceph_cluster_status
 rgw_curl_test

--- a/qa/suites/ceph-test/pynfs.sh
+++ b/qa/suites/ceph-test/pynfs.sh
@@ -88,6 +88,9 @@ run_stage_2 "$CLI"
 ceph_conf_small_cluster
 run_stage_3 "$CLI"
 ceph_cluster_status
+if [ "$FSAL" = "cephfs" -o "$FSAL" = "both" ] ; then
+  create_all_pools_at_once cephfs_data cephfs_metadata
+fi
 nfs_ganesha_no_root_squash
 run_stage_4 "$CLI"
 ceph_cluster_status


### PR DESCRIPTION
Without this, Stage 4 creates certain pools with pg_num 128, often causing tests to fail because of too many, or too few, PGs per OSD.

Backport PR is #909