### PR TITLE
QA test  - migration from filestore to bluestore

### DIFF
--- a/qa/suites/ceph-test/fs_to_bs_migration.sh
+++ b/qa/suites/ceph-test/fs_to_bs_migration.sh
@@ -23,7 +23,7 @@ run_stage_1
 policy_cfg_base
 policy_cfg_mon_flex
 policy_cfg_storage # no node will be a "client"
-configure_OSD_to_filestore
+configure_all_OSDs_to_filestore
 cat_policy_cfg
 run_stage_2
 ceph_conf_small_cluster
@@ -31,10 +31,10 @@ ceph_conf_mon_allow_pool_delete
 run_stage_3
 ceph_cluster_status
 ceph_health_test
-check_OSD_type
+check_OSD_type filestore
 migrate_to_bluestore
 ceph_health_test
-check_OSD_type
+check_OSD_type bluestore
 
 echo "OK"
 

--- a/qa/suites/ceph-test/fs_to_bs_migration.sh
+++ b/qa/suites/ceph-test/fs_to_bs_migration.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+#
+# DeepSea integration test "suites/ceph-test/fs_to_bs_migration.sh"
+#
+# This script deploys a basic cluster with filestore type of OSDs,
+# after cluster is healthy, migrate to bluestore OSD type. 
+#
+# On success, the script returns 0. On failure, for whatever reason, the script
+# returns non-zero.
+#
+# The script produces verbose output on stdout, which can be captured for later
+# forensic analysis.
+
+set -ex
+BASEDIR=$(pwd)
+source $BASEDIR/common/common.sh
+
+install_deps
+cat_salt_config
+disable_restart_in_stage_0
+run_stage_0
+run_stage_1
+policy_cfg_base
+policy_cfg_mon_flex
+policy_cfg_storage # no node will be a "client"
+configure_OSD_to_filestore
+cat_policy_cfg
+run_stage_2
+ceph_conf_small_cluster
+ceph_conf_mon_allow_pool_delete
+run_stage_3
+ceph_cluster_status
+ceph_health_test
+check_OSD_type
+migrate_to_bluestore
+ceph_health_test
+check_OSD_type
+
+echo "OK"
+


### PR DESCRIPTION
# QA test  - migration from filestore to bluestore 

New QA test case for testing migration from filestore to bluestore:
- Disabled restart in stage 0
- Cluster deployed with filestore OSDs
- Then migration run with DS command ceph.migrate.osds
- No services deployed, not special settings for OSDs

New functions added to common.sh :
- configure_OSD_to_filestore
- check_OSD_type
- migrate_to_bluestore
- disable_restart_in_stage_0