### PR TITLE
[backport][SES5] Prefer underscore device names

### DIFF
--- a/srv/salt/_modules/osd.py
+++ b/srv/salt/_modules/osd.py
@@ -1629,7 +1629,7 @@ class OSDDevices(object):
 
     def _uuid_device(self, device, pathname="/dev/disk/by-id"):
         """
-        Return the uuid device, last one if multiple are matched
+        Return the uuid device, prefer the most descriptive
         """
         if os.path.exists(device):
             if os.path.exists(pathname):
@@ -1637,11 +1637,29 @@ class OSDDevices(object):
                        r"-o -name nvme* \)".format(pathname, device))
                 _, _stdout, _stderr = _run(cmd)
                 if _stdout:
-                    return _stdout.split()[-1]
-                else:
-                    return readlink(device)
-            else:
+                    _devices = _stdout.split()
+                    index = self._prefer_underscores(_devices)
+                    return _devices[index]
                 return readlink(device)
+            return readlink(device)
+
+    def _prefer_underscores(self, devicenames):
+        """
+        Many symlinks in /dev/disk/by-id refer to the same device.  The
+        most descriptive names have the most underscores.  These are likely
+        the most useful to the admin.
+
+        In the worst case, return the last device
+        """
+        index = -1
+        count = 0
+        for _idx, device in enumerate(devicenames):
+            underscores = device.count('_')
+            if underscores > count:
+                count = underscores
+                index = _idx
+        return index
+
 
 class OSDGrains(object):
     """

--- a/srv/salt/_modules/proposal.py
+++ b/srv/salt/_modules/proposal.py
@@ -192,16 +192,36 @@ class Proposal(object):
                     filtered.append(disk)
         return filtered
 
+
     def _device(self, drive):
         """
-        Default to Device File value.  Use by-id if available.
+        Default to Device File value.  Prefer most descriptive.
         """
         if 'Device Files' in drive:
-            for path in drive['Device Files'].split(', '):
-                if 'by-id' in path:
-                    return path
-        # fallback to Device File if no by-id path was found
+            devices = drive['Device Files'].split(', ')
+            index = _prefer_underscores(devices)
+            # Prefer 'Device File' over last item
+            if index > -1:
+                return devices[index]
         return drive['Device File']
+
+
+def _prefer_underscores(devicenames):
+    """
+    Many symlinks in /dev/disk/by-id refer to the same device.  The
+    most descriptive names have the most underscores.  These are likely
+    the most useful to the admin.
+
+    In the worst case, return the last device
+    """
+    index = -1
+    count = 0
+    for _idx, device in enumerate(devicenames):
+        underscores = device.count('_')
+        if underscores > count:
+            count = underscores
+            index = _idx
+    return index
 
 
 def generate(**kwargs):

--- a/tests/unit/_modules/test_osd.py
+++ b/tests/unit/_modules/test_osd.py
@@ -1990,6 +1990,35 @@ class TestOSDCommands():
     def test_detect(self):
         pass
 
+class TestOSDDevices():
+
+    def test_prefer_underscores(self):
+        devices = [
+            '/dev/disk/by-id/wwn-0x5002538d70022771',
+            '/dev/disk/by-id/scsi-SATA_Samsung_SSD_850_S24CNWAG402893J',
+            '/dev/disk/by-id/scsi-SATA_Samsung_SSD_850S24CNWAG402893J',
+            '/dev/disk/by-id/scsi-35002538d70022771',
+            '/dev/disk/by-id/scsi-1ATA_Samsung_SSD_850_EVO_M.2_500GB_S24CNWAG402893J',
+            '/dev/disk/by-id/scsi-0ATA_Samsung_SSD_850_S24CNWAG402893J',
+            '/dev/disk/by-id/ata-Samsung_SSD_850_EVO_M.2_500GB_S24CNWAG402893J'
+        ]
+
+        with patch.object(osd.OSDDevices, "__init__", lambda self: None):
+            osddevices = osd.OSDDevices()
+            ret = osddevices._prefer_underscores(devices)
+            assert ret == 4
+
+    def test_prefer_underscores_no_match(self):
+        devices = [
+            '/dev/disk/by-id/wwn-0x5002538d70022771',
+        ]
+
+        with patch.object(osd.OSDDevices, "__init__", lambda self: None):
+            osddevices = osd.OSDDevices()
+            ret = osddevices._prefer_underscores(devices)
+            assert ret == -1
+
+
 class Test_is_incorrect():
     '''
     Create the six possible OSDs in a FakeFilesystem.  Overwrite the


### PR DESCRIPTION
Many symlinks in /dev/disk/by-id match a single device, but the most
useful for the administrator has the best description.

Intentional code duplication to not conflate issues.

Signed-off-by: Eric Jackson <ejackson@suse.com>
(cherry picked from commit a0168a10092c906f20b9516a1b3dfcc4eb691e3d)

backport of #1061 


**conflicts, review with caution** 

-----------------

[Please find more information on how to run integration tests here](https://github.com/SUSE/DeepSea/wiki/Integration-tests)
