### PR TITLE
Change PG ratio to 4:1

### DIFF
--- a/srv/salt/ceph/mds/pools/default.sls
+++ b/srv/salt/ceph/mds/pools/default.sls
@@ -9,7 +9,7 @@ prevent empty rendering:
 
 cephfs data:
   cmd.run:
-    - name: "ceph osd pool create cephfs_data 128"
+    - name: "ceph osd pool create cephfs_data 256"
     - unless:
       - "rados lspools | grep -q cephfs_data"
       - "ceph fs ls | grep -q ^name"
@@ -20,7 +20,7 @@ cephfs data pool enable application:
 
 cephfs metadata:
   cmd.run:
-    - name: "ceph osd pool create cephfs_metadata 128"
+    - name: "ceph osd pool create cephfs_metadata 64"
     - unless:
       - "rados lspools | grep -q cephfs_metadata"
       - "ceph fs ls | grep -q ^name"


### PR DESCRIPTION
While we do not have a magic calculator for pools yet to be created,
changing the defaults will help convey to administrators the expected
ratio when increasing the PGs.

Signed-off-by: Eric Jackson <ejackson@suse.com>

Fixes #887 