### PR TITLE
apparmor: add initial profiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -183,6 +183,15 @@ copy-files:
 	install -m 644 srv/salt/ceph/admin/key/*.sls $(DESTDIR)/srv/salt/ceph/admin/key/
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/admin/files
 	install -m 644 srv/salt/ceph/admin/files/*.j2 $(DESTDIR)/srv/salt/ceph/admin/files/
+	# state files apparmor
+	install -d -m 755 $(DESTDIR)/srv/salt/ceph/apparmor
+	install -d -m 755 $(DESTDIR)/srv/salt/ceph/apparmor/files
+	install -d -m 755 $(DESTDIR)/srv/salt/ceph/apparmor/files/ceph.d
+	install -d -m 755 $(DESTDIR)/srv/salt/ceph/apparmor/install
+	install -m 644 srv/salt/ceph/apparmor/*.sls $(DESTDIR)/srv/salt/ceph/apparmor/
+	install -m 644 srv/salt/ceph/apparmor/files/usr* $(DESTDIR)/srv/salt/ceph/apparmor/files/
+	install -m 644 srv/salt/ceph/apparmor/files/ceph.d/* $(DESTDIR)/srv/salt/ceph/apparmor/files/ceph.d/
+	install -m 644 srv/salt/ceph/apparmor/install/*.sls $(DESTDIR)/srv/salt/ceph/apparmor/install/
 	# state files benchmarks
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/benchmarks
 	install -m 644 srv/salt/ceph/benchmarks/*.sls $(DESTDIR)/srv/salt/ceph/benchmarks/

--- a/Makefile
+++ b/Makefile
@@ -104,6 +104,8 @@ copy-files:
 	install -m 644 srv/salt/ceph/tests/restart/rgw/forced/*.sls $(DESTDIR)/srv/salt/ceph/tests/restart/rgw/forced
 	install -m 644 srv/salt/ceph/tests/restart/rgw/nochange/*.sls $(DESTDIR)/srv/salt/ceph/tests/restart/rgw/nochange
 	# smoketests
+	install -d -m 755 $(DESTDIR)/srv/salt/ceph/smoketests/apparmor
+	install -m 644 srv/salt/ceph/smoketests/apparmor/*.sls $(DESTDIR)/srv/salt/ceph/smoketests/apparmor
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/smoketests/keyrings
 	install -m 644 srv/salt/ceph/smoketests/keyrings/*.sls $(DESTDIR)/srv/salt/ceph/smoketests/keyrings
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/smoketests/macros

--- a/deepsea.spec.in
+++ b/deepsea.spec.in
@@ -99,6 +99,10 @@ systemctl try-restart salt-api > /dev/null 2>&1 || :
 %dir %attr(0700, salt, salt) /srv/salt/ceph/admin/cache
 %dir /srv/salt/ceph/admin/files
 %dir /srv/salt/ceph/admin/key
+%dir /srv/salt/ceph/apparmor
+%dir /srv/salt/ceph/apparmor/files
+%dir /srv/salt/ceph/apparmor/files/ceph.d
+%dir /srv/salt/ceph/apparmor/install
 %dir /srv/salt/ceph/benchmarks
 %dir /srv/salt/ceph/benchmarks/blockdev
 %dir /srv/salt/ceph/benchmarks/fs
@@ -419,6 +423,10 @@ systemctl try-restart salt-api > /dev/null 2>&1 || :
 %config /srv/salt/ceph/admin/*.sls
 %config /srv/salt/ceph/admin/files/*.j2
 %config /srv/salt/ceph/admin/key/*.sls
+%config /srv/salt/ceph/apparmor/*.sls
+%config /srv/salt/ceph/apparmor/files/*
+%config /srv/salt/ceph/apparmor/files/ceph.d/*
+%config /srv/salt/ceph/apparmor/install/*
 %config /srv/salt/ceph/benchmarks/*.sls
 %config /srv/salt/ceph/benchmarks/blockdev/*.sls
 %config /srv/salt/ceph/benchmarks/fs/*.sls

--- a/deepsea.spec.in
+++ b/deepsea.spec.in
@@ -737,16 +737,17 @@ the README for more information.
 %files qa
 %{_libexecdir}/deepsea/qa
 %dir /srv/salt/ceph/smoketests
+%dir /srv/salt/ceph/smoketests/apparmor
 %dir /srv/salt/ceph/smoketests/keyrings
 %dir /srv/salt/ceph/smoketests/macros
 %dir /srv/salt/ceph/smoketests/macros/os_switch
 %dir /srv/salt/ceph/smoketests/quiescent
+%dir /srv/salt/ceph/smoketests/restart
 %dir /srv/salt/ceph/tests
 %dir /srv/salt/ceph/tests/keyrings
 %dir /srv/salt/ceph/tests/os_switch
 %dir /srv/salt/ceph/tests/quiescent
 %dir /srv/salt/ceph/tests/quiescent/timeout
-%dir /srv/salt/ceph/smoketests/restart
 %dir /srv/salt/ceph/tests/quiescent
 %dir /srv/salt/ceph/tests/quiescent/timeout
 %dir /srv/salt/ceph/tests/restart
@@ -766,6 +767,7 @@ the README for more information.
 %dir /srv/salt/ceph/tests/restart/rgw/change
 %dir /srv/salt/ceph/tests/restart/rgw/forced
 %dir /srv/salt/ceph/tests/restart/rgw/nochange
+/srv/salt/ceph/smoketests/apparmor/*.sls
 /srv/salt/ceph/smoketests/keyrings/*.sls
 /srv/salt/ceph/smoketests/macros/os_switch/*.sls
 /srv/salt/ceph/smoketests/quiescent/*.sls

--- a/srv/modules/utils/ready.py
+++ b/srv/modules/utils/ready.py
@@ -77,15 +77,38 @@ class Checks(object):
                                   [('/usr/sbin/aa-status --enabled '
                                     '2>/dev/null; echo $?')],
                                   tgt_type="compound")
+        # check if all file.managed for the profiles would apply
+        # cleanly using test=True. If so salt returns 'result': True
+        # burried in its return structure
+        profile_test = self.local.cmd(self.search, 'state.apply',
+                                      ['ceph.apparmor.profiles'],
+                                      kwarg={'test': 'true'},
+                                      tgt_type="compound")
+
+        minions_with_apparmor = 0
+        minions_with_profiles = 0
         for minion in contents:
             if contents[minion] and int(contents[minion]) == 0:
-                msg = "enabled on minion {}".format(minion)
-                if 'apparmor' in self.warnings:
-                    self.warnings['apparmor'].append(msg)
-                else:
-                    self.warnings['apparmor'] = [msg]
-        if 'apparmor' not in self.warnings:
+                minions_with_apparmor += 1
+                # aggregate the number of 'result': True we got
+                profiles_present = [v['result'] for k, v in
+                                    profile_test[minion].items()
+                                    if v['result'] == True]
+                # and compare to number of file.managed state we have, i.e. the
+                # number of profiles
+                if len(profile_test[minion]) == len(profiles_present):
+                    minions_with_profiles += 1
+        if minions_with_apparmor == 0:
             self.passed['apparmor'] = "disabled"
+        else:
+            msg = ('enabled on {}/{} minions; {} minions have all ceph.apparmor'
+                   ' profiles').format(minions_with_apparmor,
+                                       len(profile_test),
+                                       minions_with_profiles)
+            if minions_with_apparmor == minions_with_profiles:
+                self.passed['apparmor'] = msg
+            else:
+                self.warnings['apparmor'] = msg
 
     def report(self):
         """

--- a/srv/salt/ceph/apparmor/default-complain.sls
+++ b/srv/salt/ceph/apparmor/default-complain.sls
@@ -18,3 +18,8 @@ aa-complain /etc/apparmor.d/usr.bin.ceph-osd:
 aa-complain /etc/apparmor.d/usr.bin.radosgw:
   cmd.run
 
+aa-complain /etc/apparmor.d/usr.sbin.httpd-prefork:
+  cmd.run
+
+aa-complain /etc/apparmor.d/usr.sbin.oaconfig:
+  cmd.run

--- a/srv/salt/ceph/apparmor/default-complain.sls
+++ b/srv/salt/ceph/apparmor/default-complain.sls
@@ -1,0 +1,20 @@
+
+include:
+  - .install
+  - .profiles
+
+aa-complain /etc/apparmor.d/usr.bin.ceph-mds:
+  cmd.run
+
+aa-complain /etc/apparmor.d/usr.bin.ceph-mgr:
+  cmd.run
+
+aa-complain /etc/apparmor.d/usr.bin.ceph-mon:
+  cmd.run
+
+aa-complain /etc/apparmor.d/usr.bin.ceph-osd:
+  cmd.run
+
+aa-complain /etc/apparmor.d/usr.bin.radosgw:
+  cmd.run
+

--- a/srv/salt/ceph/apparmor/default-disable.sls
+++ b/srv/salt/ceph/apparmor/default-disable.sls
@@ -18,3 +18,8 @@ aa-disable /etc/apparmor.d/usr.bin.ceph-osd:
 aa-disable /etc/apparmor.d/usr.bin.radosgw:
   cmd.run
 
+aa-disable /etc/apparmor.d/usr.sbin.httpd-prefork:
+  cmd.run
+
+aa-disable /etc/apparmor.d/usr.sbin.oaconfig:
+  cmd.run

--- a/srv/salt/ceph/apparmor/default-disable.sls
+++ b/srv/salt/ceph/apparmor/default-disable.sls
@@ -1,0 +1,20 @@
+
+include:
+  - .install
+  - .profiles
+
+aa-disable /etc/apparmor.d/usr.bin.ceph-mds:
+  cmd.run
+
+aa-disable /etc/apparmor.d/usr.bin.ceph-mgr:
+  cmd.run
+
+aa-disable /etc/apparmor.d/usr.bin.ceph-mon:
+  cmd.run
+
+aa-disable /etc/apparmor.d/usr.bin.ceph-osd:
+  cmd.run
+
+aa-disable /etc/apparmor.d/usr.bin.radosgw:
+  cmd.run
+

--- a/srv/salt/ceph/apparmor/default-enforce.sls
+++ b/srv/salt/ceph/apparmor/default-enforce.sls
@@ -18,3 +18,8 @@ aa-enforce /etc/apparmor.d/usr.bin.ceph-osd:
 aa-enforce /etc/apparmor.d/usr.bin.radosgw:
   cmd.run
 
+aa-enforce /etc/apparmor.d/usr.sbin.httpd-prefork:
+  cmd.run
+
+aa-enforce /etc/apparmor.d/usr.sbin.oaconfig:
+  cmd.run

--- a/srv/salt/ceph/apparmor/default-enforce.sls
+++ b/srv/salt/ceph/apparmor/default-enforce.sls
@@ -1,0 +1,20 @@
+
+include:
+  - .install
+  - .profiles
+
+aa-enforce /etc/apparmor.d/usr.bin.ceph-mds:
+  cmd.run
+
+aa-enforce /etc/apparmor.d/usr.bin.ceph-mgr:
+  cmd.run
+
+aa-enforce /etc/apparmor.d/usr.bin.ceph-mon:
+  cmd.run
+
+aa-enforce /etc/apparmor.d/usr.bin.ceph-osd:
+  cmd.run
+
+aa-enforce /etc/apparmor.d/usr.bin.radosgw:
+  cmd.run
+

--- a/srv/salt/ceph/apparmor/default.sls
+++ b/srv/salt/ceph/apparmor/default.sls
@@ -1,0 +1,3 @@
+
+apparmor noop:
+  test.nop

--- a/srv/salt/ceph/apparmor/files/ceph.d/common
+++ b/srv/salt/ceph/apparmor/files/ceph.d/common
@@ -1,0 +1,33 @@
+# vim:syntax=apparmor
+# Author: Jan Fajerski <jfajerski@suse.com>
+
+  #include <abstractions/base>
+  #include <abstractions/nameservice>
+  #include <abstractions/python>
+  capability setgid,
+  capability setuid,
+  capability dac_override,
+  capability dac_read_search,
+
+  network inet stream,
+  network inet6 stream,
+
+  /etc/ceph/* r,
+  /etc/libnl/classid r,
+  /etc/os-release r,
+
+  /run/ceph** rw,
+  /tmp/ r,
+  /var/lib/ceph/** rwk,
+  /var/log/ceph/* rwk,
+  /var/run/ceph/* rwk,
+  /var/tmp/ r,
+
+  /proc/*/task/** rw,
+  /proc/*/cmdline r,
+  /proc/*/auxv r,
+  /proc/*/net/dev r,
+  /proc/*/net/psched r,
+  /proc/loadavg r,
+  /proc/cpuinfo r,
+  /proc/meminfo r,

--- a/srv/salt/ceph/apparmor/files/usr.bin.ceph-mds
+++ b/srv/salt/ceph/apparmor/files/usr.bin.ceph-mds
@@ -1,0 +1,10 @@
+#include <tunables/global>
+
+# vim:syntax=apparmor
+# Author: Jan Fajerski <jfajerski@suse.com>
+
+/usr/bin/ceph-mds {
+  #include <ceph.d/common>
+
+  /usr/bin/ceph-mds mr,
+}

--- a/srv/salt/ceph/apparmor/files/usr.bin.ceph-mgr
+++ b/srv/salt/ceph/apparmor/files/usr.bin.ceph-mgr
@@ -1,0 +1,41 @@
+#include <tunables/global>
+
+# vim:syntax=apparmor
+# Author: Jan Fajerski <jfajerski@suse.com>
+
+/usr/bin/ceph-mgr {
+  #include <ceph.d/common>
+  #include <abstractions/openssl>
+
+  /usr/bin/ceph-mgr mrix,
+
+  /etc/mime.types r,
+  /bin/bash mr,
+  /bin/bash cx,
+
+  profile /bin/bash {
+    #include <abstractions/base>
+    #include <abstractions/consoles>
+    #include <abstractions/nameservice>
+
+    /bin/bash mr,
+    /usr/bin/uname mrix,
+  }
+
+  /sbin/ldconfig mr,
+  /sbin/ldconfig cx,
+
+  profile /sbin/ldconfig {
+    #include <abstractions/base>
+
+    /sbin/ldconfig mr,
+  }
+
+  /usr/bin/ld.bfd mrix,
+
+  /proc/*/fd** r,
+  /proc/*/mounts r,
+
+  /usr/lib64/ceph/mgr/** rw,
+
+}

--- a/srv/salt/ceph/apparmor/files/usr.bin.ceph-mon
+++ b/srv/salt/ceph/apparmor/files/usr.bin.ceph-mon
@@ -1,0 +1,12 @@
+# vim:syntax=apparmor
+# Author: Jan Fajerski <jfajerski@suse.com>
+#include <tunables/global>
+
+/usr/bin/ceph-mon {
+  #include <ceph.d/common>
+
+  /usr/bin/ceph-mon mr,
+
+  /proc/sys/kernel/random/uuid r,
+  /sys/devices/** r,
+}

--- a/srv/salt/ceph/apparmor/files/usr.bin.ceph-osd
+++ b/srv/salt/ceph/apparmor/files/usr.bin.ceph-osd
@@ -1,0 +1,18 @@
+# vim:syntax=apparmor
+# Author: Jan Fajerski <jfajerski@suse.com>
+#include <tunables/global>
+
+/usr/bin/ceph-osd {
+  #include <ceph.d/common>
+
+  /usr/bin/ceph-osd mr,
+
+  /var/lib/ceph/osd/** l,
+
+  /proc/sys/kernel/random/uuid r,
+  /dev/ r,
+  /dev/** rwk,
+  /sys/devices/** r,
+  /proc/partitions r,
+  /run/blkid/blkid.tab r,
+}

--- a/srv/salt/ceph/apparmor/files/usr.bin.radosgw
+++ b/srv/salt/ceph/apparmor/files/usr.bin.radosgw
@@ -1,0 +1,15 @@
+# vim:syntax=apparmor
+# Author: Jan Fajerski <jfajerski@suse.com>
+#include <tunables/global>
+
+/usr/bin/radosgw {
+  #include <ceph.d/common>
+  #include <abstractions/openssl>
+
+  capability chown,
+
+  /usr/bin/radosgw mr,
+
+  /etc/mime.types r,
+}
+

--- a/srv/salt/ceph/apparmor/files/usr.sbin.httpd-prefork
+++ b/srv/salt/ceph/apparmor/files/usr.sbin.httpd-prefork
@@ -1,0 +1,103 @@
+# vim:syntax=apparmor
+# Author: Laura Paduano <lpaduano@suse.com>
+# "Failed name lookup - disconnected path" AppArmor error see:
+# https://gitlab.com/apparmor/apparmor/wikis/FAQ
+
+#include <tunables/global>
+
+/usr/sbin/httpd-prefork {
+  #include <abstractions/apache2-common>
+  #include <abstractions/base>
+  #include <abstractions/nameservice>
+  #include <abstractions/openssl>
+  #include <abstractions/ssl_keys>
+
+
+  capability       chown,
+  capability       net_admin,
+  capability       net_bind_service,
+  capability       setgid,
+  capability       setuid,
+  capability       net_admin,
+  capability       kill,
+
+
+  /etc/ r,
+  /etc/SuSE-release r,
+  /etc/apache2/conf.d/ r,
+  /etc/apache2/conf.d/openattic.conf r,
+  /etc/apache2/default-server.conf r,
+  /etc/apache2/errors.conf r,
+  /etc/apache2/httpd.conf r,
+  /etc/apache2/listen.conf r,
+  /etc/apache2/loadmodule.conf rw,
+  /etc/apache2/global.conf r,
+  /etc/apache2/mod_autoindex-defaults.conf r,
+  /etc/apache2/mod_cgid-timeout.conf r,
+  /etc/apache2/mod_info.conf r,
+  /etc/apache2/mod_log_config.conf r,
+  /etc/apache2/mod_mime-defaults.conf r,
+  /etc/apache2/mod_reqtimeout.conf r,
+  /etc/apache2/mod_status.conf r,
+  /etc/apache2/mod_userdir.conf r,
+  /etc/apache2/mod_usertrack.conf r,
+  /etc/apache2/server-tuning.conf r,
+  /etc/apache2/ssl-global.conf r,
+  /etc/apache2/sysconfig.d/global.conf r,
+  /etc/apache2/sysconfig.d/include.conf r,
+  /etc/apache2/sysconfig.d/loadmodule.conf r,
+  /etc/apache2/uid.conf r,
+  /etc/apache2/vhosts.d/ r,
+  /etc/ceph/ r,
+  /etc/ceph/ceph.client.openattic.keyring r,
+  /etc/ceph/ceph.conf r,
+  /etc/libnl/classid r,
+  /etc/mime.types r,
+  /etc/openattic/database.ini r,
+  /etc/sysconfig/openattic r,
+  /proc/*/mounts r,
+  /proc/*/net/psched r,
+  /proc/filesystems r,
+  /proc/sys/crypto/fips_enabled r,
+  /run/httpd.pid rw,
+  /run/wsgi.*.*.*.lock wk,
+  /run/wsgi.*.*.*.sock w,
+  /sbin/ldconfig mrCx,
+  /srv/www/htdocs/* r,
+  /tmp/ r,
+  /usr/bin/rbd mrCx,
+  /usr/lib{,32,64}/** mr,
+  /usr/sbin/httpd-prefork mr,
+  /usr/share/openattic-gui/** r,
+  /usr/share/openattic/** rw,
+  /var/log/apache2/access_log w,
+  /var/log/apache2/error_log w,
+  /var/log/openattic/openattic.log w,
+  /var/tmp/ r,
+
+
+  profile /sbin/ldconfig {
+    #include <abstractions/base>
+
+
+    /sbin/ldconfig mr,
+
+  }
+
+  profile /usr/bin/rbd {
+    #include <abstractions/base>
+
+    network inet stream,
+
+
+    /etc/ceph/ceph.client.openattic.keyring r,
+    /etc/ceph/ceph.conf r,
+    /etc/libnl/classid r,
+    /etc/passwd r,
+    /proc/*/net/psched r,
+    /tmp/ r,
+    /usr/bin/rbd mr,
+    /var/tmp/ r,
+
+  }
+}

