### PR TITLE
force python2 virtualenv for pylint

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,4 @@
-# Tox (http://tox.testrun.org/) is a tool for running tests
+# Tox (https://tox.readthedocs.io/en/latest/) is a tool for running tests
 # in multiple virtualenvs. This configuration file will run the
 # test suite on all supported python versions. To use it, "pip install tox"
 # and then run "tox" from this directory.
@@ -24,6 +24,7 @@ deps =
     boto
 
 [testenv:lint]
+basepython = python2.7
 commands = pylint --rcfile=.pylintrc --jobs=5 srv/
 deps =
     {[base]deps}


### PR DESCRIPTION
Signed-off-by: Alexander Graul <agraul@suse.com>

`lint` virtualenv defaults to python2 on travis but can default to python3 (e.g. on Tumbleweed). That is a problem for two reasons: the first problem is the lack of consistency between travis and dev setups, the second is that `make lint` does not work with python3 properly.

This change forces a python2 virtualenv to ensure the same `pylint` is used locally and on travis.

I also fixed the broken tox documentation URL.
-----------------

[Please find more information on how to run integration tests here](https://github.com/SUSE/DeepSea/wiki/Integration-tests)
