### PR TITLE
[backport][SES5] Add missing role to cephprocesses map

### DIFF
--- a/srv/salt/_modules/cephprocesses.py
+++ b/srv/salt/_modules/cephprocesses.py
@@ -36,6 +36,7 @@ processes = {'mon': ['ceph-mon'],
              'client-iscsi': [],
              'client-nfs': [],
              'client-radosgw': [],
+             'benchmark-rbd': [],
              'master': []}
 
 # Processes like lrbd have an inverted logic


### PR DESCRIPTION
Signed-off-by: Joshua Schmid <jschmid@suse.de>
(cherry picked from commit 5e40503ee0edd0cfe321a715d3537f3280179bdc)

backport of #1099 

-----------------

[Please find more information on how to run integration tests here](https://github.com/SUSE/DeepSea/wiki/Integration-tests)
