### PR TITLE
Support kwargs in orchestrations

### DIFF
--- a/srv/modules/runners/proposal.py
+++ b/srv/modules/runners/proposal.py
@@ -121,6 +121,11 @@ def _parse_args(kwargs):
     """
     args = STD_ARGS.copy()
     args.update(kwargs)
+    if 'kwargs' in kwargs:
+        args.update(kwargs['kwargs'])
+        args.pop('kwargs')
+    log.info("args: {}".format(args))
+
     if args.get('name') == 'import':
         print(('ERROR: profile name import is a reserved name. Please use'
               ' another name'))

--- a/srv/salt/ceph/stage/discovery/default-nvme.sls
+++ b/srv/salt/ceph/stage/discovery/default-nvme.sls
@@ -1,0 +1,48 @@
+{% if salt['saltutil.runner']('validate.saltapi') == False %}
+
+salt-api failed:
+  salt.state:
+    - name: just.exit
+    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - failhard: True
+
+{% endif %}
+
+{% if salt['saltutil.runner']('validate.prep') == False %}
+
+validate failed:
+  salt.state:
+    - name: just.exit
+    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - failhard: True
+
+{% endif %}
+
+ready:
+  salt.runner:
+    - name: minions.ready
+    - timeout: {{ salt['pillar.get']('ready_timeout', 300) }}
+
+refresh_pillar0:
+  salt.state:
+    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - sls: ceph.refresh
+
+discover roles:
+  salt.runner:
+    - name: populate.proposals
+    - require:
+        - salt: refresh_pillar0
+
+
+discover storage profiles:
+  salt.runner:
+    - name: proposal.populate
+    - kwargs:
+        'name': 'prod'
+        'db-size': '59G'
+        'wal-size': '1G'
+        'nvme-spinner': True
+        'ratio': 12
+    - require:
+        - salt: refresh_pillar0


### PR DESCRIPTION
The proposal runner handles kwargs, but Salt is passing the kwargs dict
as a keyword 'kwargs'.  This change allows Stage 1 to be part of the
process rather than requiring manual discovery.

Signed-off-by: Eric Jackson <ejackson@suse.com>