### PR TITLE
[RFC] [DNM] Shrink MDS cluster and restart on updates

### DIFF
--- a/srv/modules/runners/cmd.py
+++ b/srv/modules/runners/cmd.py
@@ -1,0 +1,15 @@
+import salt.client
+
+from subprocess import check_output
+
+def run(**kwargs):
+    args = {'cmd': 'echo no command supplied'}
+    args.update(kwargs)
+    local_client = salt.client.LocalClient()
+    master_minion = local_client.cmd(
+        'I@roles:master', 'pillar.get',
+        ['master_minion'], expr_form='compound').items()[0][1]
+    output = local_client.cmd(master_minion, 'cmd.shell', [args['cmd']], expr_form='compound')
+    # only return the result from the salt master
+    # TODO generalize to run commands on any minion
+    return next(iter(output.values()))

--- a/srv/salt/_modules/wait.py
+++ b/srv/salt/_modules/wait.py
@@ -10,10 +10,6 @@ log = logging.getLogger(__name__)
 
 
 class HealthCheck(object):
-    """
-    Check the Ceph health status.  Wait to return until the number of
-    successive checks matches the desired state.
-    """
 
     def __init__(self, **kwargs):
         """
@@ -41,27 +37,19 @@ class HealthCheck(object):
         self.cluster=rados.Rados(conffile=self.settings['conf'])
         self.cluster.connect()
 
-    def wait(self):
+    def _wait(self, cmd, success):
         """
         Poll until the status "matches" the specificed number of checks.
         """
-        cmd = json.dumps({"prefix":"health", "format":"json" })
         i=0
         check = 0
 
+        log.debug('wait on condition of command {}'.format(cmd))
         while i < (self.settings['timeout']/self.settings['delay']):
             ret,output,err = self.cluster.mon_command(cmd, b'', timeout=6)
-            health = json.loads(output)
-            if 'overall_status' in health:
-                current_status = json.loads(output)['overall_status']
-            if 'status' in health:
-                current_status = json.loads(output)['status']
-            if current_status:
-                log.debug("status: {}".format(current_status))
-            else:
-                raise RuntimeError("Neither status nor overall_status defined in health check")
+            json_output = json.loads(output)
 
-            if self._check_status(current_status, self.settings):
+            if success(json_output):
                 check += 1
                 if check == self.settings['check']:
                     log.debug("{} checks succeeded".format(self.settings['check']))
@@ -76,30 +64,99 @@ class HealthCheck(object):
         log.debug("Timeout expired")
         raise RuntimeError("Timeout expired")
 
-    def _check_status(self, current, settings):
+    def _check_status(self, current):
         """
         Return the "correct" matching status
         """
-        if settings['negate']:
-            log.debug("status != {}".format(settings['status']))
-            return (current != settings['status'])
+        if self.settings['negate']:
+            log.debug("status != {}".format(self.settings['status']))
+            return (current != self.settings['status'])
         else:
-            log.debug("status == {}".format(settings['status']))
-            return (current == settings['status'])
+            log.debug("status == {}".format(self.settings['status']))
+            return (current == self.settings['status'])
+
+
+class FsStatusCheck(HealthCheck):
+    """
+    Check the fsmap status of the cep status output. Wait till all active MDS's
+    daemons have reached up:active status
+    """
+
+    def __init__(self, **kwargs):
+        super(FsStatusCheck, self).__init__(**kwargs)
+
+    def wait_for_healthy_mds(self):
+        """
+        Poll until all active MDS' are up:active
+        """
+        cmd = json.dumps({"prefix":"status", "format":"json" })
+
+        def success(status):
+            if 'fsmap' in status:
+                fsmap = status['fsmap']
+            else:
+                raise RuntimeError('No fsmap found in status output')
+
+            for rank in fsmap['by_rank']:
+                if not self._check_status(rank['status']):
+                    return False
+            return True
+
+        self._wait(cmd, success)
+
+
+class HealthStatusCheck(HealthCheck):
+    """
+    Check the Ceph health status.  Wait to return until the number of
+    successive checks matches the desired state.
+    """
+
+    def __init__(self, **kwargs):
+        super(HealthStatusCheck, self).__init__(**kwargs)
+
+    def wait(self):
+        """
+        Poll until the status "matches" the specificed number of checks.
+        """
+        cmd = json.dumps({"prefix":"health", "format":"json" })
+
+        def success(health):
+            if 'overall_status' in health:
+                current_status = health['overall_status']
+            if 'status' in health:
+                current_status = health['status']
+            if current_status:
+                log.debug("status: {}".format(current_status))
+            else:
+                raise RuntimeError("Neither status nor overall_status defined in health check")
+
+            return self._check_status(current_status)
+
+
+        self._wait(cmd, success)
 
     def just(self):
         time.sleep(self.settings['delay'])
 
 def just(**kwargs):
-    hc = HealthCheck(**kwargs)
+    hc = HealthStatusCheck(**kwargs)
     hc.just()
+
 
 def until(**kwargs):
     """
     Wait around until the status matches.
     """
-    hc = HealthCheck(**kwargs)
+    hc = HealthStatusCheck(**kwargs)
     hc.wait()
+
+
+def until_mds(**kwargs):
+    """
+    Wait around for fsmap changes.
+    """
+    hc = FsStatusCheck(**kwargs)
+    hc.wait_for_healthy_mds()
 
 
 def out(**kwargs):
@@ -107,7 +164,7 @@ def out(**kwargs):
     Negate the check.  That is, wait out the status such as HEALTH_ERR.
     """
     kwargs.update({ 'negate': True })
