### PR TITLE
Check configs for deprecated k:v pairs and report

### DIFF
--- a/srv/salt/ceph/configuration/files/deprecated_map.yml
+++ b/srv/salt/ceph/configuration/files/deprecated_map.yml
@@ -1,0 +1,23 @@
+general:
+  key: value
+  super: old
+  long: time
+  depre: cated
+
+luminous:
+  lum_key: value
+  newly: deprecated 
+  foo: bar
+
+mimic:
+  deprecated: in_mimic
+  a_list:
+      - of
+      - values
+      - that
+      - are
+      - not
+      - allowd
+      - anymore
+  
+


### PR DESCRIPTION
Signed-off-by: Joshua Schmid <jschmid@suse.de>

Partly addresses  #https://github.com/SUSE/DeepSea/issues/1008

Description: 

Checks for deprecated k:v pairs from a [file](https://github.com/SUSE/DeepSea/blob/e66af3d470116c2ce9c704e1aeab3c36f0fa386b/srv/salt/ceph/configuration/files/deprecated_map.yml)


TODO:

* It's currently not "live", meaning it's not being added to any stage.3 validations or pre-upgrade validations.
* The [file](https://github.com/SUSE/DeepSea/blob/e66af3d470116c2ce9c704e1aeab3c36f0fa386b/srv/salt/ceph/configuration/files/deprecated_map.yml) is not maintained and only contains dummy content.
* Add a version check.

If there is a curated list of k:v pairs, please forward :)

with some tweaks this can also tackle #1272

-----------------

[Please find more information on how to run integration tests here](https://github.com/SUSE/DeepSea/wiki/Integration-tests)
