### PR TITLE
Fix arg name passed to changed.config

### DIFF
--- a/srv/salt/ceph/stage/deploy/core/default.sls
+++ b/srv/salt/ceph/stage/deploy/core/default.sls
@@ -68,7 +68,7 @@ configuration:
 {% set ret_osd = salt['saltutil.runner']('changed.osd') %}
 {% set ret_mgr = salt['saltutil.runner']('changed.mgr') %}
 {% for config in salt['pillar.get']('rgw_configurations', [ 'rgw' ]) %}
-{% set ret_rgw_conf = salt.saltutil.runner('changed.config', role=config) %}
+{% set ret_rgw_conf = salt.saltutil.runner('changed.config', role_name=config) %}
 {% endfor %}
 {% set ret_client = salt['saltutil.runner']('changed.client') %}
 {% set ret_global = salt['saltutil.runner']('changed.global') %}


### PR DESCRIPTION
Signed-off-by: Joshua Schmid <jschmid@suse.de>


Description: 

`Role` expects 'role_name' in kwargs but we passed 'role' in stage.3/core/default.sls

-----------------

[Please find more information on how to run integration tests here](https://github.com/SUSE/DeepSea/wiki/Integration-tests)
