### PR TITLE
Correct conditional

### DIFF
--- a/srv/salt/ceph/igw/files/lrbd.conf.j2
+++ b/srv/salt/ceph/igw/files/lrbd.conf.j2
@@ -1,4 +1,4 @@
-{% if not salt['cmd.run']('rados lspools | grep -q "^iscsi-images$"') and not salt['cmd.run']('rbd --pool iscsi-images ls | grep -q "^demo$"') %}
+{% if salt['cmd.run']('rados lspools | grep -q "^iscsi-images$"') and salt['cmd.run']('rbd --pool iscsi-images ls | grep -q "^demo$"') %}
 {
     "auth": [
         {


### PR DESCRIPTION
If the pool and image exist, generate a full lrbd.conf.  When neither
exists, use the minimal configuration.

Signed-off-by: Eric Jackson <ejackson@suse.com>
