### PR TITLE
qa: add nfs HA test script

### DIFF
--- a/qa/common/common.sh
+++ b/qa/common/common.sh
@@ -409,11 +409,14 @@ EOF
 }
 
 function policy_cfg_nfs_ganesha {
+  # takes as argument number of NFS-Ganesha nodes to deploy
+  if [[ $# == 0 ]]; then nfs_nodes_num=1;else nfs_nodes_num=$1;fi
   cat <<EOF >> /srv/pillar/ceph/proposals/policy.cfg
-# Role assignment - NFS-Ganesha (first node)
-role-ganesha/cluster/*.sls slice=[:1]
+# Role assignment - NFS-Ganesha 
+role-ganesha/cluster/*.sls slice=[:$nfs_nodes_num]
 EOF
 }
+
 
 
 #
@@ -726,3 +729,20 @@ echo "Result: OK"
 EOF
     _run_test_script_on_node $TESTSCRIPT $STORAGENODE
 }
+
+function _get_fqdn_from_pillar_role {
+	# input argument is pillar role 
+	salt -C I@roles:${1} grains.item fqdn --out yaml|grep fqdn|sed 's/fqdn: //g'|tr -d ' '
+}
+
+function _get_fqdn_from_salt_grain_key {
+	# input argument is salt grain key
+	salt -C G@${1}:* grains.item fqdn --out yaml|grep fqdn|sed 's/fqdn: //g'|tr -d ' '
+}
+
+function _get_salt_grain_value {
+	# input argument is salt grain key
+	salt -C G@${1}:* grains.item $1 --out=yaml|grep $1|sed -e "s|${1}:||g"|tr -d ' '
+}
+
+

--- a/qa/common/nfs-ganesha.sh
+++ b/qa/common/nfs-ganesha.sh
@@ -58,6 +58,7 @@ function nfs_ganesha_mount {
   local ASUSER=$2
   local CLIENTNODE=$(_client_node)
   local GANESHANODE=$(_nfs_ganesha_node)
+  if [[ -n $3 ]];then GANESHANODE=$3;fi
   local TESTSCRIPT=/tmp/test-nfs-ganesha.sh
   salt "$CLIENTNODE" pillar.get roles
   salt "$CLIENTNODE" pkg.install nfs-client # FIXME: only works on SUSE
@@ -172,3 +173,77 @@ EOF
   sed -i 's/GANESHANODE/'$GANESHANODE'/' $TESTSCRIPT
   _run_test_script_on_node $TESTSCRIPT $CLIENTNODE
 }
+
+
+function set_NFS_HA_IP {
+        HA_GANESHA_IP=$1
+        echo "NFS HA IP is : " $HA_GANESHA_IP
+        salt -C 'I@roles:ganesha' grains.setval NFS_HA_IP $HA_GANESHA_IP
+}
+
+function nfs_ganesha_disable_service {
+        salt -C 'I@roles:ganesha' cmd.run 'systemctl disable nfs-ganesha.service'
+}
+
+function set_NFS_HA_primary_node {
+  # setting one of ganesha nodes to be HA primary node
+  NFS_NODE=$(_get_fqdn_from_pillar_role ganesha|head -n 1)
+  salt $NFS_NODE grains.setval ceph_ganesha_HA_master_node True
+}
+
+function get_NFS_HA_IP {
+        echo $(_get_salt_grain_value NFS_HA_IP|tail -n 1)
+}
+function nfs_ha_cluster_bootstrap {
+        NFS_GANESHA_primary_node=$(_get_fqdn_from_salt_grain_key ceph_ganesha_HA_master_node)
+        NFS_GANESHA_secondary_node=$(_get_fqdn_from_pillar_role ganesha|grep -v $NFS_GANESHA_primary_node)
+
+        # establish passwordless ssh access to HA nodes
+        MINION_HA_NODE_1=$NFS_GANESHA_primary_node
+        MINION_HA_NODE_2=$NFS_GANESHA_secondary_node
+        salt -C 'I@roles:ganesha' cmd.run "sed -i '/StrictHostKeyChecking/c\StrictHostKeyChecking no' /etc/ssh/ssh_config"
+        salt $MINION_HA_NODE_1\* cmd.run 'ssh-keygen -t rsa -N "" -f /root/.ssh/id_rsa'
+        salt $MINION_HA_NODE_2\* cmd.run 'ssh-keygen -t rsa -N "" -f /root/.ssh/id_rsa'
+        PUB_KEY_HA_NODE_1=$(salt $MINION_HA_NODE_1 cmd.run 'cat /root/.ssh/id_rsa.pub' --out yaml|sed 's/.* ssh-rsa/ssh-rsa/g')
+        PUB_KEY_HA_NODE_2=$(salt $MINION_HA_NODE_2 cmd.run 'cat /root/.ssh/id_rsa.pub' --out yaml|sed 's/.* ssh-rsa/ssh-rsa/g')
+        salt $MINION_HA_NODE_1 cmd.run "echo $PUB_KEY_HA_NODE_2 >> ~/.ssh/authorized_keys"
+        salt $MINION_HA_NODE_2 cmd.run "echo $PUB_KEY_HA_NODE_1 >> ~/.ssh/authorized_keys"
+
+        # configure cluster
+        HA_GANESHA_IP=$(get_NFS_HA_IP)
+        salt -C 'I@roles:ganesha' cmd.run "zypper in -y ha-cluster-bootstrap"
+        salt ${NFS_GANESHA_primary_node} cmd.run 'ha-cluster-init -y'
+        salt ${NFS_GANESHA_secondary_node} cmd.run "ha-cluster-join -y -c $MINION_HA_NODE_1 csync2"
+        salt ${NFS_GANESHA_secondary_node} cmd.run "ha-cluster-join -y -c $MINION_HA_NODE_1 ssh_merge"
+        salt ${NFS_GANESHA_secondary_node} cmd.run "ha-cluster-join -y -c $MINION_HA_NODE_1 cluster"
+        salt ${NFS_GANESHA_primary_node} cmd.run "crm status"
+        salt ${NFS_GANESHA_primary_node} cmd.run 'crm configure primitive nfs-ganesha-server systemd:nfs-ganesha op monitor interval=30s'
+        salt ${NFS_GANESHA_primary_node} cmd.run 'crm configure clone nfs-ganesha-clone nfs-ganesha-server meta interleave=true'
+        salt ${NFS_GANESHA_primary_node} cmd.run "crm configure primitive ganesha-ip IPaddr2 params ip=${HA_GANESHA_IP} cidr_netmask=24 nic=eth0 op monitor interval=10 timeout=20"
+        salt ${NFS_GANESHA_primary_node} cmd.run "crm configure commit"
+        salt ${NFS_GANESHA_primary_node} cmd.run "crm status"
+        salt -C 'I@roles:ganesha' service.status nfs-ganesha
+        salt -C 'I@roles:ganesha' service.restart nfs-ganesha || echo # for some reason, first restart always fails
+        salt -C 'I@roles:ganesha' service.restart nfs-ganesha || echo # for some reason, first restart always fails
+        salt -C 'I@roles:ganesha' service.restart nfs-ganesha 
+        salt ${NFS_GANESHA_primary_node} cmd.run "crm resource cleanup nfs-ganesha-server"
+        salt ${NFS_GANESHA_primary_node} cmd.run "crm status"
+}
+function ha_ganesha_ip_failover {
+        NFS_GANESHA_primary_node_fqdn=$(_get_fqdn_from_salt_grain_key ceph_ganesha_HA_master_node)
+        NFS_GANESHA_primary_node=${NFS_GANESHA_primary_node_fqdn%%\.*}
+        echo "Primary nfs-ganesha node is : " $NFS_GANESHA_primary_node_fqdn
+        NFS_GANESHA_secondary_node_fqdn=$(_get_fqdn_from_pillar_role ganesha|grep -v $NFS_GANESHA_primary_node)
+        NFS_GANESHA_secondary_node=${NFS_GANESHA_secondary_node_fqdn%%\.*}
+        echo "Secondary nfs-ganesha node is : " $NFS_GANESHA_secondary_node_fqdn
+        current_ganesha_ip_node=$(salt ${NFS_GANESHA_primary_node_fqdn} cmd.run "crm status"|grep ganesha-ip|awk '{print $4}')
+        echo 'Current ganesha-ip node is :' $current_ganesha_ip_node
+        if [[ $current_ganesha_ip_node == $NFS_GANESHA_primary_node ]]; then
+                failover_node=$NFS_GANESHA_secondary_noden
+        else
+                failover_node=$NFS_GANESHA_primary_node
+        fi
+        salt ${NFS_GANESHA_primary_node_fqdn} cmd.run "crm resource migrate ganesha-ip $failover_node"
+        sleep 3
+}
+

--- a/qa/suites/ceph-test/nfs-ha.sh
+++ b/qa/suites/ceph-test/nfs-ha.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+#
+# DeepSea integration test "suites/ceph-test/nfs-ha.sh"
+#
+# This script runs DeepSea stages 0-4 to deploy a Ceph cluster with NFS-Ganesha.
+# After stage 4 completes, it setup NFS HA, perform basic mount and R/W NFS client test. 
+# Also failover of HA IP is triggered and client tests are done again. 
+#
+# ** IMPORTANT ** Mandatory argument is IP address of NFS HA - free virtual, not used IP addr 
+# EXAMPLE: ./suites/ceph-test/nfs-ha.sh 192.168.100.100 
+# Minumum number of nodes is 3 : 2x NFS-Ganesha nodes and 1x client node. 
+# REQUIREMENT: ha-cluster-bootstrap packege is available 
+#
+# On success, the script returns 0. On failure, for whatever reason, the script
+# returns non-zero.
+#
+# The script produces verbose output on stdout, which can be captured for later
+# forensic analysis.
+
+set -ex
+BASEDIR=$(pwd)
+source $BASEDIR/common/common.sh
+source $BASEDIR/common/nfs-ganesha.sh
+
+if [ $# == 0 ] ; then echo "Terminating..." >&2 ; exit 1 ; fi # no input argument 
+
+install_deps
+cat_salt_config
+run_stage_0
+salt_api_test
+run_stage_1
+policy_cfg_base
+policy_cfg_mon_flex
+policy_cfg_mds
+policy_cfg_rgw
+rgw_demo_users
+policy_cfg_nfs_ganesha 2 # will deploy 2 NFS-Ganesha nodes 
+policy_cfg_storage 1 # last node will be "client" (not storage)
+cat_policy_cfg  
+run_stage_2
+ceph_conf_small_cluster
+run_stage_3
+ceph_cluster_status
+create_all_pools_at_once cephfs_data cephfs_metadata
+nfs_ganesha_no_root_squash
+run_stage_4
+ceph_health_test
+nfs_ganesha_cat_config_file
+nfs_ganesha_debug_log
+# NFS_HA
+set_NFS_HA_IP $1
+nfs_ganesha_disable_service
+set_NFS_HA_primary_node
+nfs_ha_cluster_bootstrap
+sleep 5
+for v in "" "3" "4" ; do nfs_ganesha_mount "$v" root $1; sleep 5; nfs_ganesha_umount root;done 
+ha_ganesha_ip_failover
+salt -C 'I@roles:ganesha' service.status nfs-ganesha
+sleep 5
+for v in "" "3" "4" ; do nfs_ganesha_mount "$v" root $1; sleep 5; nfs_ganesha_umount root;done 
+ha_ganesha_ip_failover
+salt -C 'I@roles:ganesha' service.status nfs-ganesha
+sleep 5
+for v in "" "3" "4" ; do nfs_ganesha_mount "$v" root $1; sleep 5; nfs_ganesha_umount root;done 
+
+echo "OK"
+


### PR DESCRIPTION
Added test case for testing NFS-ganesha HA active-pasive configuration.
Limitations: when running **suites/ceph-test/nfs-ha.sh**, mandatory argument is **cluster IP**, which needs to be set manually. If there is no connection to download.suse.de, there should be other way to provide **ha-cluster-bootstrap** packege.

Modified functions: 
- policy_cfg_nfs_ganesha: takes number of nfs-ganesha nodes do deploy as first argument 
- nfs_ganesha_mount: takes 3rd argument to be mount IP (in case multiple or ha nfs-ganesha nodes )

New functions: 
- _get_fqdn_from_pillar_role
- _get_fqdn_from_salt_grain_key
- _get_salt_grain_value
- set_NFS_HA_IP
- nfs_ganesha_disable_service
- set_NFS_HA_primary_node
- get_NFS_HA_IP
- nfs_ha_cluster_bootstrap
- ha_ganesha_ip_failover