### PR TITLE
Copy the generated setup.py back to the builddir in order to make tox happy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -779,6 +779,7 @@ tarball:
 	sed "s/DEVVERSION/"$(VERSION)"/" $(TEMPDIR)/deepsea-$(VERSION)/deepsea.spec.in > $(TEMPDIR)/deepsea-$(VERSION)/deepsea.spec
 	sed -i "s/DEVVERSION/"$(VERSION)"/" $(TEMPDIR)/deepsea-$(VERSION)/srv/modules/runners/deepsea.py
 	mkdir -p ~/rpmbuild/SOURCES
+	cp $(TEMPDIR)/deepsea-$(VERSION)/setup.py .
 	tar -cjf ~/rpmbuild/SOURCES/deepsea-$(VERSION).tar.bz2 -C $(TEMPDIR) .
 	rm -r $(TEMPDIR)
 


### PR DESCRIPTION
Description:

'make rpm' is broken.

Reproducer:

rm setup.py (that is carried over from older branches)
make rpm

> 
> raise tox.exception.MissingFile(setup)
> tox.MissingFile: MissingFile: /home/jxs/projects/deepsea/setup.py
> make: *** [Makefile:787: test] Error 1
>

Signed-off-by: Joshua Schmid <jschmid@suse.de>

-----------------

[Please find more information on how to run integration tests here](https://github.com/SUSE/DeepSea/wiki/Integration-tests)
