### PR TITLE
Tuning Chrony

### DIFF
--- a/srv/salt/ceph/time/chrony/files/chrony.conf.j2
+++ b/srv/salt/ceph/time/chrony/files/chrony.conf.j2
@@ -12,8 +12,8 @@ server {{ server }} iburst
 driftfile /var/lib/chrony/drift
 
 # In first three updates step the system clock instead of slew
-# if the adjustment is larger than 1 second.
-makestep 1.0 3
+# if the adjustment is larger than 0.1 second.
+makestep 0.1 3
 
 # Enable kernel synchronization of the real-time clock (RTC).
 rtcsync


### PR DESCRIPTION
The 1 second default is too large for Ceph.  Trying 1/10th.
Signed-off-by: Eric Jackson <ejackson@suse.com>

While experimenting with the qa suite, Ceph complained about a clock skew.  Restarting chrony  had no effect because the time difference was 120ms.  