### PR TITLE
Add osd bootstrap keyring to monitor creation keyring

### DIFF
--- a/srv/salt/ceph/mon/key/default.sls
+++ b/srv/salt/ceph/mon/key/default.sls
@@ -16,3 +16,11 @@
   file.append:
     - name: {{ keyring_file }}
     - source: salt://ceph/admin/cache/ceph.client.admin.keyring
+
+{# Use this key over the generated keyring in Mimic #}
+{# Consider incorporating the keyring when keys are #}
+{# generated in Stage 3.                            #}
+{{ keyring_file }} append osd bootstrap keyring:
+  file.append:
+    - name: {{ keyring_file }}
+    - source: salt://ceph/osd/cache/bootstrap.keyring

--- a/srv/salt/ceph/stage/configure/default.sls
+++ b/srv/salt/ceph/stage/configure/default.sls
@@ -25,7 +25,7 @@ show networks:
   salt.runner:
     - name: advise.networks
 
-{% for role in [ 'admin', 'mon', 'mgr', 'osd', 'igw', 'mds', 'rgw', 'ganesha', 'openattic'] %}
+{% for role in [ 'admin', 'osd', 'mon', 'mgr', 'igw', 'mds', 'rgw', 'ganesha', 'openattic'] %}
 {{ role }} key:
   salt.state:
     - tgt: {{ master }}


### PR DESCRIPTION
Mimic monitors generate their own keyring.  Continue to use the DeepSea
generated keyring to allow others to be unblocked.

Signed-off-by: Eric Jackson <ejackson@suse.com>
