### PR TITLE
ceph.conf: refrain from setting filestore_xattr_use_omap

### DIFF
--- a/srv/salt/ceph/configuration/files/ceph.conf-shared.j2
+++ b/srv/salt/ceph/configuration/files/ceph.conf-shared.j2
@@ -5,7 +5,6 @@ mon_host = {{ salt.saltutil.runner('select.public_addresses', cluster='ceph', ro
 auth_cluster_required = cephx
 auth_service_required = cephx
 auth_client_required = cephx
-filestore_xattr_use_omap = true
 public_network = {{ salt['pillar.get']('public_network') }}
 cluster_network = {{ salt['pillar.get']('cluster_network') }}
 rbd default features = 3

--- a/srv/salt/ceph/configuration/files/ceph.conf.j2
+++ b/srv/salt/ceph/configuration/files/ceph.conf.j2
@@ -8,7 +8,6 @@ mon_host = {{ salt.saltutil.runner('select.public_addresses', cluster='ceph', ro
 auth_cluster_required = cephx
 auth_service_required = cephx
 auth_client_required = cephx
-filestore_xattr_use_omap = true
 public_network = {{ salt['pillar.get']('public_network') }}
 cluster_network = {{ salt['pillar.get']('cluster_network') }}
 


### PR DESCRIPTION
This setting was recommended for Dumpling clusters that used
ext4-based filestore OSDs.

The setting was removed by
https://github.com/ceph/ceph/commit/dc0dfb9e01d593afdd430ca776cf4da2c2240a20
which was part of the 0.71 release.

Signed-off-by: Nathan Cutler <ncutler@suse.com>

Fixes #


Description:


-----------------

[Please find more information on how to run integration tests here](https://github.com/SUSE/DeepSea/wiki/Integration-tests)
