### PR TITLE
Prefer underscore device names

### DIFF
--- a/srv/salt/_modules/osd.py
+++ b/srv/salt/_modules/osd.py
@@ -1747,7 +1747,7 @@ class OSDDevices(object):
     # pylint: disable=no-self-use
     def _uuid_device(self, device, pathname="/dev/disk/by-id"):
         """
-        Return the uuid device, last one if multiple are matched
+        Return the uuid device, prefer the most descriptive
         """
         if os.path.exists(device):
             if os.path.exists(pathname):
@@ -1755,9 +1755,28 @@ class OSDDevices(object):
                        r"-o -name nvme* \)".format(pathname, device))
                 _, _stdout, _stderr = _run(cmd)
                 if _stdout:
-                    return _stdout.split()[-1]
+                    _devices = _stdout.split()
+                    index = self._prefer_underscores(_devices)
+                    return _devices[index]
                 return readlink(device)
             return readlink(device)
+
+    def _prefer_underscores(self, devicenames):
+        """
+        Many symlinks in /dev/disk/by-id refer to the same device.  The
+        most descriptive names have the most underscores.  These are likely
+        the most useful to the admin.
+
+        In the worst case, return the last device
+        """
+        index = -1
+        count = 0
+        for _idx, device in enumerate(devicenames):
+            underscores = device.count('_')
+            if underscores > count:
+                count = underscores
+                index = _idx
+        return index
 
 
 # pylint: disable=too-few-public-methods

--- a/srv/salt/_modules/proposal.py
+++ b/srv/salt/_modules/proposal.py
@@ -235,14 +235,33 @@ class Proposal(object):
 
 def _device(drive):
     """
-    Default to Device File value.  Use by-id if available.
+    Default to Device File value.  Prefer most descriptive.
     """
     if 'Device Files' in drive:
-        for path in drive['Device Files'].split(', '):
-            if 'by-id' in path:
-                return path
-    # fallback to Device File if no by-id path was found
+        devices = drive['Device Files'].split(', ')
+        index = _prefer_underscores(devices)
+        # Prefer 'Device File' over last item
+        if index > -1:
+            return devices[index]
     return drive['Device File']
+
+
+def _prefer_underscores(devicenames):
+    """
+    Many symlinks in /dev/disk/by-id refer to the same device.  The
+    most descriptive names have the most underscores.  These are likely
+    the most useful to the admin.
+
+    In the worst case, return the last device
+    """
+    index = -1
+    count = 0
+    for _idx, device in enumerate(devicenames):
+        underscores = device.count('_')
+        if underscores > count:
+            count = underscores
+            index = _idx
+    return index
 
 
 def generate(**kwargs):

--- a/tests/unit/_modules/test_osd.py
+++ b/tests/unit/_modules/test_osd.py
@@ -2027,6 +2027,35 @@ class TestOSDCommands():
     def test_detect(self):
         pass
 
+class TestOSDDevices():
+
+    def test_prefer_underscores(self):
+        devices = [
+            '/dev/disk/by-id/wwn-0x5002538d70022771',
+            '/dev/disk/by-id/scsi-SATA_Samsung_SSD_850_S24CNWAG402893J',
+            '/dev/disk/by-id/scsi-SATA_Samsung_SSD_850S24CNWAG402893J',
+            '/dev/disk/by-id/scsi-35002538d70022771',
+            '/dev/disk/by-id/scsi-1ATA_Samsung_SSD_850_EVO_M.2_500GB_S24CNWAG402893J',
+            '/dev/disk/by-id/scsi-0ATA_Samsung_SSD_850_S24CNWAG402893J',
+            '/dev/disk/by-id/ata-Samsung_SSD_850_EVO_M.2_500GB_S24CNWAG402893J'
+        ]
+
+        with patch.object(osd.OSDDevices, "__init__", lambda self: None):
+            osddevices = osd.OSDDevices()
+            ret = osddevices._prefer_underscores(devices)
+            assert ret == 4
+
+    def test_prefer_underscores_no_match(self):
+        devices = [
+            '/dev/disk/by-id/wwn-0x5002538d70022771',
+        ]
+
+        with patch.object(osd.OSDDevices, "__init__", lambda self: None):
+            osddevices = osd.OSDDevices()
+            ret = osddevices._prefer_underscores(devices)
+            assert ret == -1
+
+
 class Test_is_incorrect():
     '''
     Create the six possible OSDs in a FakeFilesystem.  Overwrite the


### PR DESCRIPTION
Many symlinks in /dev/disk/by-id match a single device, but the most
useful for the administrator has the best description.

Intentional code duplication to not conflate issues.

Signed-off-by: Eric Jackson <ejackson@suse.com>

Fixes #952 
