### PR TITLE
[SES5] Add missing directories to deepsea-qa package

### DIFF
--- a/deepsea.spec.in
+++ b/deepsea.spec.in
@@ -645,10 +645,8 @@ the README for more information.
 %files qa
 %{_libexecdir}/deepsea/qa
 %dir /srv/salt/ceph/smoketests
-%dir /srv/salt/ceph/smoketests/keyrings
 %dir /srv/salt/ceph/smoketests/quiescent
 %dir /srv/salt/ceph/tests
-%dir /srv/salt/ceph/tests/keyrings
 %dir /srv/salt/ceph/tests/quiescent
 %dir /srv/salt/ceph/tests/quiescent/timeout
 /srv/salt/ceph/smoketests/quiescent/*.sls


### PR DESCRIPTION
Signed-off-by: Joshua Schmid <jschmid@suse.de>

OBS build error:

```
[   63s] deepsea-qa-0.8.4+git.0.e7e325073-2.15.1.noarch.rpm: directories not owned by a package:
[   63s]  - /srv/salt/ceph/smoketests
[   63s]  - /srv/salt/ceph/tests
```

after moving on par with master and merging: 3310c127891c7e046a6e4666de67156516184318 SES5 needs to be adapted as keyringstests have not been backported

-----------------

[Please find more information on how to run integration tests here](https://github.com/SUSE/DeepSea/wiki/Integration-tests)