--- a/srv/salt/ceph/apparmor/files/usr.sbin.oaconfig
+++ b/srv/salt/ceph/apparmor/files/usr.sbin.oaconfig
@@ -1,0 +1,80 @@
+#include <tunables/global>
+
+# vim:syntax=apparmor
+# Author: Laura Paduano <lpaduano@suse.com>
+
+/usr/sbin/oaconfig {
+  #include <abstractions/apache2-common>
+  #include <abstractions/authentication>
+  #include <abstractions/base>
+  #include <abstractions/bash>
+  #include <abstractions/dbus-session>
+  #include <abstractions/nameservice>
+  #include <abstractions/wutmp>
+
+
+  capability  audit_write,
+  capability  dac_override,
+  capability  setgid,
+  capability  sys_ptrace,
+  capability  net_admin,
+  capability  setuid,
+  capability  sys_resource,
+
+
+
+  /bin/bash rix,
+  /dev/tty rw,
+  /etc/** r,
+  /etc/SuSE-release r,
+  /etc/default/su r,
+  /etc/environment r,
+  /etc/libnl/classid r,
+  /etc/manpath.config r,
+  /etc/openattic/database.ini r,
+  /etc/ r,
+  /etc/opt/ r,
+  /etc/ssl/openssl.cnf r,
+  /etc/sysconfig/console r,
+  /etc/sysconfig/openattic r,
+  /opt/ r,
+  /proc/*/cgroup r,
+  /proc/*/cmdline r,
+  /proc/*/comm r,
+  /proc/*/fd/ r,
+  /proc/*/loginuid r,
+  /proc/*/mounts r,
+  /proc/*/net/psched r,
+  /proc/*/stat r,
+  /proc/filesystems r,
+  /proc/meminfo r,
+  /proc/sys/crypto/fips_enabled r,
+  /proc/sys/kernel/ngroups_max r,
+  /proc/sys/kernel/random/boot_id r,
+  /proc/*/mounts r,
+  /run/log/journal/** r,
+  /run/systemd/ask-password-block/* r,
+  /run/systemd/ask-password/ r,
+  /sbin/ldconfig rix,
+  /sys/fs/cgroup/systemd/system.slice/postgresql.service/ r,
+  /sys/fs/cgroup/systemd/system.slice/postgresql.service/cgroup.procs r,
+  /tmp/openattic-upgrade-backup-data w,
+  /usr/bin/gawk rix,
+  /usr/bin/grep rix,
+  /usr/bin/manpath rix,
+  /usr/bin/python2.7 rix,
+  /usr/bin/readlink rix,
+  /usr/bin/sed rix,
+  /usr/bin/su rix,
+  /usr/bin/systemctl rix,
+  /usr/bin/systemd-tty-ask-password-agent rix,
+  /usr/bin/tty rix,
+  /usr/bin/uname rix,
+  /usr/lib/postgresql*/bin/psql rix,
+  /usr/lib{,32,64}/** mr,
+  /usr/sbin/oaconfig rix,
+  /usr/sbin/service rix,
+  /usr/share/openattic/** rw,
+  /var/log/openattic/openattic.log w,
+
+}

--- a/srv/salt/ceph/apparmor/init.sls
+++ b/srv/salt/ceph/apparmor/init.sls
@@ -1,0 +1,6 @@
+
+{% set custom = salt['pillar.get']('apparmor_init', 'not a file') %}
+{% from 'ceph/macros/os_switch.sls' import os_switch with context %}
+
+include:
+  - .{{ os_switch(custom) }}

--- a/srv/salt/ceph/apparmor/install/SUSE.sls
+++ b/srv/salt/ceph/apparmor/install/SUSE.sls
@@ -1,0 +1,8 @@
+
+patterns-base-apparmor:
+  pkg.installed
+
+apparmor:
+  service.running:
+    - enable: True
+

--- a/srv/salt/ceph/apparmor/install/default.sls
+++ b/srv/salt/ceph/apparmor/install/default.sls
@@ -1,0 +1,10 @@
+
+install apparmor:
+  pkg.installed:
+    - pkgs:
+      - apparmor
+      - apparmor-utils
+
+apparmor:
+  service.running:
+    - enable: True

--- a/srv/salt/ceph/apparmor/install/init.sls
+++ b/srv/salt/ceph/apparmor/install/init.sls
@@ -1,0 +1,6 @@
+
+{% set custom = salt['pillar.get']('apparmor_install_init', 'not a file') %}
+{% from 'ceph/macros/os_switch.sls' import os_switch with context %}
+
+include:
+  - .{{ os_switch(custom) }}

--- a/srv/salt/ceph/apparmor/profiles.sls
+++ b/srv/salt/ceph/apparmor/profiles.sls
@@ -42,3 +42,16 @@
     - user: root
     - group: root
 
+/etc/apparmor.d/usr.sbin.httpd-prefork:
+  file.managed:
+    - source: salt://ceph/apparmor/files/usr.sbin.httpd-prefork
+    - perms: 600
+    - user: root
+    - group: root
+
+/etc/apparmor.d/usr.sbin.oaconfig:
+  file.managed:
+    - source: salt://ceph/apparmor/files/usr.sbin.oaconfig
+    - perms: 600
+    - user: root
+    - group: root

--- a/srv/salt/ceph/apparmor/profiles.sls
+++ b/srv/salt/ceph/apparmor/profiles.sls
@@ -1,0 +1,44 @@
+
+/etc/apparmor.d/usr.bin.ceph-mds:
+  file.managed:
+    - source: salt://ceph/apparmor/files/usr.bin.ceph-mds
+    - perms: 600
+    - user: root
+    - group: root
+
+/etc/apparmor.d/usr.bin.ceph-mgr:
+  file.managed:
+    - source: salt://ceph/apparmor/files/usr.bin.ceph-mgr
+    - perms: 600
+    - user: root
+    - group: root
+
+/etc/apparmor.d/usr.bin.ceph-mon:
+  file.managed:
+    - source: salt://ceph/apparmor/files/usr.bin.ceph-mon
+    - perms: 600
+    - user: root
+    - group: root
+
+/etc/apparmor.d/usr.bin.ceph-osd:
+  file.managed:
+    - source: salt://ceph/apparmor/files/usr.bin.ceph-osd
+    - perms: 600
+    - user: root
+    - group: root
+
+/etc/apparmor.d/usr.bin.radosgw:
+  file.managed:
+    - source: salt://ceph/apparmor/files/usr.bin.radosgw
+    - perms: 600
+    - user: root
+    - group: root
+
+/etc/apparmor.d/ceph.d/common:
+  file.managed:
+    - source: salt://ceph/apparmor/files/ceph.d/common
+    - makedirs: True
+    - perms: 600
+    - user: root
+    - group: root
+

--- a/srv/salt/ceph/smoketests/apparmor/init.sls
+++ b/srv/salt/ceph/smoketests/apparmor/init.sls
@@ -1,0 +1,15 @@
+{% set master = salt['master.minion']() %}
+
+enforce apparmor profiles:
+  salt.state:
+    - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
+    - tgt_type: compound
+    - sls: ceph.apparmor.default-enforce
+    - failhard: True
+
+make sure ceph cluster is healthy:
+  salt.state:
+    - tgt: {{ master }}
+    - tgt_type: compound
+    - sls: ceph.wait
+    - failhard: True

--- a/srv/salt/ceph/smoketests/init.sls
+++ b/srv/salt/ceph/smoketests/init.sls
@@ -6,3 +6,4 @@ include:
   - .restart.mgr
   - .restart.mon
   - .restart.rgw
+  - .apparmor


### PR DESCRIPTION
Signed-off-by: Jan Fajerski <jfajerski@suse.com>

Fixes #937 


Description:
Adds initial apparmor support. By default nothing is done. Setting one of those three pillar variables below installs apparmor, starts the service, pushes the profiles and puts them in the respective mode:
```
apparmor_init: default-enforce
apparmor_init: default-complain
apparmor_init: default-disable
```

I guess we could add this to stage 0 (not yet implemented)?