### PR TITLE
[backport][SES5]populate: support multiple public, cluster networks in engulf (bsc#1076010)

### DIFF
--- a/srv/modules/runners/populate.py
+++ b/srv/modules/runners/populate.py
@@ -972,11 +972,12 @@ def _replace_key_in_cluster_yml(key, val):
 
     return True
 
-def _get_existing_cluster_network(addrs, public_network=None):
+
+def _get_existing_cluster_networks(addrs, public_networks=[]):
     """
-    Based on the addrs dictionary { minion: [ ipaddress ] }, this function
-    returns an address consisting of network prefix followed by the cidr
-    prefix (ie. 10.0.0.0/24), or None.
+    Based on the addrs dictionary { minion: [ipaddress] }, this function
+    returns a list of addresses consisting of network prefix followed by the
+    cidr prefix (e.g. [ "10.0.0.0/24" ]).  It may return an empty list.
     """
     target = deepsea_minions.DeepseaMinions()
     search = target.deepsea_minions
@@ -984,11 +985,10 @@ def _get_existing_cluster_network(addrs, public_network=None):
     local = salt.client.LocalClient()
     # Stores the derived network addresses (in CIDR notation) of all addresses contained in addrs.
     minion_networks = []
-    # The network address (in CIDR notation) that we return after collapsing minion_networks,
-    # or None.
-    network = None
 
     # Grab network interfaces from salt.
+    # TODO: see if we can use network.ip_addrs (see Fio object in benchmark.py)
+    # instead of network.interfaces to simplify the following code
     minion_network_interfaces = local.cmd(search, "network.interfaces", [], expr_form="compound")
     # Remove lo.
     for entry in minion_network_interfaces:
@@ -1004,25 +1004,30 @@ def _get_existing_cluster_network(addrs, public_network=None):
                 if "inet" in data:
                     for inet_data in data["inet"]:
                         if i == "0.0.0.0":
-                            # If running on 0.0.0.0, assume we can use public_network
-                            ip = ipaddress.ip_interface(u"{}".format(public_network)) if public_network else ipaddress.ip_interface(u"{}/{}".format(i, inet_data["netmask"]))
-                            minion_networks.append(str(ip.network))
+                            # If running on 0.0.0.0, assume we can use public_networks
+                            if public_networks:
+                                for n in public_networks:
+                                    ip = ipaddress.ip_interface(u"{}".format(n))
+                                    minion_networks.append(str(ip.network))
+                            else:
+                                ip = ipaddress.ip_interface(u"{}/{}".format(i, inet_data["netmask"]))
+                                minion_networks.append(str(ip.network))
                         elif inet_data["address"] == i:
                             ip = ipaddress.ip_interface(u"{}/{}".format(inet_data["address"], inet_data["netmask"]))
                             minion_networks.append(str(ip.network))
 
-    # Check for consistency across all entries.
-    if len(set(minion_networks)) == 1:
-        # We have equal entries.
-        network = minion_networks[0]
-    else:
-        # We have multiple possible networks.  This is liable to happen with OSDs
-        # when there is a private cluster network.  Let's try to remove the public
-        # network.
-        minion_networks = [ n for n in minion_networks if n != public_network ]
-        network = minion_networks[0] if len(set(minion_networks)) == 1 else None
+    # Collapse minion_networks back to unique items.  Usually there'll
+    # be only one network after this, unless the cluster is using a
+    # separate public and private network, or is using multiple public
+    # and/or private networks
+    minion_networks = set(minion_networks)
 
-    return network
+    # in the case where there's multiple networks, and a list of public
+    # networks was passed in, strip the public networks (this is used
+    # when trying to figure out what the cluter network(s) is/are
+    minion_networks = [n for n in minion_networks if not n in public_networks]
+
+    return minion_networks
 
 def _replace_fsid_with_existing_cluster(fsid):
     """
@@ -1033,32 +1038,36 @@ def _replace_fsid_with_existing_cluster(fsid):
 
 def _replace_public_network_with_existing_cluster(mon_addrs):
     """
-    Replace proposed public_network with public_network of the running cluster.
-    Returns { 'ret': True/False, 'public_network': string/None }
+    Replace proposed public_network with public_network(s) of the running cluster.
+    Returns { 'ret': True/False, 'public_networks': list of networks }
     """
-    public_network = _get_existing_cluster_network(mon_addrs)
-    if not public_network:
+    public_networks = _get_existing_cluster_networks(mon_addrs)
+    if not public_networks:
         log.error("Failed to determine cluster's public_network.")
-        return { 'ret': False, 'public_network': None }
+        return { 'ret': False, 'public_networks': [] }
     else:
-        return { 'ret': _replace_key_in_cluster_yml("public_network", public_network),
-                 'public_network': public_network }
+        return { 'ret': _replace_key_in_cluster_yml("public_network",
+                                                    ", ".join(public_networks)),
+                 'public_networks': public_networks }
 
-def _replace_cluster_network_with_existing_cluster(osd_addrs, public_network=None):
+
+def _replace_cluster_network_with_existing_cluster(osd_addrs, public_networks=[]):
     """
-    Replace proposed cluster_network with cluster_network of the running cluster.
-    If a public_network is already provided, pass that along as a fallback for
-    _get_existing_cluster_network() to use when cluster_network is found to
-    be 0.0.0.0, and to filter the public_network from the derived cluster_network.
-    Returns { 'ret': True/False, 'cluster_network': string/None }
+    Replace proposed cluster_network with cluster_network(s) of the running cluster.
+    If a public_networks is provided, pass that along as a fallback for
+    _get_existing_cluster_networks() to use when cluster_network is found to
+    be 0.0.0.0, and to filter the public_networks from the derived cluster_networks.
+    Returns { 'ret': True/False, 'cluster_networks': list of networks }
     """
-    cluster_network = _get_existing_cluster_network(osd_addrs, public_network)
-    if not cluster_network:
+    cluster_networks = _get_existing_cluster_networks(osd_addrs, public_networks)
+    if not cluster_networks:
         log.error("Failed to determine cluster's cluster_network.")
-        return { 'ret': False, 'cluster_network': None }
+        return { 'ret': False, 'cluster_networks': [] }
     else:
-        return { 'ret': _replace_key_in_cluster_yml("cluster_network", cluster_network),
-                 'cluster_network': cluster_network }
+        return { 'ret': _replace_key_in_cluster_yml("cluster_network",
+                                                    ", ".join(cluster_networks)),
+                 'cluster_networks': cluster_networks }
+
 
 def engulf_existing_cluster(**kwargs):
     """
@@ -1306,7 +1315,8 @@ def engulf_existing_cluster(**kwargs):
         log.error("Failed to replace derived public_network with public_network of existing cluster.")
         return [ False ]
 
-    c_net_dict = _replace_cluster_network_with_existing_cluster(osd_addrs, p_net_dict['public_network'])
+    c_net_dict = _replace_cluster_network_with_existing_cluster(osd_addrs,
+                                                                p_net_dict['public_networks'])
     if not c_net_dict['ret']:
         log.error("Failed to replace derived cluster_network with cluster_network of existing cluster.")
         return [ False ]


### PR DESCRIPTION
This removes the assumption in the engulfer that there can be no more
than one public or cluster network.  Without this change, running engulf
on a cluster with (e.g.) public_network = 10.27.21.0/24, 10.27.20.0/24
will result in the following error:

  [ERROR   ] Failed to determine cluster's public_network.
  [ERROR   ] Failed to replace derived public_network with public_network
             of existing cluster.

Note that this still leaves the public_network and cluster_network settings
as strings in the pillar data (changing the pillar data to be an array would
have been somewhat more invasive).

Fixes: https://bugzilla.suse.com/show_bug.cgi?id=1076010
Fixes: https://github.com/SUSE/DeepSea/issues/582
Signed-off-by: Tim Serong <tserong@suse.com>
(cherry picked from commit 205ed7c10f38e49db0400516e816241a6f5204c6)

Fixes #


Description:


-----------------

[Please find more information on how to run integration tests here](https://github.com/SUSE/DeepSea/wiki/Integration-tests)
