### PR TITLE
benchmarks/fs: add generic filesystem benchmark

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -388,6 +388,9 @@ copy-files:
 	# state files - benchmark-blockdev
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/benchmarks/blockdev/
 	install -m 644 srv/salt/ceph/benchmarks/blockdev/*.sls $(DESTDIR)/srv/salt/ceph/benchmarks/blockdev/
+	# state files - benchmark-fs
+	install -d -m 755 $(DESTDIR)/srv/salt/ceph/benchmarks/fs/
+	install -m 644 srv/salt/ceph/benchmarks/fs/*.sls $(DESTDIR)/srv/salt/ceph/benchmarks/fs/
 	# state files - reactor
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/reactor
 	install -m 644 srv/salt/ceph/reactor/*.sls $(DESTDIR)/srv/salt/ceph/reactor/

--- a/deepsea.spec.in
+++ b/deepsea.spec.in
@@ -98,6 +98,7 @@ systemctl try-restart salt-api > /dev/null 2>&1 || :
 %dir /srv/salt/ceph/admin/key
 %dir /srv/salt/ceph/benchmarks
 %dir /srv/salt/ceph/benchmarks/blockdev
+%dir /srv/salt/ceph/benchmarks/fs
 %dir /srv/salt/ceph/cephfs
 %dir /srv/salt/ceph/cephfs/benchmarks
 %dir /srv/salt/ceph/cephfs/benchmarks/files
@@ -391,6 +392,7 @@ systemctl try-restart salt-api > /dev/null 2>&1 || :
 %config /srv/salt/ceph/admin/key/*.sls
 %config /srv/salt/ceph/benchmarks/*.sls
 %config /srv/salt/ceph/benchmarks/blockdev/*.sls
+%config /srv/salt/ceph/benchmarks/fs/*.sls
 %config /srv/salt/ceph/cephfs/benchmarks/*.sls
 %config /srv/salt/ceph/cephfs/benchmarks/files/keyring.j2
 %config /srv/salt/ceph/salt-api/*.sls

--- a/srv/modules/runners/benchmark.py
+++ b/srv/modules/runners/benchmark.py
@@ -191,8 +191,11 @@ def help():
              'salt-run benchmark.baseline work_dir=/path log_dir=/path job_dir=/path default_collection=simple.yml client_glob=target:\n\n'
              '    Run Baseline benchmarks\n'
              '\n\n'
-             'salt-run benchmark.blockdev work_dir=/path log_dir=/path job_dir=/path default_collection=simple.yml client_glob=target:\n\n'
+             'salt-run benchmark.blockdev log_dir=/path job_dir=/path default_collection=simple.yml client_glob=target:\n\n'
              '    Run local block device benchmarks (e.g. premapped kRBD or iSCSI)\n'
+             '\n\n'
+             'salt-run benchmark.fs work_dir=/path log_dir=/path job_dir=/path default_collection=simple.yml client_glob=target:\n\n'
+             '    Run local filesystem benchmarks (e.g. premounted NFS or SMB/CIFS)\n'
              '\n\n'
     )
     print usage
@@ -324,6 +327,32 @@ def blockdev(**kwargs):
               dir_options['job_dir'])
 
     for job_spec in default_collection['blockdev']:
+        print(fio.run(job_spec))
+
+    return True
+
+
+def fs(**kwargs):
+    """
+    Run local (premounted) fs benchmark jobs
+    """
+
+    client_glob = kwargs.get('client_glob',
+                             'I@roles:benchmark-fs and I@cluster:ceph')
+    log.info('client glob is {}'.format(client_glob))
+
+    dir_options = __parse_and_set_dirs(kwargs)
+
+    default_collection = __parse_collection(
+        '{}/collections/default.yml'.format(dir_options['bench_dir']))
+
+    fio = Fio(client_glob, 'fs',
+              dir_options['bench_dir'],
+              dir_options['work_dir'],
+              dir_options['log_dir'],
+              dir_options['job_dir'])
+
+    for job_spec in default_collection['fs']:
         print(fio.run(job_spec))
 
     return True

--- a/srv/modules/runners/populate.py
+++ b/srv/modules/runners/populate.py
@@ -549,7 +549,8 @@ class CephRoles(object):
         Allows admins to target non-Ceph minions
         """
         roles = [ 'client-cephfs', 'client-radosgw', 'client-iscsi',
-                  'client-nfs', 'benchmark-rbd', 'benchmark-blockdev' ]
+                  'client-nfs', 'benchmark-rbd', 'benchmark-blockdev',
+                  'benchmark-fs' ]
         self.available_roles.extend(roles)
 
         for role in roles:

--- a/srv/pillar/ceph/benchmarks/collections/default.yml
+++ b/srv/pillar/ceph/benchmarks/collections/default.yml
@@ -1,3 +1,4 @@
+# fs collection is used by both client-cephfs and benchmark-fs roles
 fs:
   - fio/rw_single_file.yml
   - fio/rw_many_files.yml

--- a/srv/salt/_modules/cephprocesses.py
+++ b/srv/salt/_modules/cephprocesses.py
@@ -37,6 +37,7 @@ processes = {'mon': ['ceph-mon'],
              'client-nfs': [],
              'client-radosgw': [],
              'benchmark-blockdev': [],
+             'benchmark-fs': [],
              'master': []}
 
 

--- a/srv/salt/ceph/benchmarks/fs.sls
+++ b/srv/salt/ceph/benchmarks/fs.sls
@@ -1,0 +1,29 @@
+
+prep master:
+  salt.state:
+    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - sls:
+      - ceph.benchmarks.fs.prepare_master
+
+prep clients:
+  salt.state:
+    - tgt: "I@roles:benchmark-fs and I@cluster:ceph"
+    - tgt_type: compound
+    - sls:
+      - ceph.benchmarks.fs.prepare_clients
+
+run fio:
+  salt.runner:
+    - name: benchmark.fs
+    - work_dir: {{ salt['pillar.get']('benchmark:work-directory') }}
+    - log_dir: {{ salt['pillar.get']('benchmark:log-file-directory') }}
+    - job_dir: {{ salt['pillar.get']('benchmark:job-file-directory') }}
+    - default_collection: {{ salt['pillar.get']('benchmark:default-collection') }}
+    - client_glob : "I@roles:benchmark-fs and I@cluster:ceph"
+
+cleanup fio:
+  salt.state:
+    - tgt: "I@roles:benchmark-fs and I@cluster:ceph"
+    - tgt_type: compound
+    - sls:
+      - ceph.benchmarks.fs.cleanup

--- a/srv/salt/ceph/benchmarks/fs/cleanup.sls
+++ b/srv/salt/ceph/benchmarks/fs/cleanup.sls
@@ -1,0 +1,3 @@
+
+include:
+  - ceph.tools.fio.cleanup

--- a/srv/salt/ceph/benchmarks/fs/prepare_clients.sls
+++ b/srv/salt/ceph/benchmarks/fs/prepare_clients.sls
@@ -1,0 +1,2 @@
+include:
+  - ceph.tools.fio.fio_service

--- a/srv/salt/ceph/benchmarks/fs/prepare_master.sls
+++ b/srv/salt/ceph/benchmarks/fs/prepare_master.sls
@@ -1,0 +1,4 @@
+
+include:
+  - ceph.tools.fio.fio
+  - ceph.tools.benchmarks.master_dirs


### PR DESCRIPTION
This functionality triggers fio, using a local path as destination
(work_dir), with the assumption that work_dir has already been mounted.

In future, this functionality will be inherited by CephFS and SMB/CIFS
benchmark backends.

Signed-off-by: David Disseldorp <ddiss@suse.de>