### PR TITLE
Sync modules before deploying salt-api

### DIFF
--- a/srv/salt/ceph/stage/prep/master/default-no-update-no-reboot.sls
+++ b/srv/salt/ceph/stage/prep/master/default-no-update-no-reboot.sls
@@ -8,15 +8,15 @@ validate failed:
 
 {% endif %}
 
-salt-api:
-  salt.state:
-    - tgt: {{ salt['pillar.get']('master_minion') }}
-    - sls: ceph.salt-api
-
 sync master:
   salt.state:
     - tgt: {{ salt['pillar.get']('master_minion') }}
     - sls: ceph.sync
+
+salt-api:
+  salt.state:
+    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - sls: ceph.salt-api
 
 {% set notice = salt['saltutil.runner']('advise.salt_run') %}
 

--- a/srv/salt/ceph/stage/prep/master/default-no-update-reboot.sls
+++ b/srv/salt/ceph/stage/prep/master/default-no-update-reboot.sls
@@ -8,15 +8,15 @@ validate failed:
 
 {% endif %}
 
-salt-api:
-  salt.state:
-    - tgt: {{ salt['pillar.get']('master_minion') }}
-    - sls: ceph.salt-api
-
 sync master:
   salt.state:
     - tgt: {{ salt['pillar.get']('master_minion') }}
     - sls: ceph.sync
+
+salt-api:
+  salt.state:
+    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - sls: ceph.salt-api
 
 {% set notice = salt['saltutil.runner']('advise.salt_run') %}
 

--- a/srv/salt/ceph/stage/prep/master/default-update-no-reboot.sls
+++ b/srv/salt/ceph/stage/prep/master/default-update-no-reboot.sls
@@ -8,15 +8,15 @@ validate failed:
 
 {% endif %}
 
-salt-api:
-  salt.state:
-    - tgt: {{ salt['pillar.get']('master_minion') }}
-    - sls: ceph.salt-api
-
 sync master:
   salt.state:
     - tgt: {{ salt['pillar.get']('master_minion') }}
     - sls: ceph.sync
+
+salt-api:
+  salt.state:
+    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - sls: ceph.salt-api
 
 {% set notice = salt['saltutil.runner']('advise.salt_run') %}
 

--- a/srv/salt/ceph/stage/prep/master/default.sls
+++ b/srv/salt/ceph/stage/prep/master/default.sls
@@ -8,15 +8,15 @@ validate failed:
 
 {% endif %}
 
-salt-api:
-  salt.state:
-    - tgt: {{ salt['pillar.get']('master_minion') }}
-    - sls: ceph.salt-api
-
 sync master:
   salt.state:
     - tgt: {{ salt['pillar.get']('master_minion') }}
     - sls: ceph.sync
+
+salt-api:
+  salt.state:
+    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - sls: ceph.salt-api
 
 {% set notice = salt['saltutil.runner']('advise.salt_run') %}
 


### PR DESCRIPTION
This appears to be a regression introduced by
9f450a2ebe4caf56412128c9465ef4097ee51339 which was merged via
https://github.com/SUSE/DeepSea/pull/718 on October 6, 2017.

If salt-api is deployed before syncing modules, Stage 0 fails with:

Rendering SLS 'base:ceph.salt-api.configure' failed: Jinja variable
'salt.utils.templates.AliasedLoader object' has no attribute 'deepsea.user'

Fixes: https://github.com/SUSE/DeepSea/issues/914
Signed-off-by: Denis Kondratenko <denis.kondratenko@suse.com>
Signed-off-by: Nathan Cutler <ncutler@suse.com>