### PR TITLE
Return a single device

### DIFF
--- a/srv/salt/_modules/cephinspector.py
+++ b/srv/salt/_modules/cephinspector.py
@@ -84,7 +84,7 @@ def _get_disk_id(partition):
     # We should only ever have one entry that we return.
     if out:
         out = _convert_out(out)
-        return out.rstrip()
+        return out.split()[-1]
     return partition
 
 


### PR DESCRIPTION
The find command may return multiple symlinks, but only one is needed.

Signed-off-by: Eric Jackson <ejackson@suse.com>

SUSE internal: bnc#1080102