### PR TITLE
qa: health-ok: fix --mini option

### DIFF
--- a/qa/suites/basic/health-ok.sh
+++ b/qa/suites/basic/health-ok.sh
@@ -37,7 +37,7 @@ function usage {
     exit 1
 }
 
-TEMP=$(getopt -o h --long "cli,encrypted,encryption,help" \
+TEMP=$(getopt -o h --long "cli,encrypted,encryption,help,mini" \
      -n 'health-ok.sh' -- "$@")
 
 if [ $? != 0 ] ; then echo "Terminating..." >&2 ; exit 1 ; fi


### PR DESCRIPTION
Commit ea7af31f0 added a --mini option to health-ok.sh, but it was
not possible to use because it was not added to the getopt command.
