### PR TITLE
Makefile: install benchmark-blockdev rescind stubs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -462,6 +462,8 @@ copy-files:
 	install -m 644 srv/salt/ceph/rescind/client-radosgw/*.sls $(DESTDIR)/srv/salt/ceph/rescind/client-radosgw/
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/rescind/benchmark-rbd
 	install -m 644 srv/salt/ceph/rescind/benchmark-rbd/*.sls $(DESTDIR)/srv/salt/ceph/rescind/benchmark-rbd/
+	install -d -m 755 $(DESTDIR)/srv/salt/ceph/rescind/benchmark-blockdev
+	install -m 644 srv/salt/ceph/rescind/benchmark-blockdev/*.sls $(DESTDIR)/srv/salt/ceph/rescind/benchmark-blockdev/
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/rescind/rgw
 	install -m 644 srv/salt/ceph/rescind/rgw/*.sls $(DESTDIR)/srv/salt/ceph/rescind/rgw/
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/rescind/rgw/keyring


### PR DESCRIPTION
Fixes: https://github.com/SUSE/DeepSea/issues/949

Signed-off-by: David Disseldorp <ddiss@suse.de>