### PR TITLE
refactor ceph_rgw_exporter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -289,6 +289,10 @@ copy-files:
 	install -m 644 srv/salt/ceph/monitoring/prometheus/exporters/files/* $(DESTDIR)/srv/salt/ceph/monitoring/prometheus/exporters/files
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/monitoring/prometheus/exporters/ceph_rgw_exporter
 	install -m 644 srv/salt/ceph/monitoring/prometheus/exporters/ceph_rgw_exporter/*.sls $(DESTDIR)/srv/salt/ceph/monitoring/prometheus/exporters/ceph_rgw_exporter
+	install -d -m 755 $(DESTDIR)/srv/salt/ceph/monitoring/prometheus/exporters/ceph_rgw_exporter/CentOS
+	install -m 644 srv/salt/ceph/monitoring/prometheus/exporters/ceph_rgw_exporter/CentOS/*.sls $(DESTDIR)/srv/salt/ceph/monitoring/prometheus/exporters/ceph_rgw_exporter/CentOS
+	install -d -m 755 $(DESTDIR)/srv/salt/ceph/monitoring/prometheus/exporters/ceph_rgw_exporter/SLES-15
+	install -m 644 srv/salt/ceph/monitoring/prometheus/exporters/ceph_rgw_exporter/SLES-15/*.sls $(DESTDIR)/srv/salt/ceph/monitoring/prometheus/exporters/ceph_rgw_exporter/SLES-15
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/monitoring/prometheus/exporters/ceph_rgw_exporter/cron
 	install -m 644 srv/salt/ceph/monitoring/prometheus/exporters/ceph_rgw_exporter/cron/*.sls $(DESTDIR)/srv/salt/ceph/monitoring/prometheus/exporters/ceph_rgw_exporter/cron
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/monitoring/prometheus/exporters/ceph_rgw_exporter/files

--- a/deepsea.spec.in
+++ b/deepsea.spec.in
@@ -177,6 +177,8 @@ systemctl try-restart salt-api > /dev/null 2>&1 || :
 %dir /srv/salt/ceph/monitoring/prometheus
 %dir /srv/salt/ceph/monitoring/prometheus/exporters
 %dir /srv/salt/ceph/monitoring/prometheus/exporters/ceph_rgw_exporter
+%dir /srv/salt/ceph/monitoring/prometheus/exporters/ceph_rgw_exporter/CentOS
+%dir /srv/salt/ceph/monitoring/prometheus/exporters/ceph_rgw_exporter/SLES-15
 %dir /srv/salt/ceph/monitoring/prometheus/exporters/ceph_rgw_exporter/cron
 %dir /srv/salt/ceph/monitoring/prometheus/exporters/ceph_rgw_exporter/files
 %dir /srv/salt/ceph/monitoring/prometheus/exporters/ceph_rgw_exporter/files/__pycache__
@@ -487,6 +489,8 @@ systemctl try-restart salt-api > /dev/null 2>&1 || :
 %config /srv/salt/ceph/monitoring/prometheus/*.sls
 %config /srv/salt/ceph/monitoring/prometheus/exporters/*.sls
 %config /srv/salt/ceph/monitoring/prometheus/exporters/ceph_rgw_exporter/*.sls
+%config /srv/salt/ceph/monitoring/prometheus/exporters/ceph_rgw_exporter/CentOS/*.sls
+%config /srv/salt/ceph/monitoring/prometheus/exporters/ceph_rgw_exporter/SLES-15/*.sls
 %config /srv/salt/ceph/monitoring/prometheus/exporters/ceph_rgw_exporter/cron/*.sls
 %config /srv/salt/ceph/monitoring/prometheus/exporters/ceph_rgw_exporter/files/*.py
 %config /srv/salt/ceph/monitoring/prometheus/exporters/ceph_rgw_exporter/files/__pycache__/*.pyc

--- a/srv/salt/ceph/monitoring/prometheus/exporters/ceph_rgw_exporter/CentOS/default-install.sls
+++ b/srv/salt/ceph/monitoring/prometheus/exporters/ceph_rgw_exporter/CentOS/default-install.sls
@@ -1,0 +1,4 @@
+install_package:
+  pkg.installed:
+    - name: python2-prometheus_client
+    - refresh: True

--- a/srv/salt/ceph/monitoring/prometheus/exporters/ceph_rgw_exporter/CentOS/default.sls
+++ b/srv/salt/ceph/monitoring/prometheus/exporters/ceph_rgw_exporter/CentOS/default.sls
@@ -1,0 +1,4 @@
+include:
+  - .default-install
+  - ..default-exporter
+  - ..cron

--- a/srv/salt/ceph/monitoring/prometheus/exporters/ceph_rgw_exporter/CentOS/init.sls
+++ b/srv/salt/ceph/monitoring/prometheus/exporters/ceph_rgw_exporter/CentOS/init.sls
@@ -1,0 +1,3 @@
+
+include:
+  - .{{ salt['pillar.get']('monitoring_prometheus_exporters_ceph_rgw_exporter_CentOS', 'default') }}

--- a/srv/salt/ceph/monitoring/prometheus/exporters/ceph_rgw_exporter/SLES-15/default-install.sls
+++ b/srv/salt/ceph/monitoring/prometheus/exporters/ceph_rgw_exporter/SLES-15/default-install.sls
@@ -1,0 +1,4 @@
+install_package:
+  pkg.installed:
+    - name: python3-prometheus-client
+    - refresh: True

--- a/srv/salt/ceph/monitoring/prometheus/exporters/ceph_rgw_exporter/SLES-15/default.sls
+++ b/srv/salt/ceph/monitoring/prometheus/exporters/ceph_rgw_exporter/SLES-15/default.sls
@@ -1,0 +1,4 @@
+include:
+  - .default-install
+  - ..default-exporter
+  - ..cron

--- a/srv/salt/ceph/monitoring/prometheus/exporters/ceph_rgw_exporter/SLES-15/init.sls
+++ b/srv/salt/ceph/monitoring/prometheus/exporters/ceph_rgw_exporter/SLES-15/init.sls
@@ -1,0 +1,3 @@
+
+include:
+  - .{{ salt['pillar.get']('monitoring_prometheus_exporters_ceph_rgw_exporter_SLE-15', 'default') }}

--- a/srv/salt/ceph/monitoring/prometheus/exporters/ceph_rgw_exporter/default-exporter.sls
+++ b/srv/salt/ceph/monitoring/prometheus/exporters/ceph_rgw_exporter/default-exporter.sls
@@ -1,0 +1,9 @@
+install_rgw_exporter:
+  file.managed:
+    - name: /var/lib/prometheus/node-exporter/ceph_rgw.py
+    - user: prometheus
+    - group: prometheus
+    - mode: 755
+    - source: salt://ceph/monitoring/prometheus/exporters/ceph_rgw_exporter/files/ceph_rgw.py
+    - makedirs: True
+

--- a/srv/salt/ceph/monitoring/prometheus/exporters/ceph_rgw_exporter/default-install.sls
+++ b/srv/salt/ceph/monitoring/prometheus/exporters/ceph_rgw_exporter/default-install.sls
@@ -1,0 +1,5 @@
+install_package:
+  pkg.installed:
+    - name: python-prometheus-client
+    - refresh: True
+

--- a/srv/salt/ceph/monitoring/prometheus/exporters/ceph_rgw_exporter/default.sls
+++ b/srv/salt/ceph/monitoring/prometheus/exporters/ceph_rgw_exporter/default.sls
@@ -1,20 +1,4 @@
-install_package:
-  pkg.installed:
-  {% if grains.get('os', '') == 'CentOS' %}
-    - name: python2-prometheus_client
-  {% else %}
-    - name: python3-prometheus-client
-  {% endif %}
-    - refresh: True
-
-install_rgw_exporter:
-  file.managed:
-    - name: /var/lib/prometheus/node-exporter/ceph_rgw.py
-    - user: prometheus
-    - group: prometheus
-    - mode: 755
-    - source: salt://ceph/monitoring/prometheus/exporters/ceph_rgw_exporter/files/ceph_rgw.py
-    - makedirs: True
-
 include:
+  - .default-install
+  - .default-exporter
   - .cron

--- a/srv/salt/ceph/monitoring/prometheus/exporters/ceph_rgw_exporter/init.sls
+++ b/srv/salt/ceph/monitoring/prometheus/exporters/ceph_rgw_exporter/init.sls
@@ -1,3 +1,20 @@
 
+{% set osfinger = grains.get('osfinger') %}
+{% set os = grains.get('os') %}
+{% set osrelease = os + "-" + grains.get('osrelease') %}
+
+{% set abspath = "/srv/salt/" + slspath %}
+{% set custom = salt['pillar.get']('monitoring_prometheus_exporters_ceph_rgw_exporter', 'not a file') %}
+
 include:
-  - .{{ salt['pillar.get']('monitoring_prometheus_exporters_ceph_rgw_exporter_init', 'default') }}
+{% if salt['file.directory_exists'](abspath + "/" +  custom) %}
+  - .{{ custom }}
+{% elif salt['file.directory_exists'](abspath + "/" +  osfinger) %}
+  - .{{ osfinger }}
+{% elif salt['file.directory_exists'](abspath + "/" + osrelease) %}
+  - .{{ osrelease }}
+{% elif salt['file.directory_exists'](abspath + "/" + os) %}
+  - .{{ os }}
+{% else %}
+  - .default
+{% endif %}


### PR DESCRIPTION
Signed-off-by: Eric Jackson <ejackson@suse.com>

Description:
SLE-15 changed package name, implement distro init.sls
This addresses the same issue as #1010, but using the #998 approach.  I ran into the same problem #1009 but thought this would work as an ideal example since the original change is minor.

The default is still python-prometheus-client, but CentOS and SLES-15 have specific package names.  All three share default-exporter logic, so no duplicate code.  I think this is about as ideal as it gets for refactoring a configuration into DRY setup that is fairly obvious.