### PR TITLE
Add salt2018 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@ nosetests.xml
 coverage.xml
 *,cover
 .hypothesis/
+.pytest_cache/
 
 # Translations
 *.mo

--- a/srv/modules/runners/filequeue.py
+++ b/srv/modules/runners/filequeue.py
@@ -240,19 +240,11 @@ def help_():
              '        salt-run filequeue.queues\n'
              '\n\n'
              'filequeue.enqueue:\n'
-             'filequeue.add:\n'
-             'filequeue.push:\n\n'
              '    Add an item on to a queue\n\n'
              '    CLI Example:\n\n'
              '        salt-run filequeue.enqueue abc\n'
              '        salt-run filequeue.enqueue abc queue=prep\n'
              '        salt-run filequeue.enqueue item=abc queue=prep\n'
-             '        salt-run filequeue.add abc\n'
-             '        salt-run filequeue.add abc queue=prep\n'
-             '        salt-run filequeue.add item=abc queue=prep\n'
-             '        salt-run filequeue.push abc\n'
-             '        salt-run filequeue.push abc queue=prep\n'
-             '        salt-run filequeue.push item=abc queue=prep\n'
              '\n\n'
              'filequeue.dequeue:\n\n'
              '    Remove and return oldest item from a queue\n\n'
@@ -333,8 +325,6 @@ def enqueue(queue=None, **kwargs):
 
 
 # pylint: disable=invalid-name
-add = salt.utils.alias_function(enqueue, 'add')
-push = salt.utils.alias_function(enqueue, 'push')
 
 
 def dequeue(**kwargs):

--- a/srv/modules/runners/fs.py
+++ b/srv/modules/runners/fs.py
@@ -18,7 +18,7 @@ import logging
 import salt.client
 import salt.utils.error
 # pylint: disable=relative-import
-from . import deepsea_minions
+from deepsea_minions import DeepseaMinions
 import six
 
 log = logging.getLogger(__name__)
@@ -325,7 +325,7 @@ def _inspect_ceph_statedir(path):
     Returns a dictionary of Path objects keyed on minion id.
 
     """
-    target = deepsea_minions.DeepseaMinions()
+    target = DeepseaMinions()
     search = target.deepsea_minions
     local = salt.client.LocalClient()
 

--- a/srv/modules/runners/net.py
+++ b/srv/modules/runners/net.py
@@ -18,7 +18,7 @@ from netaddr import IPNetwork, IPAddress
 # pylint: disable=import-error,3rd-party-module-not-gated,blacklisted-external-import,blacklisted-module
 from six.moves import range
 # pylint: disable=incompatible-py3-code
-from . import deepsea_minions
+from deepsea_minions import DeepseaMinions
 
 log = logging.getLogger(__name__)
 
@@ -151,7 +151,7 @@ def iperf(cluster=None, exclude=None, output=None, **kwargs):
             return result
     else:
         # pylint: disable=redefined-variable-type
-        search = deepsea_minions.DeepseaMinions().deepsea_minions
+        search = DeepseaMinions().deepsea_minions
         if exclude_string:
             search += " and not ( " + exclude_string + " )"
             log.debug("ping: search {} ".format(search))
@@ -345,7 +345,7 @@ def ping(cluster=None, exclude=None, ping_type=None, **kwargs):
                                           networks[host]['public_network']))
     else:
         # pylint: disable=redefined-variable-type
-        search = deepsea_minions.DeepseaMinions().deepsea_minions
+        search = DeepseaMinions().deepsea_minions
 
         if exclude_string:
             search += " and not ( " + exclude_string + " )"

--- a/srv/modules/runners/populate.py
+++ b/srv/modules/runners/populate.py
@@ -35,7 +35,6 @@ import re
 import pprint
 import string
 import random
-from subprocess import call, Popen, PIPE
 import yaml
 import json
 from os.path import dirname, basename, isdir
@@ -48,7 +47,7 @@ import uuid
 import ipaddress
 import logging
 # pylint: disable=relative-import
-import deepsea_minions
+from deepsea_minions import DeepseaMinions
 import operator
 
 import sys
@@ -495,7 +494,7 @@ class CephRoles(object):
         self.writer = writer
 
         self.root_dir = settings.root_dir
-        target = deepsea_minions.DeepseaMinions()
+        target = DeepseaMinions()
         self.search = target.deepsea_minions
 
         self.networks = self._networks(self.servers)
@@ -824,7 +823,7 @@ class CephCluster(object):
             self.names = ['ceph']
         self.writer = writer
 
-        target = deepsea_minions.DeepseaMinions()
+        target = DeepseaMinions()
         search = target.deepsea_minions
 
         local = salt.client.LocalClient()
@@ -1002,7 +1001,7 @@ def _get_existing_cluster_networks(addrs, public_networks=[]):
     returns a list of addresses consisting of network prefix followed by the
     cidr prefix (e.g. [ "10.0.0.0/24" ]).  It may return an empty list.
     """
-    target = deepsea_minions.DeepseaMinions()
+    target = DeepseaMinions()
     search = target.deepsea_minions
 
     local = salt.client.LocalClient()
@@ -1110,7 +1109,7 @@ def engulf_existing_cluster(**kwargs):
     salt_writer = SaltWriter(**kwargs)
 
     # Make sure deepsea_minions contains valid minions before proceeding with engulf.
