### PR TITLE
Support chrony, set as default, add rescind

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -478,6 +478,12 @@ copy-files:
 	install -m 644 srv/salt/ceph/rescind/openattic/keyring/*.sls $(DESTDIR)/srv/salt/ceph/rescind/openattic/keyring/
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/rescind/storage/terminate
 	install -m 644 srv/salt/ceph/rescind/storage/terminate/*.sls $(DESTDIR)/srv/salt/ceph/rescind/storage/terminate/
+	install -d -m 755 $(DESTDIR)/srv/salt/ceph/rescind/time
+	install -m 644 srv/salt/ceph/rescind/time/*.sls $(DESTDIR)/srv/salt/ceph/rescind/time/
+	install -d -m 755 $(DESTDIR)/srv/salt/ceph/rescind/time/chrony
+	install -m 644 srv/salt/ceph/rescind/time/chrony/*.sls $(DESTDIR)/srv/salt/ceph/rescind/time/chrony
+	install -d -m 755 $(DESTDIR)/srv/salt/ceph/rescind/time/ntp
+	install -m 644 srv/salt/ceph/rescind/time/ntp/*.sls $(DESTDIR)/srv/salt/ceph/rescind/time/ntp
 	# state files - repo
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/repo
 	install -m 644 srv/salt/ceph/repo/*.sls $(DESTDIR)/srv/salt/ceph/repo/
@@ -630,6 +636,10 @@ copy-files:
 	install -m 644 srv/salt/ceph/time/default.sls $(DESTDIR)/srv/salt/ceph/time/
 	install -m 644 srv/salt/ceph/time/disabled.sls $(DESTDIR)/srv/salt/ceph/time/
 	install -m 644 srv/salt/ceph/time/init.sls $(DESTDIR)/srv/salt/ceph/time/
+	install -d -m 755 $(DESTDIR)/srv/salt/ceph/time/chrony
+	install -m 644 srv/salt/ceph/time/chrony/*.sls $(DESTDIR)/srv/salt/ceph/time/chrony/
+	install -d -m 755 $(DESTDIR)/srv/salt/ceph/time/chrony/files
+	install -m 644 srv/salt/ceph/time/chrony/files/*.j2 $(DESTDIR)/srv/salt/ceph/time/chrony/files
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/time/ntp
 	install -m 644 srv/salt/ceph/time/ntp/*.sls $(DESTDIR)/srv/salt/ceph/time/ntp/
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/time/ntp/files

--- a/deepsea.spec.in
+++ b/deepsea.spec.in
@@ -269,6 +269,9 @@ systemctl try-restart salt-api > /dev/null 2>&1 || :
 %dir /srv/salt/ceph/rescind/storage
 %dir /srv/salt/ceph/rescind/storage/terminate
 %dir /srv/salt/ceph/rescind/storage/keyring
+%dir /srv/salt/ceph/rescind/time
+%dir /srv/salt/ceph/rescind/time/chrony
+%dir /srv/salt/ceph/rescind/time/ntp
 %dir /srv/salt/ceph/rescind/openattic
 %dir /srv/salt/ceph/rescind/openattic/keyring
 %dir /srv/salt/ceph/restart
@@ -328,6 +331,8 @@ systemctl try-restart salt-api > /dev/null 2>&1 || :
 %dir /srv/salt/ceph/setosdflags/sortbitwise
 %dir /srv/salt/ceph/setosdflags/requireosdrelease
 %dir /srv/salt/ceph/time
+%dir /srv/salt/ceph/time/chrony
+%dir /srv/salt/ceph/time/chrony/files
 %dir /srv/salt/ceph/time/ntp
 %dir /srv/salt/ceph/time/ntp/files
 %dir /srv/salt/ceph/maintenance
@@ -550,6 +555,9 @@ systemctl try-restart salt-api > /dev/null 2>&1 || :
 %config /srv/salt/ceph/rescind/rgw/monitoring/*.sls
 %config /srv/salt/ceph/rescind/storage/*.sls
 %config /srv/salt/ceph/rescind/storage/keyring/*.sls
+%config /srv/salt/ceph/rescind/time/*.sls
+%config /srv/salt/ceph/rescind/time/chrony/*.sls
+%config /srv/salt/ceph/rescind/time/ntp/*.sls
 %config /srv/salt/ceph/rescind/openattic/*.sls
 %config /srv/salt/ceph/rescind/openattic/keyring/*.sls
 %config /srv/salt/ceph/reset/*.sls
@@ -612,6 +620,8 @@ systemctl try-restart salt-api > /dev/null 2>&1 || :
 %config /srv/salt/ceph/setosdflags/requireosdrelease/*.sls
 %config /srv/salt/ceph/setosdflags/sortbitwise/*.sls
 %config /srv/salt/ceph/time/*.sls
+%config /srv/salt/ceph/time/chrony/*.sls
+%config /srv/salt/ceph/time/chrony/files/*.j2
 %config /srv/salt/ceph/time/ntp/*.sls
 %config /srv/salt/ceph/time/ntp/files/*.j2
 %config /srv/salt/ceph/upgrade/*.sls

--- a/srv/modules/runners/populate.py
+++ b/srv/modules/runners/populate.py
@@ -849,7 +849,6 @@ class CephCluster(object):
         filename = "{}/global.yml".format(stack_dir)
         contents = {}
         contents['time_server'] = '{{pillar.get("master_minion")}}'
-        contents['time_init'] = 'ntp'
 
         self.writer.write(filename, contents)
 

--- a/srv/salt/ceph/rescind/time/chrony/default.sls
+++ b/srv/salt/ceph/rescind/time/chrony/default.sls
@@ -1,0 +1,20 @@
+
+{% if grains['id'] not in salt['pillar.get']('time_server') %}
+
+/etc/chrony.conf:
+  file.absent
+
+stop chronyd:
+  service.dead:
+    - name: chronyd
+    - enable: False
+    - fire_event: True
+
+uninstall chronyd:
+  pkg.removed:
+    - name: chronyd
+
+{% endif %}
+
+prevent empty chrony:
+  test.nop

--- a/srv/salt/ceph/rescind/time/chrony/init.sls
+++ b/srv/salt/ceph/rescind/time/chrony/init.sls
@@ -1,0 +1,3 @@
+
+include:
+  - .{{ salt['pillar.get']('rescind_time_chrony', 'default') }}

--- a/srv/salt/ceph/rescind/time/default.sls
+++ b/srv/salt/ceph/rescind/time/default.sls
@@ -1,3 +1,4 @@
 
 include:
+  - .chrony
   - .ntp

--- a/srv/salt/ceph/rescind/time/init.sls
+++ b/srv/salt/ceph/rescind/time/init.sls
@@ -1,0 +1,3 @@
+
+include:
+  - .{{ salt['pillar.get']('rescind_time', 'default') }}

--- a/srv/salt/ceph/rescind/time/ntp/default.sls
+++ b/srv/salt/ceph/rescind/time/ntp/default.sls
@@ -1,0 +1,19 @@
+
+{% if grains['id'] not in salt['pillar.get']('time_server') %}
+/etc/ntp.conf:
+  file.absent
+
+stop ntpd:
+  service.dead:
+    - name: ntpd
+    - enable: False
+    - fire_event: True
+
+uninstall ntpd:
+  pkg.removed:
+    - name: ntpd
+{% endif %}
+
+prevent empty ntp:
+  test.nop
+

--- a/srv/salt/ceph/rescind/time/ntp/init.sls
+++ b/srv/salt/ceph/rescind/time/ntp/init.sls
@@ -1,0 +1,4 @@
+
+
+include:
+  - .{{ salt['pillar.get']('rescind_time_ntp', 'default') }}

--- a/srv/salt/ceph/time/README
+++ b/srv/salt/ceph/time/README
@@ -1,12 +1,24 @@
-Set up NTP to manage system time
+Set up Chrony or ntp to manage system time.  Chrony is preferred.
 
-Ceph relies on loosely synchronized clocks. DeepSea will by default start an
-NTP client on each cluster node and point it to the NTP server running on the
-Salt Master if and only if the ntpd.service systemd unit is not running.
+Ceph relies on synchronized clocks. DeepSea will by default start a chrony 
+client on each minion.  If chrony is not available, then ntp must be selected
+in the pillar.  In either case, the default time server is the Salt master 
+unless overridden.  The Salt master must be configured manually.  (Salt can be
+used for setting up a time server, but admins have strong opinions about the
+correct configuration for time.  The Salt master is suitable for virtual
+environments.)
 
-If you want DeepSea to always overwrite an existing NTP configuration set
-"time_init: ntp" in the pillar.
+To force the time server to use chrony, ntp or be disabled, add one of the 
+following to /srv/pillar/ceph/stack/global.yml:
 
-To disable all NTP management set "time_init: disabled" in the pillar. Note
-that the admin should have some form of time synchronisation set up in this
-case, otherwise Ceph might not function reliably.
+time_init: chrony
+time_init: ntp
+time_init: disabled
+
+Run Stage 2 or `salt '*' saltutil.refresh_pillar` to update the pillar.
+
+** Developer note
+Each state file removes the other configuration.  Chrony will remove ntp and
+ntp will remove chrony.  If a third system is ever supported, the removal of
+the configuration could be separated.  Although rescind seems like an
+appropriate place, rescind is based on role assignments.

--- a/srv/salt/ceph/time/chrony/default.sls
+++ b/srv/salt/ceph/time/chrony/default.sls
@@ -1,0 +1,44 @@
+
+{% set time_server = salt['pillar.get']('time_server') %}
+{% if time_server is string %}
+{% set time_server = [time_server] %}
+{% endif %}
+
+{% if grains['id'] not in salt['pillar.get']('time_server') %}
+
+include:
+  - ...rescind.time.ntp
+
+install chrony:
+  pkg.installed:
+    - pkgs:
+      - chrony
+    - refresh: True
+    - fire_event: True
+
+service_reload:
+  module.run:
+    - name: service.systemctl_reload
+
+/etc/chrony.conf:
+  file.managed:
+    - source:
+        - salt://ceph/time/chrony/files/chrony.conf.j2
+    - template: jinja
+    - user: root
+    - group: root
+    - mode: 644
+    - makedirs: True
+    - backup: minion
+    - fire_event: True
+
+start chronyd:
+  service.running:
+    - name: chronyd
+    - enable: True
+    - fire_event: True
+
+{% endif %}
+
+prevent empty file:
+  test.nop

--- a/srv/salt/ceph/time/chrony/files/chrony.conf.j2
+++ b/srv/salt/ceph/time/chrony/files/chrony.conf.j2
@@ -1,0 +1,34 @@
+# Use public servers from the pool.ntp.org project.
+# Please consider joining the pool (http://www.pool.ntp.org/join.html).
+{% set time_server = salt['pillar.get']('time_server') %}
+{% if time_server is string %}
+{% set time_server = [time_server] %}
+{% endif %}
+{% for server in time_server %}
+server {{ server }} iburst
+{% endfor %}
+
+# Record the rate at which the system clock gains/losses time.
+driftfile /var/lib/chrony/drift
+
+# In first three updates step the system clock instead of slew
+# if the adjustment is larger than 1 second.
+makestep 1.0 3
+
+# Enable kernel synchronization of the real-time clock (RTC).
+rtcsync
+
+# Allow NTP client access from local network.
+#allow 192.168/16
+
+# Serve time even if not synchronized to any NTP server.
+#local stratum 10
+
+# Specify file containing keys for NTP authentication.
+#keyfile /etc/chrony.keys
+
+# Specify directory for log files.
+logdir /var/log/chrony
+
+# Select which information is logged.
+#log measurements statistics tracking

--- a/srv/salt/ceph/time/chrony/init.sls
+++ b/srv/salt/ceph/time/chrony/init.sls
@@ -1,0 +1,4 @@
+
+include:
+  - .{{ salt['pillar.get']('time_chrony', 'default') }}
+

--- a/srv/salt/ceph/time/default.sls
+++ b/srv/salt/ceph/time/default.sls
@@ -1,8 +1,3 @@
 
-{% if salt['service.status']('ntpd') == False %}
 include:
-  - .ntp
-{% else %}
-include:
-  - .disabled
-{% endif %}
+  - .chrony

--- a/srv/salt/ceph/time/ntp/default.sls
+++ b/srv/salt/ceph/time/ntp/default.sls
@@ -4,6 +4,9 @@
 {% set time_server = [time_server] %}
 {% endif %}
 
+include:
+  - ...rescind.time.chrony
+
 install_ntp_packages:
   pkg.installed:
     - pkgs:


### PR DESCRIPTION
Same strategy as ntp setup.  DeepSea only handles client configuration.  Available commands are

```
salt '*' state.apply ceph.time
salt '*' state.apply ceph.time.chrony
salt '*' state.apply ceph.time.ntp
```

```
salt '*' state.apply ceph.rescind.time
salt '*' state.apply ceph.rescind.time.chrony
salt '*' state.apply ceph.rescind.time.ntp
```

The default for a fresh install is chrony.  This will work with ntpd or chronyd as a server.  (Be sure to add the 'allow' directive for chronyd to listen on port 123.)

Chrony supports immediately sync'ing, so no separate step needed.  The Salt commands are plain enough that I am hopeful these will work on other distros without exceptions.  The rescind functionality cannot be part of Stage 5 or the purge orchestration.  

Existing installations can follow #929 for now.

Signed-off-by: Eric Jackson <ejackson@suse.com>