### PR TITLE
Support restart smoketests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,11 +63,23 @@ copy-files:
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/tests/quiescent/timeout
 	install -m 644 srv/salt/ceph/tests/quiescent/*.sls $(DESTDIR)/srv/salt/ceph/tests/quiescent
 	install -m 644 srv/salt/ceph/tests/quiescent/timeout/*.sls $(DESTDIR)/srv/salt/ceph/tests/quiescent/timeout
+	install -d -m 755 $(DESTDIR)/srv/salt/ceph/tests/restart
+	install -d -m 755 $(DESTDIR)/srv/salt/ceph/tests/restart/mon
+	install -d -m 755 $(DESTDIR)/srv/salt/ceph/tests/restart/mds
+	install -d -m 755 $(DESTDIR)/srv/salt/ceph/tests/restart/mgr
+	install -d -m 755 $(DESTDIR)/srv/salt/ceph/tests/restart/rgw
+	install -m 644 srv/salt/ceph/tests/restart/*.sls $(DESTDIR)/srv/salt/ceph/tests/restart
+	install -m 644 srv/salt/ceph/tests/restart/mon/*.sls $(DESTDIR)/srv/salt/ceph/tests/restart/mon
+	install -m 644 srv/salt/ceph/tests/restart/mds/*.sls $(DESTDIR)/srv/salt/ceph/tests/restart/mds
+	install -m 644 srv/salt/ceph/tests/restart/mgr/*.sls $(DESTDIR)/srv/salt/ceph/tests/restart/mgr
+	install -m 644 srv/salt/ceph/tests/restart/rgw/*.sls $(DESTDIR)/srv/salt/ceph/tests/restart/rgw
 	# smoketests
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/smoketests/keyrings
 	install -m 644 srv/salt/ceph/smoketests/keyrings/*.sls $(DESTDIR)/srv/salt/ceph/smoketests/keyrings
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/smoketests/quiescent
 	install -m 644 srv/salt/ceph/smoketests/quiescent/*.sls $(DESTDIR)/srv/salt/ceph/smoketests/quiescent
+	install -d -m 755 $(DESTDIR)/srv/salt/ceph/smoketests/restart
+	install -m 644 srv/salt/ceph/smoketests/restart/*.sls $(DESTDIR)/srv/salt/ceph/smoketests/restart
 	# docs
 	install -d -m 755 $(DESTDIR)$(DOCDIR)/deepsea
 	install -m 644 LICENSE $(DESTDIR)$(DOCDIR)/deepsea/

--- a/deepsea.spec.in
+++ b/deepsea.spec.in
@@ -728,10 +728,24 @@ the README for more information.
 %dir /srv/salt/ceph/tests/keyrings
 %dir /srv/salt/ceph/tests/quiescent
 %dir /srv/salt/ceph/tests/quiescent/timeout
+%dir /srv/salt/ceph/smoketests/restart
+%dir /srv/salt/ceph/tests/quiescent
+%dir /srv/salt/ceph/tests/quiescent/timeout
+%dir /srv/salt/ceph/tests/restart
+%dir /srv/salt/ceph/tests/restart/mon
+%dir /srv/salt/ceph/tests/restart/mds
+%dir /srv/salt/ceph/tests/restart/mgr
+%dir /srv/salt/ceph/tests/restart/rgw
 /srv/salt/ceph/smoketests/keyrings/*.sls
 /srv/salt/ceph/smoketests/quiescent/*.sls
+/srv/salt/ceph/smoketests/restart/*.sls
 /srv/salt/ceph/tests/keyrings/*.sls
 /srv/salt/ceph/tests/quiescent/*.sls
 /srv/salt/ceph/tests/quiescent/timeout/*.sls
+/srv/salt/ceph/tests/restart/*.sls
+/srv/salt/ceph/tests/restart/mon/*.sls
+/srv/salt/ceph/tests/restart/mds/*.sls
+/srv/salt/ceph/tests/restart/mgr/*.sls
+/srv/salt/ceph/tests/restart/rgw/*.sls
 
 %changelog

--- a/srv/salt/ceph/smoketests/restart/common.sls
+++ b/srv/salt/ceph/smoketests/restart/common.sls
@@ -1,0 +1,100 @@
+
+reset systemctl initially:
+  salt.state:
+    - tgt: {{ test_node }}
+    - tgt_type: compound
+    - sls: ceph.tests.restart.{{ service }}.reset
+
+unset {{ service }} restart grain:
+  module.run:
+    - name: grains.setval
+    - key: restart_{{ service }}
+    - val: False
+
+{#########################}
+{# Check forced restarts #}
+
+check {{ service }} forced restart:
+  salt.state:
+    - tgt: {{ test_node }}
+    - tgt_type: compound
+    - sls: ceph.tests.restart.{{ service }}.forced
+    - failhard: True
+
+{#########################}
+{# Check service does not restart #}
+
+check {{ service }} no restart:
+  salt.state:
+    - tgt: {{ test_node }}
+    - tgt_type: compound
+    - sls: ceph.tests.restart.{{ service }}.nochange
+    - failhard: True
+
+{#########################}
+{# Check service restarts with change #}
+change {{ service }}.conf:
+  salt.state:
+    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt_type: compound
+    - sls: ceph.tests.restart.{{ service }}.setup
+
+create ceph.conf:
+  salt.state:
+    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt_type: compound
+    - sls: ceph.configuration.create
+
+distribute ceph.conf:
+  salt.state:
+    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt_type: compound
+    - sls: ceph.configuration
+
+check changes:
+  salt.runner:
+    - name: changed.{{ service }}
+
+check {{ service }}:
+  salt.state:
+    - tgt: {{ test_node }}
+    - tgt_type: compound
+    - sls: ceph.tests.restart.{{ service }}.change
+    - failhard: True
+
+{#########################}
+{# Check service restarts with change removed #}
+remove {{ service }}.conf:
+  salt.state:
+    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt_type: compound
+    - sls: ceph.tests.restart.{{ service }}.teardown
+
+reset systemctl:
+  salt.state:
+    - tgt: {{ test_node }}
+    - tgt_type: compound
+    - sls: ceph.tests.restart.{{ service }}.reset
+
+reset ceph.conf:
+  salt.state:
+    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt_type: compound
+    - sls: ceph.configuration.create
+
+redistribute ceph.conf:
+  salt.state:
+    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt_type: compound
+    - sls: ceph.configuration
+
+check changes again:
+  salt.runner:
+    - name: changed.{{ service }}
+
+check {{ service }} again:
+  salt.state:
+    - tgt: {{ test_node }}
+    - tgt_type: compound
+    - sls: ceph.tests.restart.{{ service }}.change
+

--- a/srv/salt/ceph/smoketests/restart/mds.sls
+++ b/srv/salt/ceph/smoketests/restart/mds.sls
@@ -1,0 +1,5 @@
+
+{% set service = 'mds' %}
+{% set test_node = salt.saltutil.runner('select.one_minion', cluster='ceph', roles=service) %}
+
+{% include slspath + '/common.sls' %}

--- a/srv/salt/ceph/smoketests/restart/mgr.sls
+++ b/srv/salt/ceph/smoketests/restart/mgr.sls
@@ -1,0 +1,5 @@
+
+{% set service = 'mgr' %}
+{% set test_node = salt.saltutil.runner('select.one_minion', cluster='ceph', roles=service) %}
+
+{% include slspath + '/common.sls' %}

--- a/srv/salt/ceph/smoketests/restart/mon.sls
+++ b/srv/salt/ceph/smoketests/restart/mon.sls
@@ -1,0 +1,5 @@
+
+{% set service = 'mon' %}
+{% set test_node = salt.saltutil.runner('select.one_minion', cluster='ceph', roles=service) %}
+
+{% include slspath + '/common.sls' %}

--- a/srv/salt/ceph/smoketests/restart/rgw.sls
+++ b/srv/salt/ceph/smoketests/restart/rgw.sls
@@ -1,0 +1,5 @@
+
+{% set service = 'rgw' %}
+{% set test_node = salt.saltutil.runner('select.one_minion', cluster='ceph', roles=service) %}
+
+{% include slspath + '/common.sls' %}

--- a/srv/salt/ceph/tests/restart/changed_pid.sls
+++ b/srv/salt/ceph/tests/restart/changed_pid.sls
@@ -1,0 +1,11 @@
+
+Changed pid:
+  cmd.run:
+    - name: "[ `pgrep ceph-{{ service }}` !=  `cat /tmp/restart.pid` ]"
+    - shell: /bin/bash
+    - failhard: True
+
+/tmp/restart.pid:
+  file.absent
+
+

--- a/srv/salt/ceph/tests/restart/mds/change/init.sls
+++ b/srv/salt/ceph/tests/restart/mds/change/init.sls
@@ -1,0 +1,6 @@
+
+include:
+  - ..save_pid
+  - .....mds.restart
+  - ..changed_pid
+

--- a/srv/salt/ceph/tests/restart/mds/changed_pid.sls
+++ b/srv/salt/ceph/tests/restart/mds/changed_pid.sls
@@ -1,0 +1,4 @@
+
+{% set service = "mds" %}
+{% include  "ceph/tests/restart/changed_pid.sls" %}
+

--- a/srv/salt/ceph/tests/restart/mds/forced/init.sls
+++ b/srv/salt/ceph/tests/restart/mds/forced/init.sls
@@ -1,0 +1,6 @@
+
+include:
+  - ..save_pid
+  - .....mds.restart.force
+  - ..changed_pid
+

--- a/srv/salt/ceph/tests/restart/mds/nochange/init.sls
+++ b/srv/salt/ceph/tests/restart/mds/nochange/init.sls
@@ -1,0 +1,6 @@
+
+include:
+  - ..save_pid
+  - .....mds.restart
+  - ..same_pid
+

--- a/srv/salt/ceph/tests/restart/mds/reset.sls
+++ b/srv/salt/ceph/tests/restart/mds/reset.sls
@@ -1,0 +1,4 @@
+
+{% set service = "mds" %}
+{% include  "ceph/tests/restart/reset.sls" %}
+

--- a/srv/salt/ceph/tests/restart/mds/same_pid.sls
+++ b/srv/salt/ceph/tests/restart/mds/same_pid.sls
@@ -1,0 +1,4 @@
+
+{% set service = "mds" %}
+{% include  "ceph/tests/restart/same_pid.sls" %}
+

--- a/srv/salt/ceph/tests/restart/mds/save_pid.sls
+++ b/srv/salt/ceph/tests/restart/mds/save_pid.sls
@@ -1,0 +1,4 @@
+
+{% set service = "mds" %}
+{% include  "ceph/tests/restart/save_pid.sls" %}
+

--- a/srv/salt/ceph/tests/restart/mds/setup.sls
+++ b/srv/salt/ceph/tests/restart/mds/setup.sls
@@ -1,0 +1,4 @@
+
+{% set service = "mds" %}
+{% include  "ceph/tests/restart/setup.sls" %}
+

--- a/srv/salt/ceph/tests/restart/mds/teardown.sls
+++ b/srv/salt/ceph/tests/restart/mds/teardown.sls
@@ -1,0 +1,4 @@
+
+{% set service = "mds" %}
+{% include  "ceph/tests/restart/teardown.sls" %}
+

--- a/srv/salt/ceph/tests/restart/mgr/change/init.sls
+++ b/srv/salt/ceph/tests/restart/mgr/change/init.sls
@@ -1,0 +1,6 @@
+
+include:
+  - ..save_pid
+  - .....mgr.restart
+  - ..changed_pid
+

--- a/srv/salt/ceph/tests/restart/mgr/changed_pid.sls
+++ b/srv/salt/ceph/tests/restart/mgr/changed_pid.sls
@@ -1,0 +1,4 @@
+
+{% set service = "mgr" %}
+{% include  "ceph/tests/restart/changed_pid.sls" %}
+

--- a/srv/salt/ceph/tests/restart/mgr/forced/init.sls
+++ b/srv/salt/ceph/tests/restart/mgr/forced/init.sls
@@ -1,0 +1,6 @@
+
+include:
+  - ..save_pid
+  - .....mgr.restart.force
+  - ..changed_pid
+

--- a/srv/salt/ceph/tests/restart/mgr/nochange/init.sls
+++ b/srv/salt/ceph/tests/restart/mgr/nochange/init.sls
@@ -1,0 +1,6 @@
+
+include:
+  - ..save_pid
+  - .....mgr.restart
+  - ..same_pid
+

--- a/srv/salt/ceph/tests/restart/mgr/reset.sls
+++ b/srv/salt/ceph/tests/restart/mgr/reset.sls
@@ -1,0 +1,4 @@
+
+{% set service = "mgr" %}
+{% include  "ceph/tests/restart/reset.sls" %}
+

--- a/srv/salt/ceph/tests/restart/mgr/same_pid.sls
+++ b/srv/salt/ceph/tests/restart/mgr/same_pid.sls
@@ -1,0 +1,4 @@
+
+{% set service = "mgr" %}
+{% include  "ceph/tests/restart/same_pid.sls" %}
+

--- a/srv/salt/ceph/tests/restart/mgr/save_pid.sls
+++ b/srv/salt/ceph/tests/restart/mgr/save_pid.sls
@@ -1,0 +1,4 @@
+
+{% set service = "mgr" %}
+{% include  "ceph/tests/restart/save_pid.sls" %}
+

--- a/srv/salt/ceph/tests/restart/mgr/setup.sls
+++ b/srv/salt/ceph/tests/restart/mgr/setup.sls
@@ -1,0 +1,4 @@
+
+{% set service = "mgr" %}
+{% include  "ceph/tests/restart/setup.sls" %}
+

--- a/srv/salt/ceph/tests/restart/mgr/teardown.sls
+++ b/srv/salt/ceph/tests/restart/mgr/teardown.sls
@@ -1,0 +1,4 @@
+
+{% set service = "mgr" %}
+{% include  "ceph/tests/restart/teardown.sls" %}
+

--- a/srv/salt/ceph/tests/restart/mon/change/init.sls
+++ b/srv/salt/ceph/tests/restart/mon/change/init.sls
@@ -1,0 +1,6 @@
+
+include:
+  - ..save_pid
+  - .....mon.restart
+  - ..changed_pid
+

--- a/srv/salt/ceph/tests/restart/mon/changed_pid.sls
+++ b/srv/salt/ceph/tests/restart/mon/changed_pid.sls
@@ -1,0 +1,4 @@
+
+{% set service = "mon" %}
+{% include  "ceph/tests/restart/changed_pid.sls" %}
+

--- a/srv/salt/ceph/tests/restart/mon/forced/init.sls
+++ b/srv/salt/ceph/tests/restart/mon/forced/init.sls
@@ -1,0 +1,6 @@
+
+include:
+  - ..save_pid
+  - .....mon.restart.force
+  - ..changed_pid
+

--- a/srv/salt/ceph/tests/restart/mon/nochange/init.sls
+++ b/srv/salt/ceph/tests/restart/mon/nochange/init.sls
@@ -1,0 +1,6 @@
+
+include:
+  - ..save_pid
+  - .....mon.restart
+  - ..same_pid
+

--- a/srv/salt/ceph/tests/restart/mon/reset.sls
+++ b/srv/salt/ceph/tests/restart/mon/reset.sls
@@ -1,0 +1,4 @@
+
+{% set service = "mon" %}
+{% include  "ceph/tests/restart/reset.sls" %}
+

--- a/srv/salt/ceph/tests/restart/mon/same_pid.sls
+++ b/srv/salt/ceph/tests/restart/mon/same_pid.sls
@@ -1,0 +1,4 @@
+
+{% set service = "mon" %}
+{% include  "ceph/tests/restart/same_pid.sls" %}
+

--- a/srv/salt/ceph/tests/restart/mon/save_pid.sls
+++ b/srv/salt/ceph/tests/restart/mon/save_pid.sls
@@ -1,0 +1,4 @@
+
+{% set service = "mon" %}
+{% include  "ceph/tests/restart/save_pid.sls" %}
+

--- a/srv/salt/ceph/tests/restart/mon/setup.sls
+++ b/srv/salt/ceph/tests/restart/mon/setup.sls
@@ -1,0 +1,4 @@
+
+{% set service = "mon" %}
+{% include  "ceph/tests/restart/setup.sls" %}
+

--- a/srv/salt/ceph/tests/restart/mon/teardown.sls
+++ b/srv/salt/ceph/tests/restart/mon/teardown.sls
@@ -1,0 +1,4 @@
+
+{% set service = "mon" %}
+{% include  "ceph/tests/restart/teardown.sls" %}
+

--- a/srv/salt/ceph/tests/restart/reset.sls
+++ b/srv/salt/ceph/tests/restart/reset.sls
@@ -1,0 +1,6 @@
+
+reset systemctl: 
+  cmd.run: 
+    - name: "systemctl reset-failed ceph-{{ service }}@{{ grains['host'] }}" 
+
+

--- a/srv/salt/ceph/tests/restart/rgw/change/init.sls
+++ b/srv/salt/ceph/tests/restart/rgw/change/init.sls
@@ -1,0 +1,6 @@
+
+include:
+  - ..save_pid
+  - .....rgw.restart
+  - ..changed_pid
+

--- a/srv/salt/ceph/tests/restart/rgw/changed_pid.sls
+++ b/srv/salt/ceph/tests/restart/rgw/changed_pid.sls
@@ -1,0 +1,11 @@
+
+Changed pid:
+  cmd.run:
+    - name: "[ `pgrep radosgw` !=  `cat /tmp/restart.pid` ]"
+    - shell: /bin/bash
+    - failhard: True
+
+/tmp/restart.pid:
+  file.absent
+
+

--- a/srv/salt/ceph/tests/restart/rgw/forced/init.sls
+++ b/srv/salt/ceph/tests/restart/rgw/forced/init.sls
@@ -1,0 +1,6 @@
+
+include:
+  - ..save_pid
+  - .....rgw.restart.force
+  - ..changed_pid
+

--- a/srv/salt/ceph/tests/restart/rgw/nochange/init.sls
+++ b/srv/salt/ceph/tests/restart/rgw/nochange/init.sls
@@ -1,0 +1,6 @@
+
+include:
+  - ..save_pid
+  - .....rgw.restart
+  - ..same_pid
+

--- a/srv/salt/ceph/tests/restart/rgw/reset.sls
+++ b/srv/salt/ceph/tests/restart/rgw/reset.sls
@@ -1,0 +1,6 @@
+
+reset systemctl: 
+  cmd.run: 
+    - name: "systemctl reset-failed ceph-radosgw@rgw.{{ grains['host'] }}" 
+
+

--- a/srv/salt/ceph/tests/restart/rgw/same_pid.sls
+++ b/srv/salt/ceph/tests/restart/rgw/same_pid.sls
@@ -1,0 +1,9 @@
+
+Check pid:
+  cmd.run:
+    - name: "[ `pgrep radosgw` ==  `cat /tmp/restart.pid` ]"
+    - failhard: True
+
+/tmp/restart.pid:
+  file.absent
+

--- a/srv/salt/ceph/tests/restart/rgw/save_pid.sls
+++ b/srv/salt/ceph/tests/restart/rgw/save_pid.sls
@@ -1,0 +1,7 @@
+
+Save pid:
+  cmd.run:
+    - name: "pgrep radosgw > /tmp/restart.pid"
+    - shell: /bin/bash
+
+

--- a/srv/salt/ceph/tests/restart/rgw/setup.sls
+++ b/srv/salt/ceph/tests/restart/rgw/setup.sls
@@ -1,0 +1,4 @@
+
+{% set service = "rgw" %}
+{% include  "ceph/tests/restart/setup.sls" %}
+

--- a/srv/salt/ceph/tests/restart/rgw/teardown.sls
+++ b/srv/salt/ceph/tests/restart/rgw/teardown.sls
@@ -1,0 +1,4 @@
+
+{% set service = "rgw" %}
+{% include  "ceph/tests/restart/teardown.sls" %}
+

--- a/srv/salt/ceph/tests/restart/same_pid.sls
+++ b/srv/salt/ceph/tests/restart/same_pid.sls
@@ -1,0 +1,9 @@
+
+Check pid:
+  cmd.run:
+    - name: "[ `pgrep ceph-{{ service }}` ==  `cat /tmp/restart.pid` ]"
+    - failhard: True
+
+/tmp/restart.pid:
+  file.absent
+

--- a/srv/salt/ceph/tests/restart/save_pid.sls
+++ b/srv/salt/ceph/tests/restart/save_pid.sls
@@ -1,0 +1,6 @@
+
+Save pid:
+  cmd.run:
+    - name: "pgrep ceph-{{ service }} > /tmp/restart.pid"
+    - shell: /bin/bash
+

--- a/srv/salt/ceph/tests/restart/setup.sls
+++ b/srv/salt/ceph/tests/restart/setup.sls
@@ -1,0 +1,6 @@
+
+update {{ service }}.conf:
+  cmd.run:
+    - name: "date +\\#\\ %c > /srv/salt/ceph/configuration/files/ceph.conf.d/{{ service }}.conf"
+
+

--- a/srv/salt/ceph/tests/restart/teardown.sls
+++ b/srv/salt/ceph/tests/restart/teardown.sls
@@ -1,0 +1,4 @@
+
+/srv/salt/ceph/configuration/files/ceph.conf.d/{{ service }}.conf:
+  file.absent
+


### PR DESCRIPTION
Initially working for mon, mds, mgr and rgw.  Each service is checked
for the following:

1) Forced restart must restart
2) No config changes must not restart
3) Config changes must restart
4) Config removal must restart

The global.conf, igw and ganesha are not addressed.  Test 2 will fail if your cluster does have pending changes.  I an undecided on further initializing or requiring that pending changes be applied.

Signed-off-by: Eric Jackson <ejackson@suse.com>

