### PR TITLE
Create cli subpackage

### DIFF
--- a/deepsea.spec.in
+++ b/deepsea.spec.in
@@ -32,18 +32,16 @@ Url:            https://github.com/suse/deepsea
 Source0:        %{name}-%{version}.tar.bz2
 
 BuildRequires:  salt-master
-BuildRequires:  python3-setuptools
 Requires:       salt-master
 Requires:       salt-minion
 Requires:       salt-api
 Requires:       python3-netaddr
 Requires:       python3-rados
-Requires:       python3-setuptools
 Requires:       python3-configobj
 Requires:       python3-six
-Requires:       python3-click
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 BuildArch:      noarch
+Recommends:     deepsea-cli
 
 %description
 A collection of Salt files providing a deployment of Ceph as a series of stages.
@@ -78,9 +76,6 @@ systemctl try-restart salt-api > /dev/null 2>&1 || :
 
 %files
 %defattr(-,root,root,-)
-%{_bindir}/deepsea
-%{python3_sitelib}/deepsea/
-%{python3_sitelib}/deepsea-%{version}-py%{python3_version}.egg-info
 /srv/modules/pillar/stack.py*
 %dir %attr(0755, salt, salt) /srv/pillar/ceph
 %dir %attr(0755, salt, salt) /srv/pillar/ceph/stack
@@ -692,6 +687,23 @@ systemctl try-restart salt-api > /dev/null 2>&1 || :
 %dir %{_libexecdir}/deepsea
 %dir %attr(-, root, root) %{_docdir}/%{name}
 %{_docdir}/%{name}/*
+
+%package cli
+Summary:        DeepSea command line
+Group:          System/Console
+BuildRequires:  python3-setuptools
+Requires:       python3-setuptools
+Requires:       python3-click
+
+%description cli
+The deepsea-cli contains the deepsea command.  This command reports the
+progress of orchestrations.  The default Salt behavior is silent until an
+orchestration completes.
+
+%files cli
+%{_bindir}/deepsea
+%{python3_sitelib}/deepsea/
+%{python3_sitelib}/deepsea-%{version}-py%{python3_version}.egg-info
 
 %package qa
 Summary:        DeepSea integration test scripts


### PR DESCRIPTION
Signed-off-by: Eric Jackson <ejackson@suse.com>

Partly addresses #993 by moving the abi requirement.  Also, I think the requires communicate a bit better to anyone wanting to understand the dependency differences between the Salt portions and the cli.

Also, I do not know if I have the best wording for the cli description.
