### PR TITLE
ganesha: install: Refrain from installing recommended packages

### DIFF
--- a/srv/salt/ceph/ganesha/install/default.sls
+++ b/srv/salt/ceph/ganesha/install/default.sls
@@ -20,4 +20,5 @@ install_ganesha:
 {% if grains.get('os_family', '') == 'Suse' %}
         - nfs-ganesha-utils
 {% endif %}
+    - install_recommends: False
     - fire_event: True


### PR DESCRIPTION
By default, this pkg.installed block will do:

zypper --non-interactive in nfs-ganesha nfs-ganesha-ceph nfs-ganesha-rgw nfs-ganesha-utils

which brings in 170 packages (including entire GUI stack). Adding `--no-recommends` would fix this, but we're not running zypper directly here.

The Salt docs say that "install_recommends" is supported only with APT, but maybe it
has been implemented for zypper in the meantime. Anyway, it's worth a try!