### PR TITLE
Stage 3: fail immediately if MONs or MGRs do not stay up after starting

### DIFF
--- a/srv/salt/ceph/mgr/default.sls
+++ b/srv/salt/ceph/mgr/default.sls
@@ -7,4 +7,13 @@ start mgr:
     - name: ceph-mgr@{{ grains['host'] }}
     - enable: True
 
-
+wait for mgr:
+  module.run:
+    - name: cephprocesses.wait
+    - kwargs:
+        'timeout': 6
+        'delay': 2
+        'roles':
+          - mgr
+    - fire_event: True
+    - failhard: True

--- a/srv/salt/ceph/mon/default.sls
+++ b/srv/salt/ceph/mon/default.sls
@@ -33,17 +33,9 @@ create_mon_fs:
         - file: /var/lib/ceph/tmp/keyring.mon
 
 
-# TODO: we can put this check in a nice exec. module
-start-mon:
-  cmd.run:
-    - name: "systemctl start ceph-mon@{{ grains['host'] }}"
+start mon:
+  service.running:
+    - name: ceph-mon@{{ grains['host'] }}
     - require:
-        - cmd: create_mon_fs
-
-enable-mon:
-  cmd.run:
-    - name: "systemctl enable ceph-mon@{{ grains['host'] }}"
-    - require:
-        - cmd: create_mon_fs
-
-
+      - cmd: create_mon_fs
+    - enable: True

--- a/srv/salt/ceph/mon/default.sls
+++ b/srv/salt/ceph/mon/default.sls
@@ -39,3 +39,15 @@ start mon:
     - require:
       - cmd: create_mon_fs
     - enable: True
+
+
+wait for mon:
+  module.run:
+    - name: cephprocesses.wait
+    - kwargs:
+        'timeout': 6
+        'delay': 2
+        'roles':
+          - mon
+    - fire_event: True
+    - failhard: True

--- a/srv/salt/ceph/stage/deploy/default.sls
+++ b/srv/salt/ceph/stage/deploy/default.sls
@@ -1,5 +1,5 @@
 include:
   - .core
   - ...restart.mon.lax
-  - ...restart.osd.lax
   - ...restart.mgr.lax
+  - ...restart.osd.lax


### PR DESCRIPTION
`service.running` will start and enable the service, which is nice, but it reports the service as up and running even if it fails, e.g., 0.5 seconds after being started.
    
Add a small bash script that waits a short time and checks the service status, so we don't continue with a failed MGR.

Do the same with the MONs (and migrate them to `service.running`).

Also, restart the MGRs before the OSDs since the OSDs cannot start if MGRs are not running.

Fixes: https://github.com/SUSE/DeepSea/issues/1019

-----------------

[Please find more information on how to run integration tests here](https://github.com/SUSE/DeepSea/wiki/Integration-tests)
