### PR TITLE
Avoid random _client_node name

### DIFF
--- a/qa/common/helper.sh
+++ b/qa/common/helper.sh
@@ -79,12 +79,12 @@ function _client_node {
   #
   # FIXME: migrate this to "salt --static --out json ... | jq ..."
   #
-  salt --no-color -C 'not I@roles:storage' test.ping | grep -o -P '^\S+(?=:)' | head -1
+  salt --no-color -C 'not I@roles:storage' test.ping | grep -o -P '^\S+(?=:)' | sort | head -1
 }
 
 function _first_x_node {
   local ROLE=$1
-  salt --no-color -C "I@roles:$ROLE" test.ping | grep -o -P '^\S+(?=:)' | head -1
+  salt --no-color -C "I@roles:$ROLE" test.ping | grep -o -P '^\S+(?=:)' | sort | head -1
 }
 
 function _run_test_script_on_node {


### PR DESCRIPTION
Hostnames are ordered randomly and it causes failures when e.g. test tries to umount nfs on node4 while priously was nfs mounted on master
```
Testing NFS-Ganesha with NFS version ->3<-
master.openqa.de:
    - master
    - admin
    - mon
    - mgr
    - mds
    - ganesha
master.openqa.de:
    ----------
master.openqa.de:
    ----------
    /tmp/test-nfs-ganesha.sh:
        True
master.openqa.de:
    + trap 'echo "Result: NOT_OK"' ERR
    + echo 'nfs-ganesha mount test script'
    nfs-ganesha mount test script
    + test '!' -e /root/mnt
    + mkdir /root/mnt
    + test -d /root/mnt
    + mount -t nfs -o sync,nfsvers=3 master.openqa.de:/ /root/mnt
    + ls -lR /root/mnt
    /root/mnt:
    total 0
    + echo 'Result: OK'
    Result: OK
node4.openqa.de:
    ----------
    /tmp/test-nfs-ganesha-write.sh:
        True
ERROR: Minions returned with non-zero exit code
node4.openqa.de:
    + trap 'echo "Result: NOT_OK"' ERR
    + echo 'nfs-ganesha write test script'
    nfs-ganesha write test script
    + test -e /root/mnt/saturn
    + touch /root/mnt/saturn
    touch: cannot touch '/root/mnt/saturn': No such file or directory
    ++ echo 'Result: NOT_OK'
    Result: NOT_OK
```