### PR TITLE
qa: run zypper refresh in try/wait loop

### DIFF
--- a/deepsea.spec.in
+++ b/deepsea.spec.in
@@ -708,6 +708,7 @@ orchestration completes.
 %package qa
 Summary:        DeepSea integration test scripts
 Group:          System/Libraries
+Requires:       jq
 Recommends:     deepsea
 
 %description qa

--- a/qa/common/common.sh
+++ b/qa/common/common.sh
@@ -68,11 +68,20 @@ function assert_enhanced_getopt {
 # functions for setting up the Salt Master node so it can run these tests
 #
 
+function zypper_ref {
+    set +x
+    for delay in 60 60 60 60 ; do
+        zypper --non-interactive --gpg-auto-import-keys refresh && break
+        sleep $delay
+    done
+    set -x
+}
+
 function install_deps {
   echo "Installing dependencies on the Salt Master node"
-  DEPENDENCIES="jq
+  local DEPENDENCIES="jq
   "
-  zypper --non-interactive --no-gpg-checks refresh
+  zypper_ref
   for d in $DEPENDENCIES ; do
     zypper --non-interactive install --no-recommends $d
   done
@@ -92,7 +101,7 @@ function run_stage_1 {
 }
 
 function run_stage_2 {
-  salt '*' cmd.run "zypper --non-interactive --no-gpg-checks refresh"
+  salt '*' cmd.run "for delay in 60 60 60 60 ; do sudo zypper --non-interactive --gpg-auto-import-keys refresh && break ; sleep $delay ; done"
   _run_stage 2 "$@"
   salt_pillar_items
 }
@@ -659,9 +668,13 @@ function iscsi_mount_and_sanity_test {
   local CLIENTNODE=$(_client_node)
   local IGWNODE=$(_first_x_node igw)
   cat << EOF > $TESTSCRIPT
-set -ex
+set -e
 trap 'echo "Result: NOT_OK"' ERR
-zypper --non-interactive --no-gpg-checks refresh
+for delay in 60 60 60 60 ; do
+    sudo zypper --non-interactive --gpg-auto-import-keys refresh && break
+    sleep $delay
+done
+set -x
 zypper --non-interactive install --no-recommends open-iscsi multipath-tools
 systemctl start iscsid.service
 sleep 5

--- a/qa/common/common.sh
+++ b/qa/common/common.sh
@@ -22,6 +22,9 @@ else
     exit 1
 fi
 
+# show which repos are active/enabled
+zypper lr -upEP
+
 # show salt RPM version in log and fail if salt is not installed
 rpm -q salt-master
 rpm -q salt-minion

--- a/qa/common/nfs-ganesha.sh
+++ b/qa/common/nfs-ganesha.sh
@@ -150,6 +150,12 @@ function assert_success {
 }
 
 echo "nfs-ganesha PyNFS test script running as $(whoami) on $(hostname --fqdn)"
+set +x
+for delay in 60 60 60 60 ; do
+    sudo zypper --non-interactive --gpg-auto-import-keys refresh && break
+    sleep $delay
+done
+set -x
 zypper --non-interactive install --no-recommends krb5-devel python3-devel
 git clone --depth 1 https://github.com/supriti/Pynfs
 cd Pynfs

--- a/qa/common/rgw.sh
+++ b/qa/common/rgw.sh
@@ -65,7 +65,12 @@ set -ex
 trap 'echo "Result: NOT_OK"' ERR
 echo "rgw curl test running as $(whoami) on $(hostname --fqdn)"
 RGWNODE=$(salt --no-color -C "I@roles:rgw" test.ping | grep -o -P '^\S+(?=:)' | head -1)
-zypper --non-interactive --no-gpg-checks refresh
+set +x
+for delay in 60 60 60 60 ; do
+    sudo zypper --non-interactive --gpg-auto-import-keys refresh && break
+    sleep $delay
+done
+set -x
 zypper --non-interactive install --no-recommends curl libxml2-tools
 RGWXMLOUT=/tmp/rgw_test.xml
 curl $RGWNODE > $RGWXMLOUT
@@ -86,10 +91,15 @@ set -ex
 trap 'echo "Result: NOT_OK"' ERR
 echo "rgw curl test running as $(whoami) on $(hostname --fqdn)"
 RGWNODE=$(salt --no-color -C "I@roles:rgw" test.ping | grep -o -P '^\S+(?=:)' | head -1)
-zypper --non-interactive --no-gpg-checks refresh
+set +x
+for delay in 60 60 60 60 ; do
+    sudo zypper --non-interactive --gpg-auto-import-keys refresh && break
+    sleep $delay
+done
+set -x
 zypper --non-interactive install --no-recommends curl libxml2-tools
 RGWXMLOUT=/tmp/rgw_test.xml
-curl -k https://$RGWNODE  > $RGWXMLOUT
+curl -k https://$RGWNODE > $RGWXMLOUT
 test -f $RGWXMLOUT
 xmllint $RGWXMLOUT
 grep anonymous $RGWXMLOUT


### PR DESCRIPTION
Fixes: https://github.com/SUSE/DeepSea/issues/977

(This fixes the problem to the extent that it occurs in the test code. It does not help when zypper is being run by `pkg.installed` calls within DeepSea orchestrations.)