### PR TITLE
Correct permissions on job cache

### DIFF
--- a/srv/salt/ceph/configuration/create/default.sls
+++ b/srv/salt/ceph/configuration/create/default.sls
@@ -12,6 +12,11 @@ removing minion cache:
     - makedirs: True
     - fire_event: True
 
-
-
+/var/cache/salt/master/jobs:
+  file.directory:
+    - user: {{ salt['deepsea.user']() }}
+    - group: {{ salt['deepsea.group']() }}
+    - recurse:
+      - user
+      - group
 

--- a/srv/salt/ceph/ganesha/auth/default.sls
+++ b/srv/salt/ceph/ganesha/auth/default.sls
@@ -15,4 +15,11 @@ auth {{ keyring_file }}:
 {% endfor %}
 {% endfor %}
 
+/var/cache/salt/master/jobs:
+  file.directory:
+    - user: {{ salt['deepsea.user']() }}
+    - group: {{ salt['deepsea.group']() }}
+    - recurse:
+      - user
+      - group
 

--- a/srv/salt/ceph/ganesha/config/default.sls
+++ b/srv/salt/ceph/ganesha/config/default.sls
@@ -36,3 +36,12 @@ check {{ role }}:
 
 {% endfor %}
 {% endfor %}
+
+/var/cache/salt/master/jobs:
+  file.directory:
+    - user: {{ salt['deepsea.user']() }}
+    - group: {{ salt['deepsea.group']() }}
+    - recurse:
+      - user
+      - group
+

--- a/srv/salt/ceph/ganesha/key/default.sls
+++ b/srv/salt/ceph/ganesha/key/default.sls
@@ -30,4 +30,11 @@ check {{ role }}:
 {% endfor %}
 {% endfor %}
 
+/var/cache/salt/master/jobs:
+  file.directory:
+    - user: {{ salt['deepsea.user']() }}
+    - group: {{ salt['deepsea.group']() }}
+    - recurse:
+      - user
+      - group
 

--- a/srv/salt/ceph/igw/auth/default.sls
+++ b/srv/salt/ceph/igw/auth/default.sls
@@ -12,3 +12,12 @@ auth {{ keyring_file }}:
     - name: "ceph auth add {{ client }} -i {{ keyring_file }}"
 
 {% endfor %}
+
+/var/cache/salt/master/jobs:
+  file.directory:
+    - user: {{ salt['deepsea.user']() }}
+    - group: {{ salt['deepsea.group']() }}
+    - recurse:
+      - user
+      - group
+

--- a/srv/salt/ceph/igw/config/default.sls
+++ b/srv/salt/ceph/igw/config/default.sls
@@ -38,4 +38,11 @@ clear master file cache:
 
 {% endif %}
 
+/var/cache/salt/master/jobs:
+  file.directory:
+    - user: {{ salt['deepsea.user']() }}
+    - group: {{ salt['deepsea.group']() }}
+    - recurse:
+      - user
+      - group
 

--- a/srv/salt/ceph/igw/key/default.sls
+++ b/srv/salt/ceph/igw/key/default.sls
@@ -20,3 +20,12 @@ prevent empty rendering:
     - fire_event: True
 
 {% endfor %}
+
+/var/cache/salt/master/jobs:
+  file.directory:
+    - user: {{ salt['deepsea.user']() }}
+    - group: {{ salt['deepsea.group']() }}
+    - recurse:
+      - user
+      - group
+

--- a/srv/salt/ceph/mds/auth/default.sls
+++ b/srv/salt/ceph/mds/auth/default.sls
@@ -13,4 +13,11 @@ auth {{ keyring_file }}:
 
 {% endfor %}
 
+/var/cache/salt/master/jobs:
+  file.directory:
+    - user: {{ salt['deepsea.user']() }}
+    - group: {{ salt['deepsea.group']() }}
+    - recurse:
+      - user
+      - group
 

