### PR TITLE
Fix template

### DIFF
--- a/srv/salt/ceph/monitoring/prometheus/files/prometheus.yml.j2
+++ b/srv/salt/ceph/monitoring/prometheus/files/prometheus.yml.j2
@@ -13,7 +13,7 @@ scrape_configs:
   # The job name is added as a label `job=<job_name>` to any timeseries scraped from this config.
   - job_name: 'ceph-exporter'
     static_configs:
-      - targets: ['{{ salt['master.minion']() }}:9128']
+      - targets: ['{{ salt['cmd.run']('cat /etc/salt/minion_id') }}:9128']
 
   - job_name: 'node-exporter'
     file_sd_configs:


### PR DESCRIPTION
The master.minion module is not available in Jinja templates.  Since
prometheus is undergoing a reimplementation as a role, use the
/etc/salt/minion_id directly as a stop gap.

Signed-off-by: Eric Jackson <ejackson@suse.com>

Fixes #1112