### PR TITLE
[backport][SES5] Avoid random _client_node name

### DIFF
--- a/qa/common/helper.sh
+++ b/qa/common/helper.sh
@@ -79,12 +79,12 @@ function _client_node {
   #
   # FIXME: migrate this to "salt --static --out json ... | jq ..."
   #
-  salt --no-color -C 'not I@roles:storage' test.ping | grep -o -P '^\S+(?=:)' | head -1
+  salt --no-color -C 'not I@roles:storage' test.ping | grep -o -P '^\S+(?=:)' | sort | head -1
 }
 
 function _first_x_node {
   local ROLE=$1
-  salt --no-color -C "I@roles:$ROLE" test.ping | grep -o -P '^\S+(?=:)' | head -1
+  salt --no-color -C "I@roles:$ROLE" test.ping | grep -o -P '^\S+(?=:)' | sort | head -1
 }
 
 function _run_test_script_on_node {


### PR DESCRIPTION
Backport of #939

Hostnames are ordered randomly and it causes failures when
e.g. test tries to umount nfs on node4 while priously was nfs mounted on master

(cherry picked from commit 2a70b84344e3f7bd9773b222b8096a7ab9439a33)