--- a/srv/salt/ceph/mds/key/default.sls
+++ b/srv/salt/ceph/mds/key/default.sls
@@ -21,4 +21,11 @@ prevent empty rendering:
 
 {% endfor %}
 
+/var/cache/salt/master/jobs:
+  file.directory:
+    - user: {{ salt['deepsea.user']() }}
+    - group: {{ salt['deepsea.group']() }}
+    - recurse:
+      - user
+      - group
 

--- a/srv/salt/ceph/mds/pools/default.sls
+++ b/srv/salt/ceph/mds/pools/default.sls
@@ -36,3 +36,11 @@ cephfs:
 
 {% endif %}
 
+/var/cache/salt/master/jobs:
+  file.directory:
+    - user: {{ salt['deepsea.user']() }}
+    - group: {{ salt['deepsea.group']() }}
+    - recurse:
+      - user
+      - group
+

--- a/srv/salt/ceph/mgr/auth/default.sls
+++ b/srv/salt/ceph/mgr/auth/default.sls
@@ -13,4 +13,11 @@ auth {{ keyring_file }}:
 
 {% endfor %}
 
+/var/cache/salt/master/jobs:
+  file.directory:
+    - user: {{ salt['deepsea.user']() }}
+    - group: {{ salt['deepsea.group']() }}
+    - recurse:
+      - user
+      - group
 

--- a/srv/salt/ceph/mgr/key/default.sls
+++ b/srv/salt/ceph/mgr/key/default.sls
@@ -21,4 +21,11 @@ prevent empty rendering:
 
 {% endfor %}
 
+/var/cache/salt/master/jobs:
+  file.directory:
+    - user: {{ salt['deepsea.user']() }}
+    - group: {{ salt['deepsea.group']() }}
+    - recurse:
+      - user
+      - group
 

--- a/srv/salt/ceph/monitoring/default.sls
+++ b/srv/salt/ceph/monitoring/default.sls
@@ -3,3 +3,12 @@ include:
   - .prometheus.update_service_discovery
   - .prometheus.alertmanager
   - .grafana
+
+/var/cache/salt/master/jobs:
+  file.directory:
+    - user: {{ salt['deepsea.user']() }}
+    - group: {{ salt['deepsea.group']() }}
+    - recurse:
+      - user
+      - group
+

--- a/srv/salt/ceph/monitoring/grafana/init.sls
+++ b/srv/salt/ceph/monitoring/grafana/init.sls
@@ -123,3 +123,4 @@ remove rgw-users dashboard:
           -XDELETE http://admin:admin@localhost:3000/api/dashboards/db/ceph-object-gateway-users
 
 {% endif %}
+

--- a/srv/salt/ceph/monitoring/prometheus/update_service_discovery.sls
+++ b/srv/salt/ceph/monitoring/prometheus/update_service_discovery.sls
@@ -26,4 +26,3 @@
        - file: /etc/prometheus/ses_nodes/{{ minion }}.yml
 {% endfor %}
 
-

--- a/srv/salt/ceph/remove/ganesha/default.sls
+++ b/srv/salt/ceph/remove/ganesha/default.sls
@@ -14,3 +14,12 @@ auth {{ keyring }}:
 {% endfor %}
 {% endfor %}
 {% endif %}
+
+/var/cache/salt/master/jobs:
+  file.directory:
+    - user: {{ salt['deepsea.user']() }}
+    - group: {{ salt['deepsea.group']() }}
+    - recurse:
+      - user
+      - group
+

--- a/srv/salt/ceph/remove/mds/default.sls
+++ b/srv/salt/ceph/remove/mds/default.sls
@@ -22,3 +22,11 @@ remove data:
 
 {% endif %}
 
+/var/cache/salt/master/jobs:
+  file.directory:
+    - user: {{ salt['deepsea.user']() }}
+    - group: {{ salt['deepsea.group']() }}
+    - recurse:
+      - user
+      - group
+

--- a/srv/salt/ceph/remove/mgr/default.sls
+++ b/srv/salt/ceph/remove/mgr/default.sls
@@ -10,3 +10,12 @@ remove mgr auth:
 
 
 {% endif %}
