### PR TITLE
[backport][SES5] Add active+clean wait for migrations 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,14 @@ copy-files:
 	install -m 644 qa/common/*.sh $(DESTDIR)/usr/lib/deepsea/qa/common/
 	install -m 755 qa/suites/basic/*.sh $(DESTDIR)/usr/lib/deepsea/qa/suites/basic/
 	install -m 755 qa/suites/ceph-test/*.sh $(DESTDIR)/usr/lib/deepsea/qa/suites/ceph-test/
+	# tests
+	install -d -m 755 $(DESTDIR)/srv/salt/ceph/tests/quiescent
+	install -d -m 755 $(DESTDIR)/srv/salt/ceph/tests/quiescent/timeout
+	install -m 644 srv/salt/ceph/tests/quiescent/*.sls $(DESTDIR)/srv/salt/ceph/tests/quiescent
+	install -m 644 srv/salt/ceph/tests/quiescent/timeout/*.sls $(DESTDIR)/srv/salt/ceph/tests/quiescent/timeout
+	# smoketests
+	install -d -m 755 $(DESTDIR)/srv/salt/ceph/smoketests/quiescent
+	install -m 644 srv/salt/ceph/smoketests/quiescent/*.sls $(DESTDIR)/srv/salt/ceph/smoketests/quiescent
 	# docs
 	install -d -m 755 $(DESTDIR)$(DOCDIR)/deepsea
 	install -m 644 LICENSE $(DESTDIR)$(DOCDIR)/deepsea/

--- a/deepsea.spec.in
+++ b/deepsea.spec.in
@@ -644,5 +644,11 @@ the README for more information.
 
 %files qa
 %{_libexecdir}/deepsea/qa
+%dir /srv/salt/ceph/smoketests/quiescent
+%dir /srv/salt/ceph/tests/quiescent
+%dir /srv/salt/ceph/tests/quiescent/timeout
+/srv/salt/ceph/smoketests/quiescent/*.sls
+/srv/salt/ceph/tests/quiescent/*.sls
+/srv/salt/ceph/tests/quiescent/timeout/*.sls
 
 %changelog

--- a/srv/salt/_modules/osd.py
+++ b/srv/salt/_modules/osd.py
@@ -348,11 +348,21 @@ class OSDWeight(object):
         ret,output,err = self.cluster.mon_command(cmd, b'', timeout=6)
         #log.debug(json.dumps((json.loads(output)['nodes']), indent=4))
         for entry in json.loads(output)['nodes']:
-            if entry['id'] == self.id:
+            if entry['id'] == int(self.osd_id):
                 log.debug(pprint.pformat(entry))
                 return entry
         log.warn("ID {} not found".format(self.id))
         return {}
+
+    # pylint: disable=invalid-name
+    def osd_safe_to_destroy(self):
+        """
+        Returns safe-to-destroy output, does not return JSON
+        """
+        cmd = json.dumps({"prefix": "osd safe-to-destroy",
+                          "ids": ["{}".format(self.osd_id)]})
+        rc, _, output = self.cluster.mon_command(cmd, b'', timeout=6)
+        return rc, output
 
     def is_empty(self):
         """
@@ -368,11 +378,15 @@ class OSDWeight(object):
         i = 0
         last_pgs = 0
         while i < self.settings['timeout']/self.settings['delay']:
+            rc, msg = self.osd_safe_to_destroy()
+            if rc == 0:
+                log.info("osd.{} is safe to destroy".format(self.osd_id))
+                return ""
             entry = self.osd_df()
             if 'pgs' in entry:
                 if entry['pgs'] == 0:
-                    log.info("osd.{} has no PGs".format(self.id))
-                    return ""
+                    log.warning("osd.{} has {} PGs remaining but {}".
+                                format(self.osd_id, entry['pgs'], msg))
                 else:
                     log.warn("osd.{} has {} PGs remaining".format(self.id, entry['pgs']))
                     if last_pgs != entry['pgs']:
@@ -380,17 +394,14 @@ class OSDWeight(object):
                         i = 0
                         last_pgs = entry['pgs']
             else:
-                msg = "osd.{} does not exist".format(self.id)
-                log.warn(msg)
-                return msg
+                msg = "osd.{} does not exist {}".format(self.osd_id, msg)
+                log.warning(msg)
             i += 1
             time.sleep(self.settings['delay'])
 
         log.debug("Timeout expired")
         raise RuntimeError("Timeout expired")
 
-<<<<<<< HEAD
-=======
 
 class CephPGs(object):
     """
@@ -467,7 +478,6 @@ class CephPGs(object):
         return json.loads(output)['num_pg_by_state']
 
 
->>>>>>> dd688e193... Add active+clean wait for migrations
 def _settings(**kwargs):
     """
     Initialize settings to use the client.storage name and keyring
@@ -487,9 +497,6 @@ def _settings(**kwargs):
     return settings
 
 
-<<<<<<< HEAD
-def zero_weight(id, wait=True, **kwargs):
-=======
 def ceph_quiescent(**kwargs):
     """
     Check that PGs are active+clean
@@ -501,7 +508,6 @@ def ceph_quiescent(**kwargs):
 
 
 def zero_weight(osd_id, wait=True, **kwargs):
->>>>>>> dd688e193... Add active+clean wait for migrations
     """
     Set weight to zero and wait until PGs are moved
     """
@@ -1871,7 +1877,7 @@ def redeploy(simultaneous=False, **kwargs):
         if not os.path.exists(partition) or is_incorrect(disk):
             pgs = CephPGs(**settings)
             pgs.quiescent()
-            remove(_id)
+            remove(_id, **settings)
             config = OSDConfig(disk)
             osdp = OSDPartitions(config)
             osdp.partition()

--- a/srv/salt/ceph/redeploy/nodes/default-10m.sls
+++ b/srv/salt/ceph/redeploy/nodes/default-10m.sls
@@ -1,0 +1,13 @@
+
+redeploy:
+  module.run:
+    - name: osd.redeploy
+    - simultaneous: True
+    - kwargs:
+        timeout: 600
+        delay: 12
+
+save grains:
+  module.run:
+    - name: osd.retain
+

--- a/srv/salt/ceph/redeploy/osds/default-10m.sls
+++ b/srv/salt/ceph/redeploy/osds/default-10m.sls
@@ -1,0 +1,12 @@
+
+redeploy:
+  module.run:
+    - name: osd.redeploy
+    - kwargs:
+        timeout: 600
+        delay: 12
+
+save grains:
+  module.run:
+    - name: osd.retain
+

--- a/srv/salt/ceph/smoketests/quiescent/init.sls
+++ b/srv/salt/ceph/smoketests/quiescent/init.sls
@@ -1,0 +1,17 @@
+
+{% set node = salt.saltutil.runner('select.one_minion', cluster='ceph', roles='storage') %}
+
+{{ node }}:
+  test.nop
+
+check active+clean:
+  salt.state:
+    - tgt: {{ node }}
+    - tgt_type: compound
+    - sls: ceph.tests.quiescent
+
+check not active+clean:
+  salt.state:
+    - tgt: {{ node }}
+    - tgt_type: compound
+    - sls: ceph.tests.quiescent.timeout

--- a/srv/salt/ceph/tests/quiescent/init.sls
+++ b/srv/salt/ceph/tests/quiescent/init.sls
@@ -1,0 +1,6 @@
+
+active+clean:
+  module.run:
+    - name: osd.ceph_quiescent
+    - timeout: 1
+    - delay: 1

--- a/srv/salt/ceph/tests/quiescent/timeout/init.sls
+++ b/srv/salt/ceph/tests/quiescent/timeout/init.sls
@@ -1,0 +1,31 @@
+
+{% set id = salt['osd.list']() | first %}
+
+"{{ id }}":
+  test.nop 
+
+stop OSD:
+  cmd.run:
+    - name: "systemctl stop ceph-osd@{{ id }}"
+
+not active+clean:
+  module.run:
+    - name: osd.ceph_quiescent
+    - kwargs:
+        timeout: 1
+        delay: 1
+    - onfail:
+        - test: passes
+
+Timeout failed:
+  test.fail_without_changes:
+    - onlyif:
+      - not active+clean
+
+passes:
+  test.nop
+
+start OSD:
+  cmd.run:
+    - name: "systemctl start ceph-osd@{{ id }}"
+

--- a/tests/unit/_modules/test_osd.py
+++ b/tests/unit/_modules/test_osd.py
@@ -121,21 +121,61 @@ class TestOSDInstanceMethods():
 class TetstOSDState():
     pass
 
-@pytest.mark.skip(reason="Low priority: skipped")
 class TestOSDWeight():
-    pass
+    """
+    Initial checks for the wait method.  Override the __init__ funciton to
+    avoid the rados logic.  Set osd_id and settings directly.
+    """
+
+    @patch('srv.salt._modules.osd.OSDWeight.osd_safe_to_destroy')
+    def test_wait(self, ostd):
+        """
+        Check that wait returns successfully
+        """
+        ostd.return_value = (0, "safe to destroy")
+        with patch.object(osd.OSDWeight, "__init__", lambda self, _id: None):
+            osdw = osd.OSDWeight(0)
+            osdw.osd_id = 0
+            osdw.settings = {'timeout': 1, 'delay': 1}
+            ret = osdw.wait()
+            assert ret == ""
+
+    @pytest.mark.skip(reason='skip')
+    @patch('srv.salt._modules.osd.OSDWeight.osd_df')
+    @patch('srv.salt._modules.osd.OSDWeight.osd_safe_to_destroy')
+    def test_wait_timeout(self, od, ostd):
+        """
+        Check that wait can timeout
+        """
+        od = {}
+        ostd.return_value = (-16, "Ceph is busy")
+        with patch.object(osd.OSDWeight, "__init__", lambda self, _id: None):
+            osdw = osd.OSDWeight(0)
+            osdw.osd_id = 0
+            osdw.settings = {'timeout': 1, 'delay': 1, 'osd_id': 0}
+            with pytest.raises(RuntimeError) as excinfo:
+                ret = osdw.wait()
+                assert 'Timeout expired' in str(excinfo.value)
+
+    @pytest.mark.skip(reason='skip')
+    @patch('srv.salt._modules.osd.OSDWeight.osd_df')
+    @patch('srv.salt._modules.osd.OSDWeight.osd_safe_to_destroy')
+    def test_wait_loops(self, od, ostd):
+        """
+        Check that wait does loop
+        """
+        od = {}
+        ostd.return_value = (-16, "Ceph is busy")
+        with patch.object(osd.OSDWeight, "__init__", lambda self, _id: None):
+            osdw = osd.OSDWeight(0)
+            osdw.osd_id = 0
+            osdw.settings = {'timeout': 1, 'delay': 1, 'osd_id': 0}
+            with pytest.raises(RuntimeError) as excinfo:
+                ret = osdw.wait()
+                assert ostd.call_count == 2
 
 
 class TestOSDConfig():
-
-    # How to properly reset the salt_internals after it was altered..
-    # fixtures allow you to teardown the fixture..
-    # can you yield multiple things?
-    @pytest.fixture(scope='class')
-    def salt_internals(self):
-        osd.__pillar__ = {}
-        osd.__salt__ = {'mine.get': 'asd'}
-        osd.__grains__ = {'id': 1}
 
     @pytest.fixture(scope='class')
     def osd_o(self):


### PR DESCRIPTION
Before removing an OSD, ensure that all PGs are active+clean.
Includes unit and functional tests.

Signed-off-by: Eric Jackson <ejackson@suse.com>
(cherry picked from commit 678becc)

Signed-off-by: Eric Jackson <ejackson@suse.com>
(cherry picked from commit dd688e1)


backport of #1026 

_**!Review with caution. Lots of conflicts!**_

-----------------

[Please find more information on how to run integration tests here](https://github.com/SUSE/DeepSea/wiki/Integration-tests)
