### PR TITLE
[backport][SES5] Return a single device

### DIFF
--- a/srv/salt/_modules/cephinspector.py
+++ b/srv/salt/_modules/cephinspector.py
@@ -67,9 +67,9 @@ def _get_disk_id(partition):
 
     # We should only ever have one entry that we return.
     if out:
-        return out.rstrip()
-    else:
-        return partition
+        return out.split()[-1]
+    return partition
+
 
 def _get_osd_type(part_dict):
     """


### PR DESCRIPTION
The find command may return multiple symlinks, but only one is needed.

Signed-off-by: Eric Jackson <ejackson@suse.com>
(cherry picked from commit 8131286dc4be3fa0a3204febd5bd47315b2aeb08)

backport of #1049 

-----------------

[Please find more information on how to run integration tests here](https://github.com/SUSE/DeepSea/wiki/Integration-tests)