-    minions = deepsea_minions.DeepseaMinions()
+    minions = DeepseaMinions()
     search = minions.deepsea_minions
     from . import validate
     validator = validate.Validate("ceph", local.cmd(search, 'pillar.items', [],

--- a/srv/modules/runners/proposal.py
+++ b/srv/modules/runners/proposal.py
@@ -15,7 +15,7 @@ import logging
 import salt.client
 import yaml
 # pylint: disable=import-error
-import deepsea_minions
+from deepsea_minions import DeepseaMinions
 
 log = logging.getLogger(__name__)
 
@@ -89,7 +89,7 @@ List of recognized parameters and their defaults:
                     gibibytes (G), tebibytes (T), or pebibytes (P).
 '''
 
-TARGET = deepsea_minions.DeepseaMinions()
+TARGET = DeepseaMinions()
 
 STD_ARGS = {
     'leftovers': False,

--- a/srv/modules/runners/validate.py
+++ b/srv/modules/runners/validate.py
@@ -31,7 +31,7 @@ import yaml
 import salt.client
 import salt.utils.error
 # pylint: disable=relative-import
-from . import deepsea_minions
+from deepsea_minions import DeepseaMinions
 
 
 log = logging.getLogger(__name__)
@@ -156,7 +156,7 @@ class ClusterAssignment(object):
         """
         Query the cluster assignment and remove unassigned
         """
-        target = deepsea_minions.DeepseaMinions()
+        target = DeepseaMinions()
         search = target.deepsea_minions
         self.minions = local.cmd(search, 'pillar.get', ['cluster'])
 
@@ -589,8 +589,10 @@ class Validate(object):
         stderr = []
         proc = Popen(cmd, stdout=PIPE, stderr=PIPE)
         for line in proc.stdout:
+            line = line.decode('ascii')
             stdout.append(line.rstrip('\n'))
         for line in proc.stderr:
+            line = line.decode('ascii')
             stderr.append(line.rstrip('\n'))
         proc.wait()
         return (stdout, stderr)
@@ -750,7 +752,7 @@ class Validate(object):
         """
         Scan all minions for ceph versions in their repos.
         """
-        target = deepsea_minions.DeepseaMinions()
+        target = DeepseaMinions()
         search = target.deepsea_minions
         local = salt.client.LocalClient()
         contents = local.cmd(search, 'pkg.latest_version', ['ceph-common'], tgt_type="compound")
@@ -1000,7 +1002,7 @@ def discovery(cluster=None, printer=None, **kwargs):
     local = salt.client.LocalClient()
 
     # Restrict search to this cluster
-    target = deepsea_minions.DeepseaMinions()
+    target = DeepseaMinions()
     search = target.deepsea_minions
     if 'cluster' in __pillar__:
         if __pillar__['cluster']:
@@ -1072,7 +1074,7 @@ def deploy(**kwargs):
     """
     Verify that Stage 4, Services can succeed.
     """
-    target = deepsea_minions.DeepseaMinions()
+    target = DeepseaMinions()
     search = target.deepsea_minions
     local = salt.client.LocalClient()
     pillar_data = local.cmd(search, 'pillar.items', [], tgt_type="compound")
@@ -1093,7 +1095,7 @@ def saltapi(**kwargs):
     """
     Verify that the Salt API is working
     """
-    target = deepsea_minions.DeepseaMinions()
+    target = DeepseaMinions()
     search = target.deepsea_minions
     local = salt.client.LocalClient()
 
@@ -1122,7 +1124,7 @@ def setup(**kwargs):
     """
     Check that initial files prior to any stage are correct
     """
-    target = deepsea_minions.DeepseaMinions()
+    target = DeepseaMinions()
     search = target.deepsea_minions
     local = salt.client.LocalClient()
 

--- a/srv/salt/_modules/cephdisks.py
+++ b/srv/salt/_modules/cephdisks.py
@@ -14,7 +14,7 @@ from glob import glob
 from subprocess import Popen, PIPE
 import logging
 # pylint: disable=import-error
-from helper import _convert_out
+
 
 log = logging.getLogger(__name__)
 
@@ -97,7 +97,7 @@ class HardwareDetections(object):
         cmd = lsscsi_path
         proc = Popen(cmd, stdout=PIPE, stderr=PIPE, shell=True)
         for line in proc.stdout:
-            line = _convert_out(line)
+            line = __salt__['helper.convert_out'](line)
             if device in line:
                 match = re.match(r'\[(.*?)\]', line)
                 if len(match.group(1).split(":")) >= 2:
@@ -136,7 +136,7 @@ class HardwareDetections(object):
                 log.info("{}\nrc: {} - {}".format(cmd, proc.returncode, proc.stderr.read()))
                 raise RuntimeError("Smartctl failure")
             for line in proc.stdout:
-                line = _convert_out(line)
+                line = __salt__['helper.convert_out'](line)
                 # ADD PARSING HERE TO DETECT FAILURE
                 if "A mandatory SMART command failed" in line:
                     log.warning("Something went wrong during smartctl query")
@@ -196,7 +196,7 @@ class HardwareDetections(object):
         # TODO: See if other places are also infected
         proc = Popen(cmd, stdout=PIPE, stderr=PIPE, shell=True)
         for line in proc.stdout:
-            line = _convert_out(line)
+            line = __salt__['helper.convert_out'](line)
             # match one of the available raid ctrls
             # areca, megaraid, 3ware, hprr
             if 'megaraid' in line.lower():
@@ -309,7 +309,7 @@ class HardwareDetections(object):
         cmd = "{} --disk --only /dev/{}".format(hwinfo_path, device)
         proc = Popen(cmd, stdout=PIPE, stderr=PIPE, shell=True)
         for line in proc.stdout:
-            line = _convert_out(line)
+            line = __salt__['helper.convert_out'](line)
             match = re.match("  ([^:]+): (.*)", line)
             if match:
                 if match.group(1) == "Capacity":
@@ -340,7 +340,7 @@ class HardwareDetections(object):
         stdout, stderr = proc.communicate()
         if stdout:
             for line in stdout:
-                line = _convert_out(line)
+                line = __salt__['helper.convert_out'](line)
                 if 'by-id' in line:
                     return "/dev/" + line.split()[1]
         elif stderr:
@@ -369,7 +369,7 @@ class HardwareDetections(object):
             cmd = "{} -i {} {}".format(sgdisk_path, partition_id, device)
             proc = Popen(cmd, stdout=PIPE, stderr=PIPE, shell=True)
             for line in proc.stdout:
-                line = _convert_out(line)
+                line = __salt__['helper.convert_out'](line)
                 if line.startswith("Partition GUID code:"):
                     for guuid_code in guuid_table.values():
                         if guuid_code in line:
@@ -394,7 +394,7 @@ class HardwareDetections(object):
         proc = Popen(cmd, stdout=PIPE, stderr=PIPE, shell=True)
         stdout, stderr = proc.communicate()
         if stdout:
-            stdout = _convert_out(stdout)
+            stdout = __salt__['helper.convert_out'](stdout)
             data = et.fromstring(stdout)
         elif stderr:
             err_msg = "Something went wrong during 'lshw' execution"

--- a/srv/salt/_modules/cephimages.py
+++ b/srv/salt/_modules/cephimages.py
@@ -6,7 +6,6 @@ List the rbd images
 from __future__ import absolute_import
 from subprocess import Popen, PIPE
 # pylint: disable=import-error
-from helper import _convert_out
 
 
 def list_():
@@ -16,12 +15,12 @@ def list_():
     images = {}
     proc = Popen(['rados', 'lspools'], stdout=PIPE, stderr=PIPE)
     for line in proc.stdout:
-        line = _convert_out(line)
+        line = __salt__['helper.convert_out'](line)
         pool = line.rstrip('\n')
         cmd = ['/usr/bin/rbd', '-p', pool, 'ls']
         rbd_proc = Popen(cmd, stdout=PIPE, stderr=PIPE)
         for rbd_line in rbd_proc.stdout:
-            rbd_line = _convert_out(rbd_line)
+            rbd_line = __salt__['helper.convert_out'](rbd_line)
             if pool not in images:
                 images[pool] = []
             images[pool].append(rbd_line.rstrip('\n'))

--- a/srv/salt/_modules/cephinspector.py
+++ b/srv/salt/_modules/cephinspector.py
@@ -13,7 +13,7 @@ import json
 import logging
 # pylint: disable=import-error,3rd-party-module-not-gated
 import psutil
-from helper import _convert_out
+
 
 log = logging.getLogger(__name__)
 
@@ -83,7 +83,7 @@ def _get_disk_id(partition):
 
     # We should only ever have one entry that we return.
     if out:
-        out = _convert_out(out)
+        out = __salt__['helper.convert_out'](out)
         return out.split()[-1]
     return partition
 
@@ -154,7 +154,7 @@ def _get_partition_size(partition):
     size, err = blockdev_cmd.communicate()
 
     try:
-        size = _convert_out(size)
+        size = __salt__['helper.convert_out'](size)
         size = _convert_size(int(size))
     # pylint: disable=unused-variable
     except ValueError as err:
@@ -214,8 +214,8 @@ def get_ceph_disks_yml(**kwargs):
     ceph_disk_list = Popen("PYTHONWARNINGS=ignore ceph-disk list --format=json",
                            stdout=PIPE, stderr=PIPE, shell=True)
     out, err = ceph_disk_list.communicate()
-    out = _convert_out(out)
-    err = _convert_out(err)
+    out = __salt__['helper.convert_out'](out)
+    err = __salt__['helper.convert_out'](err)
 
     ceph_disks = {"ceph":
                   {"storage":
@@ -309,6 +309,6 @@ def get_keyring(**kwargs):
     cmd = Popen("ceph auth get " + kwargs["key"], stdout=PIPE, stderr=PIPE, shell=True)
     # pylint: disable=unused-variable
     out, err = cmd.communicate()
-    out = _convert_out(out)
+    out = __salt__['helper.convert_out'](out)
 
     return out if out else None

--- a/srv/salt/_modules/cephprocesses.py
+++ b/srv/salt/_modules/cephprocesses.py
@@ -13,7 +13,7 @@ import shlex
 # pylint: disable=import-error,3rd-party-module-not-gated
 from subprocess import Popen, PIPE
 import psutil
-from helper import _convert_out
+
 
 log = logging.getLogger(__name__)
 
@@ -182,7 +182,7 @@ def _process_map():
                   stdin=proc1.stdout, stdout=PIPE, stderr=PIPE)
     proc1.stdout.close()
     stdout, _ = proc2.communicate()
-    stdout = _convert_out(stdout)
+    stdout = __salt__['helper.convert_out'](stdout)
     for proc_l in stdout.split('\n'):
         proc = proc_l.split(' ')
         proc_info = {}
@@ -206,7 +206,7 @@ def zypper_ps(role, lsof_map):
     assert role
     proc1 = Popen(shlex.split('zypper ps -sss'), stdout=PIPE)
     stdout, _ = proc1.communicate()
-    stdout = _convert_out(stdout)
+    stdout = __salt__['helper.convert_out'](stdout)
     processes_ = processes
     # adding instead of overwriting, eh?
     # radosgw is ceph-radosgw in zypper ps.

--- a/srv/salt/_modules/helper.py
+++ b/srv/salt/_modules/helper.py
@@ -12,7 +12,7 @@ from subprocess import Popen, PIPE
 log = logging.getLogger(__name__)
 
 
-def _convert_out(out):
+def convert_out(out):
     """
     Since python3 most system calls return type(byte)
     instead of type(str). We mostly use the output of
@@ -32,7 +32,7 @@ def _convert_out(out):
                         format(output=out, type_out=type(out)))
 
 
-def _run(cmd, shell=False):
+def run(cmd, shell=False):
     """
     Generic function for running shell commands
 
@@ -49,10 +49,10 @@ def _run(cmd, shell=False):
 
     log.info("executing: {cmd}".format(cmd=cmd))
     proc = Popen(cmd, stdout=PIPE, stderr=PIPE, shell=shell)
-    _stdout = _convert_out(proc.stdout.read())
+    _stdout = convert_out(proc.stdout.read())
     _stdout = _stdout.rstrip()
 
-    _stderr = _convert_out(proc.stdout.read())
+    _stderr = convert_out(proc.stdout.read())
     _stderr = _stderr.rstrip()
 
     _retcode = proc.wait()

--- a/srv/salt/_modules/kernel.py
+++ b/srv/salt/_modules/kernel.py
@@ -27,7 +27,7 @@ import logging
 import re
 import os
 # pylint: disable=import-error,3rd-party-module-not-gated,redefined-builtin
-from helper import _run
+
 
 log = logging.getLogger(__name__)
 
@@ -82,7 +82,7 @@ def _kernel_pkg():
     query = _query_command(_boot_image(kernel))
     if query:
         log.debug("query: {}".format(query))
-        _, stdout, _ = _run(query)
+        _, stdout, _ = __salt__['helper.run'](query)
         package = stdout
 
         log.info("package: {}".format(package))

--- a/srv/salt/_modules/keyring.py
+++ b/srv/salt/_modules/keyring.py
@@ -10,7 +10,6 @@ import struct
 import base64
 import time
 # pylint: disable=import-error,3rd-party-module-not-gated,redefined-builtin
-from helper import _convert_out
 
 
 def secret(filename):
@@ -38,7 +37,7 @@ def gen_secret():
     key = os.urandom(16)
     header = struct.pack('<hiih', 1, int(time.time()), 0, len(key))
     keyring = base64.b64encode(header + key)
-    return _convert_out(keyring)
+    return __salt__['helper.convert_out'](keyring)
 
 
 # pylint: disable=too-many-return-statements

--- a/srv/salt/_modules/multi.py
+++ b/srv/salt/_modules/multi.py
@@ -12,11 +12,11 @@ import re
 import socket
 from subprocess import Popen
 # pylint: disable=import-error
-from helper import _run
+
 log = logging.getLogger(__name__)
 
 try:
-    from salt.utils import which
+    from salt.utils.path import which
 except ImportError:
     from distutils.spawn import which
 
@@ -168,7 +168,7 @@ def iperf_client_cmd(server, cpu=0, port=5200):
     iperf_cmd = ["/usr/bin/iperf3", "-fm", "-A"+str(cpu),
                  "-t10", "-c"+server, "-p"+str(port)]
     log.debug('iperf_client_cmd: cmd {}'.format(iperf_cmd))
-    retcode, stdout, stderr = _run(iperf_cmd)
+    retcode, stdout, stderr = __salt__['helper.run'](iperf_cmd)
     return server, retcode, stdout, stderr
 
 
@@ -223,7 +223,7 @@ def ping_cmd(host):
         sudo salt 'node' multi.ping_cmd <hostname>|<ip>
     '''
     cmd = ["/usr/bin/ping", "-c1", "-q", "-W1", host]
-    retcode, stdout, stderr = _run(cmd)
+    retcode, stdout, stderr = __salt__['helper.run'](cmd)
     return host, retcode, stdout, stderr
 
 
@@ -251,7 +251,7 @@ def jumbo_ping_cmd(host):
     '''
     cmd = ["/usr/bin/ping", "-Mdo", "-s8972", "-c1", "-q", "-W1", host]
     log.debug('ping_cmd hostname={}'.format(host))
-    retcode, stdout, stderr = _run(cmd)
+    retcode, stdout, stderr = __salt__['helper.run'](cmd)
     return host, retcode, stdout, stderr
 
 

--- a/srv/salt/_modules/openattic.py
+++ b/srv/salt/_modules/openattic.py
@@ -14,11 +14,6 @@ import configobj
 log = logging.getLogger(__name__)
 
 try:
-    import salt.utils
-except ImportError:
-    logging.error("Could not import salt.util")
-
-try:
     from salt.exceptions import CommandExecutionError
 except ImportError:
     logging.error("Could not import salt.util")
@@ -30,7 +25,7 @@ def _write_config_file(config_file, config):
     """
     conf_content = ""
     write_log = set()
-    with salt.utils.fopen(config_file, "r") as fir:
+    with open(config_file, "r") as fir:
         for line in fir:
             sline = line.strip()
             idx = sline.find('=')
@@ -56,7 +51,7 @@ def _write_config_file(config_file, config):
             conf_content += '{}={}\n'.format(key, val_str)
 
     try:
-        with salt.utils.fopen(config_file, "w") as fiw:
+        with open(config_file, "w") as fiw:
             fiw.write(conf_content)
     except IOError as ex:
         if ex.errno == 13:

--- a/srv/salt/_modules/osd.py
+++ b/srv/salt/_modules/osd.py
@@ -17,7 +17,7 @@ import re
 import pprint
 import yaml
 # pylint: disable=import-error,3rd-party-module-not-gated,redefined-builtin
-from helper import _run
+
 
 log = logging.getLogger(__name__)
 
@@ -278,7 +278,7 @@ class OSDWeight(object):
         cmd = ("ceph --keyring={} --name={} osd crush reweight osd.{} "
                "{}".format(self.settings['keyring'], self.settings['client'],
                            self.osd_id, weight))
-        return _run(cmd)
+        return __salt__['helper.run'](cmd)
 
     def osd_df(self):
         """
@@ -493,7 +493,7 @@ def readlink(device, follow=True):
     if follow:
         option = '-f'
     cmd = "readlink {} {}".format(option, device)
-    _, stdout, _ = _run(cmd)
+    _, stdout, _ = __salt__['helper.run'](cmd)
     return stdout
 
 
@@ -784,7 +784,7 @@ class OSDPartitions(object):
         pathnames = _find_paths(self.osd.device)
         if pathnames:
             cmd = "sgdisk -Z --clear -g {}".format(self.osd.device)
-            _rc, _stdout, _stderr = _run(cmd)
+            _rc, _stdout, _stderr = __salt__['helper.run'](cmd)
             if _rc != 0:
                 raise RuntimeError("{} failed".format(cmd))
 
@@ -954,17 +954,22 @@ class OSDPartitions(object):
                 cmd = ("/usr/sbin/sgdisk -N {} -t {}:{} "
                        "{}".format(number, number,
                                    self.osd.types[partition_type], device))
-            _rc, _stdout, _stderr = _run(cmd)
+            _rc, _stdout, _stderr = __salt__['helper.run'](cmd)
             if _rc != 0:
+                log.debug("Stdout of {}: {}".format(cmd, _stdout))
+                log.debug("Stderr of {}: {}".format(cmd, _stderr))
                 raise RuntimeError("{} failed".format(cmd))
-            log.info("partprobe disk")
+            log.info("partprobing disk {}".format(device))
             self._part_probe(device)
             # Seems odd to wipe a just created partition ; however, ghost
             # filesystems on reused disks seem to be an issue
             if os.path.exists("{}{}".format(device, number)):
-                wipe_cmd = ("dd if=/dev/zero of={}{} bs=4096 count=1 "
-                            "oflag=direct".format(device, number))
-                _run(wipe_cmd)
+                prefix = ''
+                if device.startswith('/dev/nvme'):
+                    prefix = 'p'
+                wipe_cmd = ("dd if=/dev/zero of={}{}{} bs=4096 count=1 "
+                            "oflag=direct".format(device, prefix, number))
+                __salt__['helper.run'](wipe_cmd)
             index += 1
 
     def _part_probe(self, device):
@@ -975,7 +980,7 @@ class OSDPartitions(object):
         retries = 5
         cmd = "/usr/sbin/partprobe {}".format(device)
         for _ in range(1, retries + 1):
-            _rc, _stdout, _stderr = _run(cmd)
+            _rc, _stdout, _stderr = __salt__['helper.run'](cmd)
             if _rc == 0:
                 return
             time.sleep(wait_time)
@@ -1045,7 +1050,7 @@ class OSDCommands(object):
         Check partition type
         """
         cmd = "/usr/sbin/sgdisk -i {} {}".format(_partition, device)
-        _, result, _ = _run(cmd)
+        _, result, _ = __salt__['helper.run'](cmd)
         _id = "Partition GUID code: {}".format(self.osd.types[partition_type])
         return _id in result
 
@@ -1345,7 +1350,7 @@ class OSDCommands(object):
             return True
         if size:
             cmd = "blockdev --getsize64 {}".format(devicename)
-            _, _stdout, _stderr = _run(cmd)
+            _, _stdout, _stderr = __salt__['helper.run'](cmd)
             bsize = int(_stdout)
             _bytes = self._convert(size)
             if _bytes != bsize:
@@ -1469,15 +1474,15 @@ class OSDRemove(object):
         """
         # Check weight is zero
         cmd = "systemctl disable ceph-osd@{}".format(self.osd_id)
-        _run(cmd)
+        __salt__['helper.run'](cmd)
         # How long with this hang on a broken OSD
         cmd = "systemctl stop ceph-osd@{}".format(self.osd_id)
-        _run(cmd)
+        __salt__['helper.run'](cmd)
         cmd = r"pkill -f ceph-osd.*{}\ --".format(self.osd_id)
-        _run(cmd)
+        __salt__['helper.run'](cmd)
         time.sleep(1)
         cmd = r"pkill -9 -f ceph-osd.*{}\ --".format(self.osd_id)
-        _run(cmd)
+        __salt__['helper.run'](cmd)
         time.sleep(1)
         return ""
 
@@ -1495,7 +1500,7 @@ class OSDRemove(object):
                     mount = entry[0]
                 if mount in mounted:
                     cmd = "umount {}".format(mount)
-                    _rc, _stdout, _stderr = _run(cmd)
+                    _rc, _stdout, _stderr = __salt__['helper.run'](cmd)
                     log.debug("returncode: {}".format(_rc))
                     if _rc != 0:
                         msg = "Unmount failed - check for processes on {}".format(entry[0])
@@ -1505,7 +1510,7 @@ class OSDRemove(object):
 
         if '/dev/dm' in self.partitions['osd']:
             cmd = "dmsetup remove {}".format(self.partitions['osd'])
-            _run(cmd)
+            __salt__['helper.run'](cmd)
         return ""
 
     def _mounted(self):
@@ -1527,7 +1532,7 @@ class OSDRemove(object):
             for _, _partition in six.iteritems(self.partitions):
                 if os.path.exists(_partition):
                     cmd = "dd if=/dev/zero of={} bs=4096 count=1 oflag=direct".format(_partition)
-                    _run(cmd)
+                    __salt__['helper.run'](cmd)
         else:
             msg = "Nothing to wipe - no partitions available"
             log.error(msg)
@@ -1565,7 +1570,7 @@ class OSDRemove(object):
             log.debug("Checking attr {}".format(attr))
             if '/dev/dm' in self.partitions[attr]:
                 cmd = "dmsetup remove {}".format(self.partitions[attr])
-                _run(cmd)
+                __salt__['helper.run'](cmd)
                 continue
 
             short_name = readlink(self.partitions[attr])
@@ -1584,7 +1589,7 @@ class OSDRemove(object):
                     if disk:
                         log.debug("disk: {} partition: {}".format(disk, _partition))
                         cmd = "sgdisk -d {} {}".format(_partition, disk)
-                        _run(cmd)
+                        __salt__['helper.run'](cmd)
             else:
                 log.error("Partition {} does not exist".format(short_name))
 
@@ -1594,12 +1599,12 @@ class OSDRemove(object):
         """
         if self.osd_disk and os.path.exists(self.osd_disk):
             cmd = "blockdev --getsz {}".format(self.osd_disk)
-            _, _stdout, _stderr = _run(cmd)
+            _, _stdout, _stderr = __salt__['helper.run'](cmd)
             end_of_disk = int(_stdout)
             seek_position = int(end_of_disk/4096 - 33)
             cmd = ("dd if=/dev/zero of={} bs=4096 count=33 seek={} "
                    "oflag=direct".format(self.osd_disk, seek_position))
-            _run(cmd)
+            __salt__['helper.run'](cmd)
             return ""
 
     def _delete_osd(self):
@@ -1608,7 +1613,7 @@ class OSDRemove(object):
         """
         if self.osd_disk and os.path.exists(self.osd_disk):
             cmd = "sgdisk -Z --clear -g {}".format(self.osd_disk)
-            _rc, _stdout, _stderr = _run(cmd)
+            _rc, _stdout, _stderr = __salt__['helper.run'](cmd)
             if _rc != 0:
                 raise RuntimeError("{} failed".format(cmd))
 
@@ -1620,7 +1625,7 @@ class OSDRemove(object):
         for cmd in ['udevadm settle --timeout=20',
                     'partprobe',
                     'udevadm settle --timeout=20']:
-            _run(cmd)
+            __salt__['helper.run'](cmd)
 
 
 def remove(osd_id, **kwargs):
@@ -1753,7 +1758,7 @@ class OSDDevices(object):
             if os.path.exists(pathname):
                 cmd = (r"find -L {} -samefile {} \( -name ata* -o -name scsi* "
                        r"-o -name nvme* \)".format(pathname, device))
-                _, _stdout, _stderr = _run(cmd)
+                _, _stdout, _stderr = __salt__['helper.run'](cmd)
                 if _stdout:
                     _devices = _stdout.split()
                     index = self._prefer_underscores(_devices)
@@ -1886,8 +1891,8 @@ def deploy():
             osdp.clean()
             osdp.partition()
             osdc = OSDCommands(config)
-            _run(osdc.prepare())
-            _run(osdc.activate())
+            __salt__['helper.run'](osdc.prepare())
+            __salt__['helper.run'](osdc.activate())
 
 
 def redeploy(simultaneous=False, **kwargs):
@@ -1924,8 +1929,8 @@ def redeploy(simultaneous=False, **kwargs):
             osdp = OSDPartitions(config)
             osdp.partition()
             osdc = OSDCommands(config)
-            _run(osdc.prepare())
-            _run(osdc.activate())
+            __salt__['helper.run'](osdc.prepare())
+            __salt__['helper.run'](osdc.activate())
             # not is_prepared(disk)):
 
 
@@ -1972,7 +1977,7 @@ def _fsck(device, _partition):
         prefix = 'p'
     # cmd = "/sbin/fsck -t xfs -n {}{}{}".format(device, prefix, partition)
     cmd = "/usr/sbin/xfs_admin -u {}{}{}".format(device, prefix, _partition)
-    _rc, _stdout, _stderr = _run(cmd)
+    _rc, _stdout, _stderr = __salt__['helper.run'](cmd)
     return _rc == 0
 
 

--- a/srv/salt/_modules/packagemanager.py
+++ b/srv/salt/_modules/packagemanager.py
@@ -8,7 +8,7 @@ from subprocess import Popen, PIPE
 import logging
 import os
 # pylint: disable=import-error,3rd-party-module-not-gated,redefined-builtin
-from helper import _convert_out
+
 
 log = logging.getLogger(__name__)
 
@@ -85,7 +85,7 @@ class Apt(PackageManager):
         # pylint: disable=unused-variable
         proc = Popen(cmd, stdout=PIPE, stderr=PIPE, shell=True)
         _, stderr = proc.communicate()
-        stderr = _convert_out(stderr)
+        stderr = __salt__['helper.convert_out'](stderr)
         for cn_err in stderr.split(";"):
             if int(cn_err) > 0:
                 log.info('Update Needed')

--- a/srv/salt/_modules/proposal.py
+++ b/srv/salt/_modules/proposal.py
@@ -9,7 +9,6 @@ from __future__ import absolute_import
 # pylint: disable=import-error, redefined-builtin,3rd-party-module-not-gated
 import logging
 from salt.ext.six.moves import range
-import cephdisks
 # pylint: disable=incompatible-py3-code
 log = logging.getLogger(__name__)
 
@@ -299,7 +298,7 @@ def generate(**kwargs):
          'ssd-spinner': <proposal>,
          'standalone': <proposal>}
     '''
-    disks = cephdisks.list_(**kwargs)
+    disks = __salt__['cephdisks.list'](**kwargs)
     proposal = Proposal(disks, **kwargs)
     return proposal.create()
 

--- a/srv/salt/_modules/retry.py
+++ b/srv/salt/_modules/retry.py
@@ -14,7 +14,6 @@ import time
 import logging
 # pylint: disable=import-error,3rd-party-module-not-gated,redefined-builtin
 from salt.ext.six.moves import range
-from helper import _convert_out
 
 
 log = logging.getLogger(__name__)
@@ -36,10 +35,10 @@ def cmd(**kwargs):
         proc = Popen(_cmd, stdout=PIPE, stderr=PIPE, shell=True)
         proc.wait()
         for line in proc.stdout:
-            line = _convert_out(line)
+            line = __salt__['helper.convert_out'](line)
             print(line)
         for line in proc.stderr:
-            line = _convert_out(line)
+            line = __salt__['helper.convert_out'](line)
             sys.stderr.write(line)
         if proc.returncode != 0:
             if attempt < retry:

--- a/srv/salt/_modules/rgw.py
+++ b/srv/salt/_modules/rgw.py
@@ -22,7 +22,7 @@ import boto
 import boto.s3.connection
 # pylint: disable=import-error,3rd-party-module-not-gated
 import boto.exception
-from helper import _convert_out, _run
+
 
 log = logging.getLogger(__name__)
 
@@ -66,7 +66,7 @@ def users(realm='default', contains=None):
     Return the list of users for a realm.
     """
     cmd = "radosgw-admin user list --rgw-realm={}".format(realm)
-    retcode, stdout, _ = _run(cmd)
+    retcode, stdout, _ = __salt__['helper.run'](cmd)
     if retcode != '0':
         if contains:
             return [item for item in json.loads(stdout) if contains in item]
@@ -116,20 +116,20 @@ def add_users(pathname="/srv/salt/ceph/rgw/cache", jinja="/srv/salt/ceph/rgw/fil
                 filename = "{}/user.{}.json".format(pathname, user['uid'])
                 with open(filename, "w") as _json:
                     for line in proc.stdout:
-                        line = _convert_out(line)
+                        line = __salt__['helper.convert_out'](line)
                         _json.write(line)
                 for line in proc.stderr:
-                    line = _convert_out(line)
+                    line = __salt__['helper.convert_out'](line)
                     log.info("stderr: {}".format(line))
                     proc = Popen(command.split(), stdout=PIPE, stderr=PIPE)
                     with open(filename, "w") as _json:
                         # pylint: disable=redefined-outer-name
                         for line in proc.stdout:
-                            line = _convert_out(line)
+                            line = __salt__['helper.convert_out'](line)
                             _json.write(line)
                     # pylint: disable=redefined-outer-name
                     for line in proc.stderr:
-                        line = _convert_out(line)
+                        line = __salt__['helper.convert_out'](line)
                         log.info("stderr: {}".format(line))
 
                 proc.wait()
@@ -145,10 +145,10 @@ def add_users(pathname="/srv/salt/ceph/rgw/cache", jinja="/srv/salt/ceph/rgw/fil
                     proc = Popen(args, stdout=PIPE, stderr=PIPE)
                     with open(filename, "w") as _json:
                         for line in proc.stdout:
-                            line = _convert_out(line)
+                            line = __salt__['helper.convert_out'](line)
                             _json.write(line)
                     for line in proc.stderr:
-                        line = _convert_out(line)
+                        line = __salt__['helper.convert_out'](line)
                         log.info("stderr: {}".format(line))
                     proc.wait()
 

--- a/srv/salt/_modules/zypper_locks.py
+++ b/srv/salt/_modules/zypper_locks.py
@@ -15,7 +15,6 @@ from subprocess import Popen, PIPE
 import time
 import logging
 # pylint: disable=import-error,3rd-party-module-not-gated,redefined-builtin
-from helper import _convert_out
 
 
 log = logging.getLogger(__name__)
@@ -36,10 +35,10 @@ def ready(**kwargs):
         proc = Popen(cmd, stdout=PIPE, stderr=PIPE, shell=True)
         proc.wait()
         for line in proc.stdout:
-            line = _convert_out(line)
+            line = __salt__['helper.convert_out'](line)
             print(line)
         for line in proc.stderr:
-            line = _convert_out(line)
+            line = __salt__['helper.convert_out'](line)
             sys.stderr.write(line)
         if proc.returncode != 0:
             wait_time = sleep

--- a/srv/salt/ceph/reactor/initialize.sls
+++ b/srv/salt/ceph/reactor/initialize.sls
@@ -3,7 +3,7 @@
 # automation, the last stage will remove the lock.  Overlapping restarts
 # will trigger only one run.
 
-{% if salt['saltutil.runner']('filequeue.add', item='lock', queue='master', duplicate_fail=True) == True %}
+{% if salt['saltutil.runner']('filequeue.enqueue', item='lock', queue='master', duplicate_fail=True) == True %}
 
 master:
   runner.state.orchestrate:

--- a/srv/salt/ceph/stage/prep/master/default-no-update-no-reboot.sls
+++ b/srv/salt/ceph/stage/prep/master/default-no-update-no-reboot.sls
@@ -36,7 +36,7 @@ unlock:
 
 complete marker:
   salt.runner:
-    - name: filequeue.add
+    - name: filequeue.enqueue
     - queue: 'master'
     - item: 'complete'
 

--- a/srv/salt/ceph/stage/prep/master/default-no-update-reboot.sls
+++ b/srv/salt/ceph/stage/prep/master/default-no-update-reboot.sls
@@ -41,7 +41,7 @@ restart master:
 
 complete marker:
   salt.runner:
-    - name: filequeue.add
+    - name: filequeue.enqueue
     - queue: 'master'
     - item: 'complete'
 

--- a/srv/salt/ceph/stage/prep/master/default-update-no-reboot.sls
+++ b/srv/salt/ceph/stage/prep/master/default-update-no-reboot.sls
@@ -41,7 +41,7 @@ unlock:
 
 complete marker:
   salt.runner:
-    - name: filequeue.add
+    - name: filequeue.enqueue
     - queue: 'master'
     - item: 'complete'
 

--- a/srv/salt/ceph/stage/prep/master/default.sls
+++ b/srv/salt/ceph/stage/prep/master/default.sls
@@ -48,7 +48,7 @@ restart master:
 
 complete marker:
   salt.runner:
-    - name: filequeue.add
+    - name: filequeue.enqueue
     - queue: 'master'
     - item: 'complete'
 

--- a/tests/unit/_modules/test_kernel.py
+++ b/tests/unit/_modules/test_kernel.py
@@ -1,7 +1,5 @@
 import pytest
-import StringIO
 from srv.salt._modules import kernel
-
 from mock import patch, MagicMock
 
 def test_boot_image():

--- a/tests/unit/_modules/test_packagemanager.py
+++ b/tests/unit/_modules/test_packagemanager.py
@@ -3,8 +3,7 @@ from srv.salt._modules.packagemanager import PackageManager, Zypper, Apt
 from srv.salt._modules import packagemanager as pm
 import sys
 sys.path.insert(0, 'srv/salt/_modules')
-from srv.salt._modules.helper import _run
-from mock import MagicMock, patch, mock
+from mock import MagicMock, patch, mock, create_autospec
 
 
 class TestPackageManager():
@@ -254,6 +253,10 @@ class TestApt():
         """
         pm.__grains__ = {'os': 'ubuntu'}
         args = {'debug': False, 'kernel': False, 'reboot': False}
+        def pass_through(*args, **kwargs):
+            return args[0]
+        mock_func = create_autospec(lambda x: x, side_effect=pass_through)
+        pm.__salt__ = {'helper.convert_out': mock_func}
         yield PackageManager(**args).pm
 
     @mock.patch('srv.salt._modules.packagemanager.Popen')
@@ -334,7 +337,7 @@ class TestApt():
     @mock.patch('srv.salt._modules.packagemanager.PackageManager._reboot')
     @mock.patch('srv.salt._modules.packagemanager.Popen')
     @mock.patch('srv.salt._modules.packagemanager.Apt._updates_needed')
-    def test__handle_updates_present_reboot_file_not_present(self, updates_needed, po, _reboot, apt):      
+    def test__handle_updates_present_reboot_file_not_present(self, updates_needed, po, _reboot, apt):
         """
         Given there are pending updates.
         And Apt returns with 0

--- a/tests/unit/_modules/test_rgw.py
+++ b/tests/unit/_modules/test_rgw.py
@@ -4,9 +4,7 @@ import os
 import sys
 sys.path.insert(0, 'srv/salt/_modules')
 from pyfakefs import fake_filesystem, fake_filesystem_glob
-
 from mock import patch, MagicMock
-import mock
 from srv.salt._modules import rgw
 
 fs = fake_filesystem.FakeFilesystem()

--- a/tests/unit/_modules/test_validate.py
+++ b/tests/unit/_modules/test_validate.py
@@ -2,6 +2,8 @@ import pytest
 import salt.client
 import sys
 sys.path.insert(0, 'srv/salt/_modules')
+sys.path.insert(0, 'srv/modules/runners')
+sys.path.insert(0, 'srv/modules/runners/utils')
 
 from mock import patch, MagicMock
 from srv.modules.runners import validate

--- a/tests/unit/helper/fixtures.py
+++ b/tests/unit/helper/fixtures.py
@@ -1,0 +1,105 @@
+import pytest
+from mock import patch, create_autospec, mock
+
+def pass_through(*args):
+    return args[0]
+
+@pytest.fixture(scope='class')
+def helper_specs(module=None, ret_val=(0, 'stdout', 'stderr'), side_effect=pass_through):
+    """
+    A module wide fixture that adds a dict that mirrors salt's __salt__
+    injection.
+
+    Explanation:
+    We have helper functions in our srv/salt/_modules/helper.py module
+    which should be accessed via the __salt__ global that salt injects
+    during runtime.
+
+    __salt__ is a dict and looks like so:
+    __salt__ = {'module.function': <uninstantiated-function>, ...}
+
+    The test however does not inject this dunder and needs to be populated.
+    You also need to be able to set the return_value of your module.function
+    depending on the context of the test.
+
+    **helper.run**
+
+    Simple Example:
+
+    In the code:
+    __salt__['helper.run']('a dymanically constructed command')
+
+    In the test:
+    test_module = helper_specs(module=module_to_test)
+    test_module.__salt__['helper.run'].assert_called_with('a dynamically constructed command')
+
+    A More complex Example:
+
+    In the code:
+    def your_method():
+        rc, stdout, stderr = __salt__['helper.run']('a dymanically constructed command')
+        if stdout == 'a':
+            do_a
+        elif stdout == 'b':
+            do_b
+        else:
+        ....
+
+    In the test:
+    You now need to test for at least 3 different cases.
+    A) stdout == 'a'
+    B) stdout == 'b'
+    C) stdout == not 'a' and not 'b'
+
+    That requires you to mock the output of __salt__['helper.run'](cmd).
+    With this fixture you get the mocked version of the module back.
+
+    test_module = helper_specs(module=module_to_test)
+    test_module.__salt__['helper.run'].return_value = 'a'
+    test_module.your_method()
+    do_a.assert_called_once()
+    assert not do_b.called
+
+    ... same dance for 'b' and 'x'
+
+    **helper.convert_out**
+
+    This helper exists because of the python2-3 conversion and the
+    associated changes to type(bytes, strings and unicode).
+    Read more on that here: http://python3porting.com/problems.html
+
+    tl;dr: We need to check for bytes/string and decode when needed.
+
+    In the test however you don't really care what's being stuffed
+    in that helper. There is one caveat though. In the code we often
+    overwrite a local runtime variable.
+
+    Example:
+    ```
+    for line in stdout:
+        line = __salt__['helper.convert_out'](line)
+        print_or_handle(line)
+        #^ only accepts strings and needs to be converted.
+    ```
+
+    Without proper mocking 'line' would always be 'None' in the tests.
+    So what you want to do is basically mock the 'helper.convert_out'
+    function to 'pass through' every piece of data that it receives.
+    (Magic)Mocks have a feature called 'side_effect' that allows you
+    to pass a function that generates the return_values dynamically.
+    I'm abusing that feature to always return the first argument passed to it.
+    (convert_out only ever takes _one_ arg, hence the arg[0])
+
+    module: a module like 'osd' or 'cephdisks'
+    ret_val: return value of 'helper.run', tuple(rc, stdout, stderr)
+    side_effects: method of returning data for 'helper.convert_out'
+
+    returns <specs <module> >
+    """
+    def specs(module=module, ret_val=ret_val):
+        convert_out_mock = create_autospec(lambda x: x, side_effect=pass_through)
+        run_mock = create_autospec(lambda x: x, return_value=ret_val)
+        module.__salt__ = {'helper.run': run_mock,
+                           'helper.convert_out': convert_out_mock}
+        return module
+    return specs

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,7 @@ deps =
     salt
 
 [testenv:py27]
+basepython = python2.7
 commands =  py.test --tb=line -v --junitxml=junit-{envname}.xml {posargs}
 deps =
     {[base]deps}


### PR DESCRIPTION
Signed-off-by: Joshua Schmid <jschmid@suse.de>

Fixes #995 

Description:

* Remove filequeue.add/pop aliases
   - salt moved the alias function paths in [salt2018 ](https://docs.saltstack.com/en/latest/topics/releases/2018.3.0.html) 
   - we almost nowhere used the aliases so I dropped them to avoid
      unnessasary if/else branching when supporting salt2017/18

* Changed deepsea_minions importing
    - to `from deepsea_minions import DeepseaMinions`
    - from `import deepsea_minions`


* Change importing of modules
   - we previously used the pythonic way of importing
   - switched to the salt way  `__salt__['helper.run']`
   - and `__salt__['helper.convert_out']`


* Fix a bug in osd.py:L970
   - wrong partition handling in case of a NVME.
   - NVME partition schemes haunt us since.. ever..
      Maybe it's time for a code change here.


* Fix tests
   - reworked tests:
   - docs can be found in the docstring:
      **https://github.com/SUSE/DeepSea/pull/1051/files#diff-99735a509ed582a25412d9b35e31a592R9**

Caveats:

* There is a bug in salt(presumably) which requires the user to delete the
   `/srv/modules/runners/__pycache__` directory in order to get the runners
    imported properly.

* Skipped tests:
   I had to skip a couple of tests in the test_osd.py::Test_is_incorrect suite due to 
   flickering tests and a missbehaving `pyfakefs` module. More information here https://github.com/SUSE/DeepSea/issues/1052. Has to get reworked.

-----------------

[Please find more information on how to run integration tests here](https://github.com/SUSE/DeepSea/wiki/Integration-tests)