-    hc = HealthCheck(**kwargs)
+    hc = HealthStatusCheck(**kwargs)
     hc.wait()
 
 

--- a/srv/salt/ceph/mds/shutdown.sls
+++ b/srv/salt/ceph/mds/shutdown.sls
@@ -1,0 +1,3 @@
+shutdown daemon:
+  service.dead:
+    - name: ceph-mds@{{ grains['host'] }}

--- a/srv/salt/ceph/restart/mds/default-parallel.sls
+++ b/srv/salt/ceph/restart/mds/default-parallel.sls
@@ -1,0 +1,73 @@
+{% set fs_name = salt['saltutil.runner']('cmd.run', cmd='ceph fs dump --format=json-pretty 2>/dev/null | jq --raw-output .filesystems[0].mdsmap.fs_name') %}
+{% set ranks_in = salt['saltutil.runner']('cmd.run', cmd='ceph fs dump --format=json-pretty 2>/dev/null | jq ".filesystems[0].mdsmap.in | length"') %}
+{% set master = salt['pillar.get']('master_minion') %}
+
+wait till ceph is healthy:
+  salt.state:
+    - tgt: {{ master }}
+    - sls: ceph.wait
+    - failhard: True
+
+shrink mds cluster:
+  salt.state:
+    - tgt: {{ master }}
+    - tgt_type: compound
+    - sls:
+      - ceph.restart.mds.shrink-mds-cluster
+    - pillar:
+        'fs_name': {{ fs_name }}
+        'ranks_in': {{ ranks_in }}
+
+wait until all active mds but one have stopped:
+  salt.state:
+    - tgt: {{ master }}
+    - sls: ceph.wait.mds
+
+{% set standbys = salt['saltutil.runner']('cmd.run', cmd='ceph --format=json fs dump 2>/dev/null | jq -c [.standbys[].name]') | load_json %}
+{% for standby in standbys %}
+shutdown standby daemon {{ standby }}:
+  salt.state:
+    - tgt: {{ standby }}
+    - sls: ceph.mds.shutdown
+{% endfor %}
+
+{% set active = salt['saltutil.runner']('cmd.run', cmd='ceph --format=json fs dump 2>/dev/null | jq --raw-output "[.filesystems[0].mdsmap.info|.[].name] | .[0]"') %}
+restarting remaing active {{ active }}:
+  salt.state:
+    - tgt: '{{ active }}'
+    - sls: ceph.mds.restart
+    - failhard: True
+
+wait until all active mds are up and active:
+  salt.state:
+    - tgt: {{ master }}
+    - sls: ceph.wait.mds
+
+{% for standby in standbys %}
+start standby daemon {{ standby }}:
+   salt.state:
+     - tgt: {{ standby }}
+     - sls: ceph.mds
+{% endfor %}
+
+reset mds cluster:
+  salt.state:
+    - tgt: {{ master }}
+    - tgt_type: compound
+    - sls:
+      - ceph.restart.mds.reset-mds-cluster
+    - pillar:
+        'fs_name': {{ fs_name }}
+        'ranks_in': {{ ranks_in }}
+
+check if all processes are still running after restarting mdss:
+  salt.state:
+    - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
+    - tgt_type: compound
+    - sls: ceph.processes
+    - failhard: True
+
+final wait until all active mds are up and active:
+  salt.state:
+    - tgt: {{ master }}
+    - sls: ceph.wait.mds

