### PR TITLE
runner/ready: use aa-status instead of apparmor-status

### DIFF
--- a/srv/modules/runners/ready.py
+++ b/srv/modules/runners/ready.py
@@ -74,7 +74,7 @@ class Checks(object):
         Scan minions for apparmor settings.
         """
         contents = self.local.cmd(self.search, 'cmd.shell',
-                                  [('/usr/sbin/apparmor_status --enabled '
+                                  [('/usr/sbin/aa-status --enabled '
                                     '2>/dev/null; echo $?')],
                                   tgt_type="compound")
         for minion in contents:


### PR DESCRIPTION
aa-status is the actual executable, apparmor-status just a link to it.
has potential to be SUSE specific or change in the future.

Signed-off-by: Jan Fajerski <jfajerski@suse.com>
