### PR TITLE
Make master_minion optional

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,6 +85,9 @@ copy-files:
 	install -d -m 755 $(DESTDIR)/srv/modules/pillar/__pycache__
 	install -m 644 srv/modules/pillar/__pycache__/*.pyc $(DESTDIR)/srv/modules/pillar/__pycache__
 	install -m 644 srv/modules/pillar/stack.py $(DESTDIR)/srv/modules/pillar/
+	# modules
+	install -d -m 755 $(DESTDIR)/srv/modules/modules
+	install -m 644 srv/modules/modules/*.py* $(DESTDIR)/srv/modules/modules/
 	# runners
 	install -d -m 755 $(DESTDIR)/srv/modules/runners
 	install -d -m 755 $(DESTDIR)/srv/modules/runners/__pycache__
@@ -103,7 +106,6 @@ copy-files:
 	install -d -m 755 $(DESTDIR)/srv/pillar/ceph/benchmarks/templates
 	install -m 644 srv/pillar/ceph/benchmarks/templates/*.j2 $(DESTDIR)/srv/pillar/ceph/benchmarks/templates/
 	install -m 644 srv/pillar/ceph/init.sls $(DESTDIR)/srv/pillar/ceph/
-	install -m 644 srv/pillar/ceph/master_minion.sls $(DESTDIR)/srv/pillar/ceph/
 	install -m 644 srv/pillar/ceph/deepsea_minions.sls $(DESTDIR)/srv/pillar/ceph/
 	install -d -m 755 $(DESTDIR)/srv/pillar/ceph/stack
 	install -m 644 srv/pillar/ceph/stack/stack.cfg $(DESTDIR)/srv/pillar/ceph/stack/stack.cfg
@@ -777,7 +779,6 @@ install: pyc install-deps copy-files
 	chown $(USER):$(GROUP) $(DESTDIR)/etc/salt/master.d/*
 	echo "deepsea_minions: '*'" > /srv/pillar/ceph/deepsea_minions.sls
 	chown -R $(USER) /srv/pillar/ceph
-	sed -i '/^master_minion:/s!_REPLACE_ME_!'`cat /etc/salt/minion_id`'!' /srv/pillar/ceph/master_minion.sls
 	systemctl restart salt-master
 	$(PKG_INSTALL) salt-api
 	systemctl restart salt-api

--- a/deepsea.spec.in
+++ b/deepsea.spec.in
@@ -60,10 +60,6 @@ make DESTDIR=%{buildroot} DOCDIR=%{_docdir} copy-files VERSION=%{version}
 python3 setup.py install --prefix=%{_prefix} --root=%{buildroot}
 
 %post
-if [ $1 -eq 1 ] ; then
-  # Initialize to most likely value
-  sed -i '/^master_minion:/s!_REPLACE_ME_!'`hostname -f`'!' /srv/pillar/ceph/master_minion.sls
-fi
 # Initialize the shared secret key
 sed -i '/^sharedsecret: /s!{{ shared_secret }}!'`cat /proc/sys/kernel/random/uuid`'!' /etc/salt/master.d/sharedsecret.conf
 chown salt:salt /etc/salt/master.d/sharedsecret.conf
@@ -89,6 +85,7 @@ systemctl try-restart salt-api > /dev/null 2>&1 || :
 %dir /srv/salt/_modules/__pycache__
 %dir /srv/modules
 %dir /srv/modules/__pycache__
+%dir /srv/modules/modules
 %dir /srv/modules/runners
 %dir /srv/modules/runners/__pycache__
 %dir /srv/modules/pillar
@@ -394,6 +391,7 @@ systemctl try-restart salt-api > /dev/null 2>&1 || :
 %{_mandir}/man5/deepsea*.5.gz
 %{_mandir}/man1/deepsea*.1.gz
 %config(noreplace) %attr(-, salt, salt) /etc/salt/master.d/*.conf
+/srv/modules/modules/*.py*
 /srv/modules/runners/*.py*
 %config %attr(-, salt, salt) /srv/pillar/top.sls
 %config %attr(-, salt, salt) /srv/pillar/ceph/init.sls
@@ -402,7 +400,6 @@ systemctl try-restart salt-api > /dev/null 2>&1 || :
 %config %attr(-, salt, salt) /srv/pillar/ceph/benchmarks/collections/*.yml
 %config %attr(-, salt, salt) /srv/pillar/ceph/benchmarks/fio/*.yml
 %config %attr(-, salt, salt) /srv/pillar/ceph/benchmarks/templates/*.j2
-%config(noreplace) %attr(-, salt, salt) /srv/pillar/ceph/master_minion.sls
 %config(noreplace) %attr(-, salt, salt) /srv/pillar/ceph/deepsea_minions.sls
 %config %attr(-, salt, salt) /srv/pillar/ceph/stack/stack.cfg
 %config /srv/modules/__pycache__/*.pyc

--- a/srv/modules/modules/master.py
+++ b/srv/modules/modules/master.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+"""
+Several orchestrations must target the minion running on the Salt master.
+Currently, the Salt master and admin node are one in the same.  Originally, the
+installation process would populate /srv/pillar/ceph/master_minion.sls.  This
+fails in environments where an entire server is built prior to assigning a
+ hostname or configuring Salt.
+
+On the off chance that we may have multiple Salt masters or separate the admin
+node from the Salt master, keep /srv/pillar/ceph/master_minion.sls to allow the
+administrator to override the setting in /etc/salt/minion_id.
+
+Note that this is a module that only runs on the master.
+"""
+
+from __future__ import absolute_import
+import os
+import logging
+
+log = logging.getLogger(__name__)
+
+
+def minion():
+    """
+    Return the name of the minion running on the master.  Default to
+    reading the minion_id file, but allow overriding with the pillar.
+    """
+    if __salt__['pillar.get']('master_minion'):
+        log.info("Returning pillar value")
+        return __salt__['pillar.get']('master_minion')
+
+    id_file = "/etc/salt/minion_id"
+    with open(id_file, 'r') as id_fd:
+        minion_id = id_fd.readline().rstrip()
+        return minion_id
+    return ""
+

--- a/srv/pillar/ceph/init.sls
+++ b/srv/pillar/ceph/init.sls
@@ -1,8 +1,6 @@
 
 {% include 'ceph/cluster/' + grains['id'] + '.sls' ignore missing %}
 
-{% include 'ceph/master_minion.sls' ignore missing %}
-
 {% include 'ceph/deepsea_minions.sls' ignore missing %}
 
 

--- a/srv/pillar/ceph/master_minion.sls
+++ b/srv/pillar/ceph/master_minion.sls
@@ -1,2 +1,0 @@
-
-master_minion: _REPLACE_ME_

--- a/srv/salt/ceph/benchmarks/blockdev.sls
+++ b/srv/salt/ceph/benchmarks/blockdev.sls
@@ -3,10 +3,11 @@
 # benchmarks, assuming the iSCSI login or rbd map is performed manually
 # beforehand.
 # TODO Support per-client block devices
+{% set master = salt['master.minion']() %}
 
 prep master:
   salt.state:
-    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt: {{ master }}
     - sls: ceph.benchmarks.blockdev.prepare_master
 
 prep clients:

--- a/srv/salt/ceph/benchmarks/cephfs.sls
+++ b/srv/salt/ceph/benchmarks/cephfs.sls
@@ -1,7 +1,9 @@
 
+{% set master = salt['master.minion']() %}
+
 prep master:
   salt.state:
-    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt: {{ master }}
     - sls:
       - ceph.cephfs.benchmarks.prepare_master
 
@@ -45,5 +47,5 @@ cleanup fio:
 
 remove auth key:
   salt.state:
-    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt: {{ master }}
     - sls: ceph.cephfs.benchmarks.cleanup_key_auth

--- a/srv/salt/ceph/benchmarks/fs.sls
+++ b/srv/salt/ceph/benchmarks/fs.sls
@@ -1,7 +1,9 @@
 
+{% set master = salt['master.minion']() %}
+
 prep master:
   salt.state:
-    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt: {{ master }}
     - sls:
       - ceph.benchmarks.fs.prepare_master
 

--- a/srv/salt/ceph/benchmarks/rbd.sls
+++ b/srv/salt/ceph/benchmarks/rbd.sls
@@ -1,6 +1,9 @@
+
+{% set master = salt['master.minion']() %}
+
 prep master:
   salt.state:
-    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt: {{ master }}
     - sls: ceph.rbd.benchmarks.prepare_master
 
 prep clients:
@@ -29,6 +32,6 @@ cleanup clients:
 
 cleanup master:
   salt.state:
-    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt: {{ master }}
     - sls: ceph.rbd.benchmarks.cleanup_master
 

--- a/srv/salt/ceph/maintenance/noout/default.sls
+++ b/srv/salt/ceph/maintenance/noout/default.sls
@@ -1,5 +1,8 @@
+
+{% set master = salt['master.minion']() %}
+
 setting noout:
   salt.state:
-    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt: {{ master }}
     - sls: ceph.noout.set
     - failhard: True

--- a/srv/salt/ceph/maintenance/upgrade/cleanup/default.sls
+++ b/srv/salt/ceph/maintenance/upgrade/cleanup/default.sls
@@ -1,7 +1,9 @@
   
+{% set master = salt['master.minion']() %}
+
 remove packages:
   salt.state:
-    - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
+    - tgt: '{{ master }}'
     - sls: ceph.packages.remove
     - failhard: True
 

--- a/srv/salt/ceph/maintenance/upgrade/master/default.sls
+++ b/srv/salt/ceph/maintenance/upgrade/master/default.sls
@@ -1,3 +1,6 @@
+
+{% set master = salt['master.minion']() %}
+
 {% set timeout=salt['pillar.get']('minions_ready_timeout', 30) %}
 {% if salt.saltutil.runner('minions.ready', timeout=timeout) and salt['saltutil.runner']('upgrade.check') and salt['saltutil.runner']('validate.setup') %}
 
@@ -12,25 +15,25 @@ sync all:
 set sortbitwise flag: 
   salt.state:
     - sls: ceph.setosdflags.sortbitwise
-    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt: {{ master }}
     - failhard: True
 
 # May generate an unpack error which is safe to ignore
 update deepsea and master:
   salt.state:
-    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt: {{ master }}
     - sls: ceph.updates.master
 
 upgrading:
   salt.state:
-    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt: {{ master }}
     - tgt_type: compound
     - sls: ceph.upgrade
     - failhard: True
 
 reboot master:
   salt.state:
-    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt: {{ master }}
     - sls: ceph.updates.restart
 
 {% else %}
@@ -38,7 +41,7 @@ reboot master:
 validate failed:
   salt.state:
     - name: just.exit
-    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt: {{ master }}
     - failhard: True
 
 {% endif %}

--- a/srv/salt/ceph/maintenance/upgrade/minion/default.sls
+++ b/srv/salt/ceph/maintenance/upgrade/minion/default.sls
@@ -1,3 +1,6 @@
+
+{% set master = salt['master.minion']() %}
+
 {% set timeout=salt['pillar.get']('minions_ready_timeout', 30) %}
 {% if salt.saltutil.runner('minions.ready', timeout=timeout) %}
 
@@ -48,7 +51,7 @@ upgrading mon on {{ host }}:
 
 wait until the cluster has recovered before processing mon on {{ host }}:
   salt.state:
-    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt: {{ master }}
     - sls: ceph.wait
     - failhard: True
 
@@ -97,12 +100,12 @@ upgrading {{ host }}:
 # wait until the OSDs/MONs are acutally marked as down ~30 seconds ~1m
 wait for ceph to mark services as out/down to process {{ host }}:
   salt.state:
-    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt: {{ master }}
     - sls: ceph.wait.until.expired.30sec
 
 wait until the cluster has recovered before processing {{ host }}:
   salt.state:
-    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt: {{ master }}
     - sls: ceph.wait
     - failhard: True
 
@@ -115,7 +118,7 @@ check if all processes are still running after processing {{ host }}:
 unset noout after processing {{ host }}:
   salt.state:
     - sls: ceph.noout.unset
-    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt: {{ master }}
     - failhard: True
 
 updating {{ host }}:
@@ -128,7 +131,7 @@ updating {{ host }}:
 set noout {{ host }}: 
   salt.state:
     - sls: ceph.noout.set
-    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt: {{ master }}
     - failhard: True
 
 restart {{ host }} if updates require:
@@ -148,13 +151,13 @@ upgraded {{ host }}:
 unset noout after final iteration: 
   salt.state:
     - sls: ceph.noout.unset
-    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt: {{ master }}
     - failhard: True
 
 set luminous osds: 
   salt.state:
     - sls: ceph.setosdflags.requireosdrelease
-    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt: {{ master }}
     - failhard: True
 
 {% else %}

--- a/srv/salt/ceph/migrate/nodes/default.sls
+++ b/srv/salt/ceph/migrate/nodes/default.sls
@@ -1,8 +1,10 @@
 
+{% set master = salt['master.minion']() %}
+
 {% if salt['saltutil.runner']('disengage.check', cluster='ceph') == False %}
 safety is engaged:
   salt.state:
-    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt: {{ master }}
     - name: "Run 'salt-run disengage.safety' to disable"
     - failhard: True
 
@@ -10,7 +12,7 @@ safety is engaged:
 
 wait on healthy cluster:
   salt.state:
-    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt: {{ master }}
     - tgt_type: compound
     - sls: ceph.wait.until.OK
     - failhard: True
@@ -24,13 +26,13 @@ redeploy {{ host }} osds:
 
 cleanup {{ host }} osds:
   salt.state:
-    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt: {{ master }}
     - tgt_type: compound
     - sls: ceph.remove.migrated
 
 wait on {{ host }}:
   salt.state:
-    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt: {{ master }}
     - tgt_type: compound
     - sls: ceph.wait.1hour.until.OK
     - failhard: True

--- a/srv/salt/ceph/migrate/osds/default.sls
+++ b/srv/salt/ceph/migrate/osds/default.sls
@@ -1,8 +1,10 @@
 
+{% set master = salt['master.minion']() %}
+
 {% if salt['saltutil.runner']('disengage.check', cluster='ceph') == False %}
 safety is engaged:
   salt.state:
-    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt: {{ master }}
     - name: "Run 'salt-run disengage.safety' to disable"
     - failhard: True
 
@@ -10,7 +12,7 @@ safety is engaged:
 
 wait on healthy cluster:
   salt.state:
-    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt: {{ master }}
     - tgt_type: compound
     - sls: ceph.wait.until.OK
     - failhard: True
@@ -25,13 +27,13 @@ redeploy {{ host }} osds:
 
 cleanup {{ host }} osds:
   salt.state:
-    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt: {{ master }}
     - tgt_type: compound
     - sls: ceph.remove.migrated
 
 wait on {{ host }}:
   salt.state:
-    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt: {{ master }}
     - tgt_type: compound
     - sls: ceph.wait.1hour.until.OK
     - failhard: True

--- a/srv/salt/ceph/monitoring/prometheus/files/prometheus.yml.j2
+++ b/srv/salt/ceph/monitoring/prometheus/files/prometheus.yml.j2
@@ -13,7 +13,7 @@ scrape_configs:
   # The job name is added as a label `job=<job_name>` to any timeseries scraped from this config.
   - job_name: 'ceph-exporter'
     static_configs:
-      - targets: ['{{ salt['pillar.get']('master_minion') }}:9128']
+      - targets: ['{{ salt['master.minion']() }}:9128']
 
   - job_name: 'node-exporter'
     file_sd_configs:

--- a/srv/salt/ceph/openattic/default.sls
+++ b/srv/salt/ceph/openattic/default.sls
@@ -1,4 +1,5 @@
 
+{% set master = salt['master.minion']() %}
 
 install openattic:
   pkg.installed:
@@ -10,7 +11,7 @@ configure salt-api:
   module.run:
     - name: openattic.configure_salt_api
     - kwargs:
-      hostname: "{{ salt['pillar.get']('master_minion') }}"
+      hostname: "{{ master }}"
       port: 8000
       username: "admin"
       sharedsecret: "{{ salt['pillar.get']('salt_api_shared_secret') }}"
@@ -19,7 +20,7 @@ configure grafana:
   module.run:
     - name: openattic.configure_grafana
     - kwargs:
-      hostname: "{{ salt['pillar.get']('master_minion') }}"
+      hostname: "{{ master }}"
 
 enable openattic-systemd:
   service.running:

--- a/srv/salt/ceph/purge/default.sls
+++ b/srv/salt/ceph/purge/default.sls
@@ -1,8 +1,10 @@
 
+{% set master = salt['master.minion']() %}
+
 {% if salt['saltutil.runner']('disengage.check', cluster='ceph') == False %}
 safety is engaged:
   salt.state:
-    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt: {{ master }}
     - name: "Run 'salt-run disengage.safety' to disable"
     - failhard: True
 
@@ -10,7 +12,7 @@ safety is engaged:
 
 reset master configuration:
   salt.state:
-    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt: {{ master }}
     - tgt_type: compound
     - sls: ceph.reset
 

--- a/srv/salt/ceph/restart/ganesha/default.sls
+++ b/srv/salt/ceph/restart/ganesha/default.sls
@@ -1,4 +1,4 @@
-{% set master = salt['pillar.get']('master_minion') %}
+{% set master = salt['master.minion']() %}
 {% for host in salt.saltutil.runner('select.minions', cluster='ceph', roles='ganesha') %}
     
     wait until {{ host }} with role ganesha can be restarted:

--- a/srv/salt/ceph/restart/ganesha/lax/default.sls
+++ b/srv/salt/ceph/restart/ganesha/lax/default.sls
@@ -1,4 +1,4 @@
-{% set master = salt['pillar.get']('master_minion') %}
+{% set master = salt['master.minion']() %}
 {% for host in salt.saltutil.runner('select.minions', cluster='ceph', roles='ganesha') %}
     
     wait until {{ host }} with role ganesha can be restarted:

--- a/srv/salt/ceph/restart/igw/default.sls
+++ b/srv/salt/ceph/restart/igw/default.sls
@@ -1,4 +1,4 @@
-{% set master = salt['pillar.get']('master_minion') %}
+{% set master = salt['master.minion']() %}
 {% for host in salt.saltutil.runner('select.minions', cluster='ceph', roles='igw') %}
     
     wait until {{ host }} with role igw can be restarted:

--- a/srv/salt/ceph/restart/igw/lax/default.sls
+++ b/srv/salt/ceph/restart/igw/lax/default.sls
@@ -1,4 +1,4 @@
-{% set master = salt['pillar.get']('master_minion') %}
+{% set master = salt['master.minion']() %}
 {% for host in salt.saltutil.runner('select.minions', cluster='ceph', roles='igw') %}
     
     wait until {{ host }} with role igw can be restarted:

--- a/srv/salt/ceph/restart/mds/default.sls
+++ b/srv/salt/ceph/restart/mds/default.sls
@@ -1,4 +1,4 @@
-{% set master = salt['pillar.get']('master_minion') %}
+{% set master = salt['master.minion']() %}
 {% for host in salt.saltutil.runner('select.minions', cluster='ceph', roles='mds') %}
     
     wait until {{ host }} with role mds can be restarted:

--- a/srv/salt/ceph/restart/mds/lax/default.sls
+++ b/srv/salt/ceph/restart/mds/lax/default.sls
@@ -1,4 +1,4 @@
-{% set master = salt['pillar.get']('master_minion') %}
+{% set master = salt['master.minion']() %}
 {% for host in salt.saltutil.runner('select.minions', cluster='ceph', roles='mds') %}
     
     wait until {{ host }} with role mds can be restarted:

--- a/srv/salt/ceph/restart/mgr/default.sls
+++ b/srv/salt/ceph/restart/mgr/default.sls
@@ -1,4 +1,4 @@
-{% set master = salt['pillar.get']('master_minion') %}
+{% set master = salt['master.minion']() %}
 {% for host in salt.saltutil.runner('select.minions', cluster='ceph', roles='mgr') %}
 
     wait until {{ host }} with role mgr can be restarted:

--- a/srv/salt/ceph/restart/mgr/lax/default.sls
+++ b/srv/salt/ceph/restart/mgr/lax/default.sls
@@ -1,4 +1,4 @@
-{% set master = salt['pillar.get']('master_minion') %}
+{% set master = salt['master.minion']() %}
 {% for host in salt.saltutil.runner('select.minions', cluster='ceph', roles='mgr') %}
 
     wait until {{ host }} with role mgr can be restarted:

--- a/srv/salt/ceph/restart/mon/default.sls
+++ b/srv/salt/ceph/restart/mon/default.sls
@@ -1,4 +1,4 @@
-{% set master = salt['pillar.get']('master_minion') %}
+{% set master = salt['master.minion']() %}
 {% for host in salt.saltutil.runner('select.minions', cluster='ceph', roles='mon') %}
 
     wait until {{ host }} with role mon can be restarted:

--- a/srv/salt/ceph/restart/mon/lax/default.sls
+++ b/srv/salt/ceph/restart/mon/lax/default.sls
@@ -1,4 +1,4 @@
-{% set master = salt['pillar.get']('master_minion') %}
+{% set master = salt['master.minion']() %}
 {% for host in salt.saltutil.runner('select.minions', cluster='ceph', roles='mon') %}
 
     wait until {{ host }} with role mon can be restarted:

--- a/srv/salt/ceph/restart/openattic/default.sls
+++ b/srv/salt/ceph/restart/openattic/default.sls
@@ -1,4 +1,4 @@
-{% set master = salt['pillar.get']('master_minion') %}
+{% set master = salt['master.minion']() %}
 {% for host in salt.saltutil.runner('select.minions', cluster='ceph', roles='openattic') %}
 
     wait until {{ host }} with role openattic can be restarted:

--- a/srv/salt/ceph/restart/openattic/lax/default.sls
+++ b/srv/salt/ceph/restart/openattic/lax/default.sls
@@ -1,4 +1,4 @@
-{% set master = salt['pillar.get']('master_minion') %}
+{% set master = salt['master.minion']() %}
 {% for host in salt.saltutil.runner('select.minions', cluster='ceph', roles='openattic') %}
 
     wait until {{ host }} with role openattic can be restarted:

--- a/srv/salt/ceph/restart/osd/default.sls
+++ b/srv/salt/ceph/restart/osd/default.sls
@@ -1,4 +1,4 @@
-{% set master = salt['pillar.get']('master_minion') %}
+{% set master = salt['master.minion']() %}
 {% for host in salt.saltutil.runner('select.minions', cluster='ceph', roles='storage') %}
     
     wait until {{ host }} with role osd can be restarted:

--- a/srv/salt/ceph/restart/osd/lax/default.sls
+++ b/srv/salt/ceph/restart/osd/lax/default.sls
@@ -1,4 +1,4 @@
-{% set master = salt['pillar.get']('master_minion') %}
+{% set master = salt['master.minion']() %}
 {% for host in salt.saltutil.runner('select.minions', cluster='ceph', roles='storage') %}
     
     wait until {{ host }} with role osd can be restarted:

--- a/srv/salt/ceph/restart/rgw/default.sls
+++ b/srv/salt/ceph/restart/rgw/default.sls
@@ -1,4 +1,4 @@
-{% set master = salt['pillar.get']('master_minion') %}
+{% set master = salt['master.minion']() %}
 {% for host in salt.saltutil.runner('select.minions', cluster='ceph', roles='rgw') %}
 
     wait until {{ host }} with role rgw can be restarted:

--- a/srv/salt/ceph/restart/rgw/lax/default.sls
+++ b/srv/salt/ceph/restart/rgw/lax/default.sls
@@ -1,4 +1,4 @@
-{% set master = salt['pillar.get']('master_minion') %}
+{% set master = salt['master.minion']() %}
 {% for host in salt.saltutil.runner('select.minions', cluster='ceph', roles='rgw') %}
 
     wait until {{ host }} with role rgw can be restarted:

--- a/srv/salt/ceph/smoketests/keyrings/init.sls
+++ b/srv/salt/ceph/smoketests/keyrings/init.sls
@@ -1,7 +1,9 @@
 
+{% set master = salt['master.minion']() %}
+
 check keyrings:
   salt.state:
-    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt: {{ master }}
     - tgt_type: compound
     - sls: ceph.tests.keyrings
 

--- a/srv/salt/ceph/stage/cephfs/core/default.sls
+++ b/srv/salt/ceph/stage/cephfs/core/default.sls
@@ -1,13 +1,16 @@
+
+{% set master = salt['master.minion']() %}
+
 {% if salt.saltutil.runner('select.minions', cluster='ceph', roles='mds') %}
 
 cephfs pools:
   salt.state:
-    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt: {{ master }}
     - sls: ceph.mds.pools
 
 mds auth:
   salt.state:
-    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt: {{ master }}
     - sls: ceph.mds.auth
 
 mds:

--- a/srv/salt/ceph/stage/configure/default.sls
+++ b/srv/salt/ceph/stage/configure/default.sls
@@ -1,9 +1,12 @@
+
+{% set master = salt['master.minion']() %}
+
 {% if salt['saltutil.runner']('validate.discovery', cluster='ceph') == False %}
 
 validate failed:
   salt.state:
     - name: just.exit
-    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt: {{ master }}
     - failhard: True
 
 {% endif %}
@@ -14,7 +17,7 @@ push proposals:
 
 refresh_pillar1:
   salt.state:
-    - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
+    - tgt: '{{ master }}'
     - tgt_type: compound
     - sls: ceph.refresh
 
@@ -25,7 +28,7 @@ show networks:
 {% for role in [ 'admin', 'mon', 'mgr', 'osd', 'igw', 'mds', 'rgw', 'ganesha', 'openattic'] %}
 {{ role }} key:
   salt.state:
-    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt: {{ master }}
     - tgt_type: compound
     - sls: ceph.{{ role }}.key
     - failhard: True
@@ -34,7 +37,7 @@ show networks:
 
 setup monitoring:
   salt.state:
-    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt: {{ master }}
     - tgt_type: compound
     - sls: ceph.monitoring
 

--- a/srv/salt/ceph/stage/deploy/core/default.sls
+++ b/srv/salt/ceph/stage/deploy/core/default.sls
@@ -1,11 +1,13 @@
 
+{% set master = salt['master.minion']() %}
+
 {% set FAIL_ON_WARNING = salt['pillar.get']('FAIL_ON_WARNING', 'True') %}
 
 {% if salt['saltutil.runner']('ready.check', cluster='ceph', fail_on_warning=FAIL_ON_WARNING)  == False %}
 ready check failed:
   salt.state:
     - name: "Fail on Warning is True"
-    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt: {{ master }}
     - failhard: True
 
 {% endif %}
@@ -22,7 +24,7 @@ ready check failed:
 validate failed:
   salt.state:
     - name: just.exit
-    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt: {{ master }}
     - failhard: True
 
 {% endif %}
@@ -45,14 +47,14 @@ packages:
 
 configuration check:
   salt.state:
-    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt: {{ master }}
     - tgt_type: compound
     - sls: ceph.configuration.check
     - failhard: True
 
 create ceph.conf:
   salt.state:
-    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt: {{ master }}
     - sls: ceph.configuration.create
     - failhard: True
 
@@ -97,7 +99,7 @@ monitors:
 
 mgr auth:
   salt.state:
-    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt: {{ master }}
     - sls: ceph.mgr.auth
 
 mgrs:
@@ -109,19 +111,19 @@ mgrs:
 
 setup ceph exporter:
   salt.state:
-    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt: {{ master }}
     - tgt_type: compound
     - sls: ceph.monitoring.prometheus.exporters.ceph_exporter
 
 setup rbd exporter:
   salt.state:
-    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt: {{ master }}
     - tgt_type: compound
     - sls: ceph.monitoring.prometheus.exporters.rbd_exporter
 
 osd auth:
   salt.state:
-    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt: {{ master }}
     - tgt_type: compound
     - sls: ceph.osd.auth
     - failhard: True
@@ -149,5 +151,5 @@ grains:
 
 pools:
   salt.state:
-    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt: {{ master }}
     - sls: ceph.pool

--- a/srv/salt/ceph/stage/discovery/default-nvme.sls
+++ b/srv/salt/ceph/stage/discovery/default-nvme.sls
@@ -1,9 +1,12 @@
+
+{% set master = salt['master.minion']() %}
+
 {% if salt['saltutil.runner']('validate.saltapi') == False %}
 
 salt-api failed:
   salt.state:
     - name: just.exit
-    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt: {{ master }}
     - failhard: True
 
 {% endif %}
@@ -13,7 +16,7 @@ salt-api failed:
 validate failed:
   salt.state:
     - name: just.exit
-    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt: {{ master }}
     - failhard: True
 
 {% endif %}
@@ -25,7 +28,7 @@ ready:
 
 refresh_pillar0:
   salt.state:
-    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt: {{ master }}
     - sls: ceph.refresh
 
 discover roles:

--- a/srv/salt/ceph/stage/discovery/default.sls
+++ b/srv/salt/ceph/stage/discovery/default.sls
@@ -1,9 +1,12 @@
+
+{% set master = salt['master.minion']() %}
+
 {% if salt['saltutil.runner']('validate.saltapi') == False %}
 
 salt-api failed:
   salt.state:
     - name: just.exit
-    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt: {{ master }}
     - failhard: True
 
 {% endif %}
@@ -13,7 +16,7 @@ salt-api failed:
 validate failed:
   salt.state:
     - name: just.exit
-    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt: {{ master }}
     - failhard: True
 
 {% endif %}
@@ -25,7 +28,7 @@ ready:
 
 refresh_pillar0:
   salt.state:
-    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt: {{ master }}
     - sls: ceph.refresh
 
 discover roles:

--- a/srv/salt/ceph/stage/ganesha/core/default.sls
+++ b/srv/salt/ceph/stage/ganesha/core/default.sls
@@ -1,14 +1,17 @@
+
+{% set master = salt['master.minion']() %}
+
 {% if salt.saltutil.runner('select.minions', cluster='ceph', roles='ganesha') or salt.saltutil.runner('select.minions', cluster='ceph', roles='ganesha_configurations') %}
 
 ganesha auth:
   salt.state:
-    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt: {{ master }}
     - tgt_type: compound
     - sls: ceph.ganesha.auth
 
 ganesha config:
   salt.state:
-    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt: {{ master }}
     - tgt_type: compound
     - sls: ceph.ganesha.config
     - failhard: True

--- a/srv/salt/ceph/stage/iscsi/core/default.sls
+++ b/srv/salt/ceph/stage/iscsi/core/default.sls
@@ -1,3 +1,6 @@
+
+{% set master = salt['master.minion']() %}
+
 {% if salt.saltutil.runner('select.minions', cluster='ceph', roles='igw') %}
 
 add_mine_cephimages.list_function:
@@ -5,18 +8,18 @@ add_mine_cephimages.list_function:
     - name: mine.send
     - arg:
       - cephimages.list
-    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt: {{ master }}
     - tgt_type: compound
 
 igw config:
   salt.state:
-    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt: {{ master }}
     - tgt_type: compound
     - sls: ceph.igw.config
 
 auth:
   salt.state:
-    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt: {{ master }}
     - sls: ceph.igw.auth
 
 keyring:

--- a/srv/salt/ceph/stage/openattic/core/default.sls
+++ b/srv/salt/ceph/stage/openattic/core/default.sls
@@ -1,4 +1,6 @@
 
+{% set master = salt['master.minion']() %}
+
 openattic nop:
     test.nop
 
@@ -6,7 +8,7 @@ openattic nop:
 
 openattic auth:
     salt.state:
-        - tgt: {{ salt['pillar.get']('master_minion') }}
+        - tgt: {{ master }}
         - sls: ceph.openattic.auth
 
 openattic:

--- a/srv/salt/ceph/stage/openstack/default.sls
+++ b/srv/salt/ceph/stage/openstack/default.sls
@@ -1,7 +1,9 @@
 
+{% set master = salt['master.minion']() %}
+
 openstack:
   salt.state:
-    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt: {{ master }}
     - tgt_type: compound
     - sls: ceph.openstack
 

--- a/srv/salt/ceph/stage/prep/master/default-no-update-no-reboot.sls
+++ b/srv/salt/ceph/stage/prep/master/default-no-update-no-reboot.sls
@@ -1,28 +1,31 @@
+
+{% set master = salt['master.minion']() %}
+
 {% if salt['saltutil.runner']('validate.setup') == False %}
 
 validate failed:
   salt.state:
     - name: just.exit
-    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt: {{ master }}
     - failhard: True
 
 {% endif %}
 
 sync master:
   salt.state:
-    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt: {{ master }}
     - sls: ceph.sync
 
 salt-api:
   salt.state:
-    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt: {{ master }}
     - sls: ceph.salt-api
 
 {% set notice = salt['saltutil.runner']('advise.salt_run') %}
 
 repo master:
   salt.state:
-    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt: {{ master }}
     - sls: ceph.repo
 
 {% set kernel= grains['kernelrelease'] | replace('-default', '')  %}

--- a/srv/salt/ceph/stage/prep/master/default-no-update-reboot.sls
+++ b/srv/salt/ceph/stage/prep/master/default-no-update-reboot.sls
@@ -1,28 +1,31 @@
+
+{% set master = salt['master.minion']() %}
+
 {% if salt['saltutil.runner']('validate.setup') == False %}
 
 validate failed:
   salt.state:
     - name: just.exit
-    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt: {{ master }}
     - failhard: True
 
 {% endif %}
 
 sync master:
   salt.state:
-    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt: {{ master }}
     - sls: ceph.sync
 
 salt-api:
   salt.state:
-    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt: {{ master }}
     - sls: ceph.salt-api
 
 {% set notice = salt['saltutil.runner']('advise.salt_run') %}
 
 repo master:
   salt.state:
-    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt: {{ master }}
     - sls: ceph.repo
 
 {% set kernel= grains['kernelrelease'] | replace('-default', '')  %}
@@ -36,7 +39,7 @@ unlock:
 
 restart master:
   salt.state:
-    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt: {{ master }}
     - sls: ceph.updates.restart
 
 complete marker:

--- a/srv/salt/ceph/stage/prep/master/default-update-no-reboot.sls
+++ b/srv/salt/ceph/stage/prep/master/default-update-no-reboot.sls
@@ -1,33 +1,36 @@
+
+{% set master = salt['master.minion']() %}
+
 {% if salt['saltutil.runner']('validate.setup') == False %}
 
 validate failed:
   salt.state:
     - name: just.exit
-    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt: {{ master }}
     - failhard: True
 
 {% endif %}
 
 sync master:
   salt.state:
-    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt: {{ master }}
     - sls: ceph.sync
 
 salt-api:
   salt.state:
-    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt: {{ master }}
     - sls: ceph.salt-api
 
 {% set notice = salt['saltutil.runner']('advise.salt_run') %}
 
 repo master:
   salt.state:
-    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt: {{ master }}
     - sls: ceph.repo
 
 prepare master:
   salt.state:
-    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt: {{ master }}
     - sls: ceph.updates
 
 {% set kernel= grains['kernelrelease'] | replace('-default', '')  %}

--- a/srv/salt/ceph/stage/prep/master/default.sls
+++ b/srv/salt/ceph/stage/prep/master/default.sls
@@ -1,33 +1,35 @@
+{% set master = salt['master.minion']() %}
+
 {% if salt['saltutil.runner']('validate.setup') == False %}
 
 validate failed:
   salt.state:
     - name: just.exit
-    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt: {{ master }}
     - failhard: True
 
 {% endif %}
 
 sync master:
   salt.state:
-    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt: {{ master }}
     - sls: ceph.sync
 
 salt-api:
   salt.state:
-    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt: {{ master }}
     - sls: ceph.salt-api
 
 {% set notice = salt['saltutil.runner']('advise.salt_run') %}
 
 repo master:
   salt.state:
-    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt: {{ master }}
     - sls: ceph.repo
 
 prepare master:
   salt.state:
-    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt: {{ master }}
     - sls: ceph.updates
 
 {% set kernel= grains['kernelrelease'] | replace('-default', '')  %}
@@ -42,7 +44,7 @@ unlock:
 {% if grains.get('os_family', '') == 'Suse' %}
 restart master:
   salt.state:
-    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt: {{ master }}
     - sls: ceph.updates.restart
 {% endif %}
 

--- a/srv/salt/ceph/stage/prep/minion/default-no-update-reboot.sls
+++ b/srv/salt/ceph/stage/prep/minion/default-no-update-reboot.sls
@@ -1,3 +1,6 @@
+
+{% set master = salt['master.minion']() %}
+
 repo:
   salt.state:
     - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
@@ -40,7 +43,7 @@ starting {{ host }}:
 
 wait until the cluster has recovered before processing {{ host }}:
   salt.state:
-    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt: {{ master }}
     - sls: ceph.wait
     - failhard: True
 
@@ -54,13 +57,13 @@ check if all processes are still running after processing {{ host }}:
 unset noout {{ host }}:
   salt.state:
     - sls: ceph.noout.unset
-    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt: {{ master }}
     - failhard: True
 
 set noout {{ host }}:
   salt.state:
     - sls: ceph.noout.set
-    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt: {{ master }}
     - failhard: True
 
 restart {{ host }} if updates require:
@@ -80,7 +83,7 @@ finished {{ host }}:
 unset noout after final iteration: 
   salt.state:
     - sls: ceph.noout.unset
-    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt: {{ master }}
     - failhard: True
 
 starting remaining minions:

--- a/srv/salt/ceph/stage/prep/minion/default-update-no-reboot.sls
+++ b/srv/salt/ceph/stage/prep/minion/default-update-no-reboot.sls
@@ -1,3 +1,6 @@
+
+{% set master = salt['master.minion']() %}
+
 repo:
   salt.state:
     - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
@@ -40,7 +43,7 @@ starting {{ host }}:
 
 wait until the cluster has recovered before processing {{ host }}:
   salt.state:
-    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt: {{ master }}
     - sls: ceph.wait
     - failhard: True
 
@@ -54,7 +57,7 @@ check if all processes are still running after processing {{ host }}:
 unset noout {{ host }}:
   salt.state:
     - sls: ceph.noout.unset
-    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt: {{ master }}
     - failhard: True
 
 updating {{ host }}:
@@ -67,7 +70,7 @@ updating {{ host }}:
 set noout {{ host }}:
   salt.state:
     - sls: ceph.noout.set
-    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt: {{ master }}
     - failhard: True
 
 finished {{ host }}:
@@ -80,7 +83,7 @@ finished {{ host }}:
 unset noout after final iteration: 
   salt.state:
     - sls: ceph.noout.unset
-    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt: {{ master }}
     - failhard: True
 
 starting remaining minions:

--- a/srv/salt/ceph/stage/prep/minion/default.sls
+++ b/srv/salt/ceph/stage/prep/minion/default.sls
@@ -1,3 +1,6 @@
+
+{% set master = salt['master.minion']() %}
+
 repo:
   salt.state:
     - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
@@ -40,7 +43,7 @@ starting {{ host }}:
 
 wait until the cluster has recovered before processing {{ host }}:
   salt.state:
-    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt: {{ master }}
     - sls: ceph.wait
     - failhard: True
 
@@ -54,7 +57,7 @@ check if all processes are still running after processing {{ host }}:
 unset noout {{ host }}:
   salt.state:
     - sls: ceph.noout.unset
-    - tgt: '{{ salt['pillar.get']('master_minion') }}'
+    - tgt: '{{ master }}'
     - failhard: True
 
 updating {{ host }}:
@@ -67,7 +70,7 @@ updating {{ host }}:
 set noout {{ host }}:
   salt.state:
     - sls: ceph.noout.set
-    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt: {{ master }}
     - failhard: True
 
 {% if grains.get('os_family', '') == 'Suse' %}
@@ -89,7 +92,7 @@ finished {{ host }}:
 unset noout after final iteration:
   salt.state:
     - sls: ceph.noout.unset
-    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt: {{ master }}
     - failhard: True
 
 starting remaining minions:

--- a/srv/salt/ceph/stage/radosgw/core/default.sls
+++ b/srv/salt/ceph/stage/radosgw/core/default.sls
@@ -1,14 +1,17 @@
+
+{% set master = salt['master.minion']() %}
+
 {% if salt.saltutil.runner('select.minions', cluster='ceph', roles='rgw') or salt.saltutil.runner('select.minions', cluster='ceph', roles='rgw_configurations') %}
 
 rgw auth:
   salt.state:
-    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt: {{ master }}
     - tgt_type: compound
     - sls: ceph.rgw.auth
 
 rgw users:
   salt.state:
-    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt: {{ master }}
     - tgt_type: compound
     - sls: ceph.rgw.users
 
@@ -24,13 +27,13 @@ rgw users:
 # requires the admin keyring.
 setup prometheus rgw exporter:
   salt.state:
-    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt: {{ master }}
     - tgt_type: compound
     - sls: ceph.monitoring.prometheus.exporters.ceph_rgw_exporter
 
 rgw demo buckets:
   salt.state:
-    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt: {{ master }}
     - tgt_type: compound
     - sls: ceph.rgw.buckets
 

--- a/srv/salt/ceph/stage/removal/default-remove.sls
+++ b/srv/salt/ceph/stage/removal/default-remove.sls
@@ -1,4 +1,6 @@
 
+{% set master = salt['master.minion']() %}
+
 update mines:
   salt.function:
     - name: mine.update
@@ -8,19 +10,19 @@ update mines:
 
 remove mon:
   salt.state:
-    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt: {{ master }}
     - tgt_type: compound
     - sls: ceph.remove.mon
 
 remove mgr:
   salt.state:
-    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt: {{ master }}
     - tgt_type: compound
     - sls: ceph.remove.mgr
 
 drain osds:
   salt.state:
-    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt: {{ master }}
     - tgt_type: compound
     - sls: ceph.remove.storage.drain
 
@@ -32,13 +34,13 @@ terminate ceph osds:
 
 cleanup osds:
   salt.state:
-    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt: {{ master }}
     - tgt_type: compound
     - sls: ceph.remove.storage
 
 remove ganesha:
   salt.state:
-    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt: {{ master }}
     - tgt_type: compound
     - sls: ceph.remove.ganesha
 
@@ -50,19 +52,19 @@ rescind roles:
 
 remove cephfs:
   salt.state:
-    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt: {{ master }}
     - tgt_type: compound
     - sls: ceph.remove.mds
 
 remove rgw:
   salt.state:
-    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt: {{ master }}
     - tgt_type: compound
     - sls: ceph.remove.rgw
 
 remove openattic:
   salt.state:
-    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt: {{ master }}
     - tgt_type: compound
     - sls: ceph.remove.openattic
 
@@ -72,7 +74,7 @@ remove openattic:
 # Remove the Prometheus RGW exporter if no 'rgw' node is configured.
 remove prometheus rgw exporter:
   salt.state:
-    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt: {{ master }}
     - tgt_type: compound
     - sls: ceph.rescind.rgw.monitoring
 

--- a/srv/salt/ceph/stage/removal/default.sls
+++ b/srv/salt/ceph/stage/removal/default.sls
@@ -1,4 +1,6 @@
 
+{% set master = salt['master.minion']() %}
+
 update mines:
   salt.function:
     - name: mine.update
@@ -8,19 +10,19 @@ update mines:
 
 remove mon:
   salt.state:
-    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt: {{ master }}
     - tgt_type: compound
     - sls: ceph.remove.mon
 
 remove mgr:
   salt.state:
-    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt: {{ master }}
     - tgt_type: compound
     - sls: ceph.remove.mgr
 
 drain osds:
   salt.state:
-    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt: {{ master }}
     - tgt_type: compound
     - sls: ceph.remove.storage.drain
     - failhard: True
@@ -33,13 +35,13 @@ terminate ceph osds:
 
 cleanup osds:
   salt.state:
-    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt: {{ master }}
     - tgt_type: compound
     - sls: ceph.remove.storage
 
 remove ganesha:
   salt.state:
-    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt: {{ master }}
     - tgt_type: compound
     - sls: ceph.remove.ganesha
 
@@ -51,7 +53,7 @@ rescind roles:
 
 remove openattic:
   salt.state:
-    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt: {{ master }}
     - tgt_type: compound
     - sls: ceph.remove.openattic
 
@@ -61,7 +63,7 @@ remove openattic:
 # Remove the Prometheus RGW exporter if no 'rgw' node is configured.
 remove prometheus rgw exporter:
   salt.state:
-    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt: {{ master }}
     - tgt_type: compound
     - sls: ceph.rescind.rgw.monitoring
 

--- a/srv/salt/ceph/stage/services/default.sls
+++ b/srv/salt/ceph/stage/services/default.sls
@@ -4,7 +4,7 @@
 validate failed:
   salt.state:
     - name: just.exit
-    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt: {{ master }}
     - failhard: True
 
 {% endif %}


### PR DESCRIPTION
The master_minion setting was originally set statically in the Salt
pillar.  By using a master module (not a minion module), this value will
use /etc/salt/minion_id and stay in sync.  Continue to support
overriding with a master_minion pillar variable.

Signed-off-by: Eric Jackson <ejackson@suse.com>

Fixes #547