--- a/srv/salt/ceph/restart/mds/default-sequential.sls
+++ b/srv/salt/ceph/restart/mds/default-sequential.sls
@@ -1,0 +1,24 @@
+{% set master = salt['pillar.get']('master_minion') %}
+{% for host in salt.saltutil.runner('select.minions', cluster='ceph', roles='mds') %}
+
+    wait until {{ host }} with role mds can be restarted:
+      salt.state:
+        - tgt: {{ master }}
+        - sls: ceph.wait
+        - failhard: True
+
+    check if all processes are still running on {{ host }} after restarting mdss:
+      salt.state:
+        - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
+        - tgt_type: compound
+        - sls: ceph.processes
+        - failhard: True
+
+    restarting mds on {{ host }}:
+      salt.state:
+        - tgt: {{ host }}
+        - tgt_type: compound
+        - sls: ceph.mds.restart
+        - failhard: True
+
+{% endfor %}

--- a/srv/salt/ceph/restart/mds/default.sls
+++ b/srv/salt/ceph/restart/mds/default.sls
@@ -1,24 +1,3 @@
-{% set master = salt['pillar.get']('master_minion') %}
-{% for host in salt.saltutil.runner('select.minions', cluster='ceph', roles='mds') %}
-    
-    wait until {{ host }} with role mds can be restarted:
-      salt.state:
-        - tgt: {{ master }}
-        - sls: ceph.wait
-        - failhard: True
 
-    check if all processes are still running on {{ host }} after restarting mdss:
-      salt.state:
-        - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
-        - tgt_type: compound
-        - sls: ceph.processes
-        - failhard: True
-
-    restarting mds on {{ host }}:
-      salt.state:
-        - tgt: {{ host }}
-        - tgt_type: compound
-        - sls: ceph.mds.restart
-        - failhard: True
-
-{% endfor %}
+include:
+  - .default-sequential

--- a/srv/salt/ceph/restart/mds/reset-mds-cluster.sls
+++ b/srv/salt/ceph/restart/mds/reset-mds-cluster.sls
@@ -1,0 +1,8 @@
+{% set fs_name = salt['pillar.get']('fs_name') %}
+{% set ranks_in = salt['pillar.get']('ranks_in') %}
+
+set max_mds back to {{ ranks_in }}:
+  cmd.run:
+    - failhard: True
+    - name: ceph fs set {{ fs_name }} max_mds {{ ranks_in }}
+

--- a/srv/salt/ceph/restart/mds/shrink-mds-cluster.sls
+++ b/srv/salt/ceph/restart/mds/shrink-mds-cluster.sls
@@ -1,0 +1,16 @@
+{% set fs_name = salt['pillar.get']('fs_name') %}
+{% set ranks_in = salt['pillar.get']('ranks_in') %}
+
+set max_mds to 1:
+  cmd.run:
+    - name: ceph fs set {{ fs_name }} max_mds 1
+    - failhard: True
+
+{% for rank in range(1, ranks_in|int)|reverse %}
+
+deactivate mds rank {{ rank }}:
+  cmd.run:
+    - name: ceph mds deactivate {{ fs_name }}:{{ rank }}
+    - failhard: True
+
+{% endfor %}

--- a/srv/salt/ceph/wait/mds.sls
+++ b/srv/salt/ceph/wait/mds.sls
@@ -1,0 +1,7 @@
+wait for mds:
+ module.run:
+   - name: wait.until_mds
+   - kwargs:
+       'status': "up:active"
+   - fire_event: True
+   - failhard: True


### PR DESCRIPTION
This is a basic implementation of the [update routine recommended by upstream](http://docs.ceph.com/docs/master/cephfs/upgrading/).
This is not integrated into any stages yet. We need to add a conditional to decide if a sequential restart is ok (e.g. on config changes) or if the shrink-restart routine is needed (any time the mds package is updated).

The code can be tried by starting a cluster, updating the binaries manually and then run ```salt-run state.orch ceph.restart.mds.default-parallel```.

The naming is also not final yet. This RFC PR is against SES5 since it originally way meant to be for the update to or over 12.2.4. It has since turned out that this procedure is needed for all MDS updates until further notice. I.e. master will need a PR as well.