### PR TITLE
monitoring: move node_exporter install to its own sls

### DIFF
--- a/srv/salt/ceph/monitoring/prometheus/exporters/node_exporter.sls
+++ b/srv/salt/ceph/monitoring/prometheus/exporters/node_exporter.sls
@@ -1,32 +1,6 @@
-{% if grains.get('os', '') == 'CentOS' %}
-install_prometheus_repo:
-  pkgrepo.managed:
-    - name: prometheus-rpm_release
-    - humanname: Prometheus release repo
-    - baseurl: https://packagecloud.io/prometheus-rpm/release/el/$releasever/$basearch
-    - gpgcheck: False
-    - enabled: True
-    - fire_event: True
-
-install_node_exporter:
-  pkg.installed:
-    - name: node_exporter
-    - refresh: True
-    - fire_event: True
-
-{% else %}
-
-install node exporter package:
-  pkg.installed:
-    - name: golang-github-prometheus-node_exporter
-    - refresh: True
-    - fire_event: True
-
-{% endif %}
-
 # this switch should detect whicch node_exporter version we have. From 0.15.2
 # the node exporter options start with -- and additional options exist
-{% if salt['cmd.run']('node_exporter -h 2>&1 | grep "\-\-"') == "" %}
+{% if salt['cmd.run']('node_exporter -h 2>&1 | grep -q "\-\-"') != 0 %}
 
 set node exporter service args:
   file.managed:

--- a/srv/salt/ceph/monitoring/prometheus/exporters/node_exporter_package.sls
+++ b/srv/salt/ceph/monitoring/prometheus/exporters/node_exporter_package.sls
@@ -1,0 +1,25 @@
+{% if grains.get('os', '') == 'CentOS' %}
+install_prometheus_repo:
+  pkgrepo.managed:
+    - name: prometheus-rpm_release
+    - humanname: Prometheus release repo
+    - baseurl: https://packagecloud.io/prometheus-rpm/release/el/$releasever/$basearch
+    - gpgcheck: False
+    - enabled: True
+    - fire_event: True
+
+install_node_exporter:
+  pkg.installed:
+    - name: node_exporter
+    - refresh: True
+    - fire_event: True
+
+{% else %}
+
+install node exporter package:
+  pkg.installed:
+    - name: golang-github-prometheus-node_exporter
+    - refresh: True
+    - fire_event: True
+
+{% endif %}

--- a/srv/salt/ceph/stage/configure/default.sls
+++ b/srv/salt/ceph/stage/configure/default.sls
@@ -38,6 +38,12 @@ setup monitoring:
     - tgt_type: compound
     - sls: ceph.monitoring
 
+install node exporters:
+  salt.state:
+    - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
+    - tgt_type: compound
+    - sls: ceph.monitoring.prometheus.exporters.node_exporter_package
+
 setup node exporters:
   salt.state:
     - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'


### PR DESCRIPTION
This is needed so the jinja if statement in node_exporter.sls is
executed after the package was installed.
Fixes: #981

Signed-off-by: Jan Fajerski <jfajerski@suse.com>