+
+/var/cache/salt/master/jobs:
+  file.directory:
+    - user: {{ salt['deepsea.user']() }}
+    - group: {{ salt['deepsea.group']() }}
+    - recurse:
+      - user
+      - group
+

--- a/srv/salt/ceph/remove/migrated/default.sls
+++ b/srv/salt/ceph/remove/migrated/default.sls
@@ -18,3 +18,11 @@ remove id {{ id }}:
 
 {% endfor %}
 
+/var/cache/salt/master/jobs:
+  file.directory:
+    - user: {{ salt['deepsea.user']() }}
+    - group: {{ salt['deepsea.group']() }}
+    - recurse:
+      - user
+      - group
+

--- a/srv/salt/ceph/remove/mon/default.sls
+++ b/srv/salt/ceph/remove/mon/default.sls
@@ -10,3 +10,11 @@ remove mon.{{ minion }}:
 {% endif %}
 {% endfor %}
 
+/var/cache/salt/master/jobs:
+  file.directory:
+    - user: {{ salt['deepsea.user']() }}
+    - group: {{ salt['deepsea.group']() }}
+    - recurse:
+      - user
+      - group
+

--- a/srv/salt/ceph/remove/openattic/default.sls
+++ b/srv/salt/ceph/remove/openattic/default.sls
@@ -9,3 +9,12 @@ remove openattic auth:
     - name: "ceph auth del client.openattic"
 
 {% endif %}
+
+/var/cache/salt/master/jobs:
+  file.directory:
+    - user: {{ salt['deepsea.user']() }}
+    - group: {{ salt['deepsea.group']() }}
+    - recurse:
+      - user
+      - group
+

--- a/srv/salt/ceph/remove/rgw/default.sls
+++ b/srv/salt/ceph/remove/rgw/default.sls
@@ -34,3 +34,11 @@ remove rgw users.uid:
 
 {% endif %}
 
+/var/cache/salt/master/jobs:
+  file.directory:
+    - user: {{ salt['deepsea.user']() }}
+    - group: {{ salt['deepsea.group']() }}
+    - recurse:
+      - user
+      - group
+

--- a/srv/salt/ceph/remove/storage/default.sls
+++ b/srv/salt/ceph/remove/storage/default.sls
@@ -18,3 +18,11 @@ remove id {{ id }}:
 
 {% endfor %}
 
+/var/cache/salt/master/jobs:
+  file.directory:
+    - user: {{ salt['deepsea.user']() }}
+    - group: {{ salt['deepsea.group']() }}
+    - recurse:
+      - user
+      - group
+

--- a/srv/salt/ceph/rgw/auth/default.sls
+++ b/srv/salt/ceph/rgw/auth/default.sls
@@ -15,4 +15,13 @@ auth {{ keyring_file }}:
 {% endfor %}
 {% endfor %}
 
+/var/cache/salt/master/jobs:
+  file.directory:
+    - user: {{ salt['deepsea.user']() }}
+    - group: {{ salt['deepsea.group']() }}
+    - recurse:
+      - user
+      - group
+
+
 

--- a/srv/salt/ceph/rgw/key/default.sls
+++ b/srv/salt/ceph/rgw/key/default.sls
@@ -30,4 +30,11 @@ check {{ role }}:
 {% endfor %}
 {% endfor %}
 
+/var/cache/salt/master/jobs:
+  file.directory:
+    - user: {{ salt['deepsea.user']() }}
+    - group: {{ salt['deepsea.group']() }}
+    - recurse:
+      - user
+      - group
 


### PR DESCRIPTION
Any state file including Jinja templates that call a salt runner
indirectly creates a Salt job owned by root.  Dropping privileges in the
runner will break the state.  This kludge will keep the Salt cron
equivalent from crashing with a permissions exception.

Signed-off-by: Eric Jackson <ejackson@suse.com>

Fixes #935, #1004
