### PR TITLE
Add disengage_safety_duration parameter.

### DIFF
--- a/srv/modules/runners/disengage.py
+++ b/srv/modules/runners/disengage.py
@@ -10,6 +10,9 @@ from __future__ import absolute_import
 from __future__ import print_function
 import os
 import time
+import logging
+
+log = logging.getLogger(__name__)
 
 
 class SafetyFile(object):
@@ -29,7 +32,7 @@ def help_():
              '    Touches a file to signify imminent dangerous operations\n'
              '\n\n'
              'salt-run disengage.check:\n\n'
-             '    Check whether the timestamp is less than a minute old\n'
+             '    Check whether the timestamp is less than 300 seconds old\n'
              '\n\n')
     print(usage)
     return ""
@@ -41,18 +44,19 @@ def safety(cluster='ceph'):
     """
     sff = SafetyFile(cluster)
     with open(sff.filename, "w") as safe_file:
+        logging.debug('Disengaged safety for cluster: {}'.format(cluster))
         safe_file.write("")
         return "safety is now disabled for cluster {}".format(cluster)
 
 
-def check(cluster='ceph'):
+def check(cluster='ceph', timeout=300):
     """
     Check that time stamp of file is less than one minute
     """
     sff = SafetyFile(cluster)
     if os.path.exists(sff.filename):
         stamp = os.stat(sff.filename).st_mtime
-        return stamp + 60 > time.time()
+        return stamp + int(timeout) > time.time()
     else:
         return False
 

--- a/srv/salt/ceph/migrate/nodes/default.sls
+++ b/srv/salt/ceph/migrate/nodes/default.sls
@@ -1,5 +1,5 @@
-
-{% if salt['saltutil.runner']('disengage.check', cluster='ceph') == False %}
+{% set dsd = salt['pillar.get']('disengage_safety_duration', 300) %}
+{% if salt['saltutil.runner']('disengage.check', cluster='ceph', timeout=dsd) == False %}
 safety is engaged:
   salt.state:
     - tgt: {{ salt['pillar.get']('master_minion') }}

--- a/srv/salt/ceph/migrate/osds/default.sls
+++ b/srv/salt/ceph/migrate/osds/default.sls
@@ -1,5 +1,5 @@
-
-{% if salt['saltutil.runner']('disengage.check', cluster='ceph') == False %}
+{% set dsd = salt['pillar.get']('disengage_safety_duration', 300) %}
+{% if salt['saltutil.runner']('disengage.check', cluster='ceph', timeout=dsd) == False %}
 safety is engaged:
   salt.state:
     - tgt: {{ salt['pillar.get']('master_minion') }}

--- a/srv/salt/ceph/purge/default.sls
+++ b/srv/salt/ceph/purge/default.sls
@@ -1,5 +1,5 @@
-
-{% if salt['saltutil.runner']('disengage.check', cluster='ceph') == False %}
+{% set dsd = salt['pillar.get']('disengage_safety_duration', 300) %}
+{% if salt['saltutil.runner']('disengage.check', cluster='ceph', timeout=dsd) == False %}
 safety is engaged:
   salt.state:
     - tgt: {{ salt['pillar.get']('master_minion') }}


### PR DESCRIPTION
Fixes: #962

That parameter allows to set the disengaged safety time from the
default(300) seconds to a variable amount.

Invocation with:
``` bash

salt-run disengage.check timeout=42

salt-run remove.osd timeout=42
(the _timeout_ arg is passed through)

```

For orchestrations you can obviously can't utilize kwarg passing. For those cases there is now a 

*disengage_safety_duration* 

variable which can be set in the pillar.

Note that passing args via the CLI has higher precendence.


Signed-off-by: Joshua Schmid <jschmid@suse.de>