### PR TITLE
[DNM] [RFC] use jinja macros for simpler dist switch in init.sls

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -224,6 +224,9 @@ copy-files:
 	install -m 644 srv/salt/ceph/igw/restart/force/*.sls $(DESTDIR)/srv/salt/ceph/igw/restart/force
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/igw/restart/reload
 	install -m 644 srv/salt/ceph/igw/restart/reload/*.sls $(DESTDIR)/srv/salt/ceph/igw/restart/reload
+	# state files - macros
+	install -d -m 755 $(DESTDIR)/srv/salt/ceph/macros
+	install -m 644 srv/salt/ceph/macros/*.sls $(DESTDIR)/srv/salt/ceph/macros/
 	# state files - mds
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/mds
 	install -m 644 srv/salt/ceph/mds/*.sls $(DESTDIR)/srv/salt/ceph/mds/

--- a/deepsea.spec.in
+++ b/deepsea.spec.in
@@ -136,6 +136,7 @@ systemctl try-restart salt-api > /dev/null 2>&1 || :
 %dir /srv/salt/ceph/igw/restart/force
 %dir /srv/salt/ceph/igw/restart/reload
 %dir /srv/salt/ceph/igw/sysconfig
+%dir /srv/salt/ceph/macros
 %dir /srv/salt/ceph/mds
 %dir %attr(0700, salt, salt) /srv/salt/ceph/mds/cache
 %dir /srv/salt/ceph/mds/files
@@ -453,6 +454,7 @@ systemctl try-restart salt-api > /dev/null 2>&1 || :
 %config /srv/salt/ceph/igw/restart/force/*.sls
 %config /srv/salt/ceph/igw/restart/reload/*.sls
 %config /srv/salt/ceph/igw/sysconfig/*.sls
+%config /srv/salt/ceph/macros/*.sls
 %config /srv/salt/ceph/mds/*.sls
 %config /srv/salt/ceph/mds/files/*.j2
 %config /srv/salt/ceph/mds/key/*.sls

--- a/srv/salt/ceph/macros/os_switch.sls
+++ b/srv/salt/ceph/macros/os_switch.sls
@@ -1,0 +1,17 @@
+{% macro os_switch(custom) -%}
+  {% set abspath = "/srv/salt/" + slspath %}
+  {%- set osfinger = grains.get('osfinger') -%}
+  {%- set os = grains.get('os') -%}
+  {%- set osrelease = os + "-" + grains.get('osrelease') -%}
+  {%- if salt['file.directory_exists'](abspath + "/" +  custom) -%}
+    {{ custom }}
+  {%- elif salt['file.directory_exists'](abspath + "/" +  osfinger) -%}
+    {{ osfinger }}
+  {%- elif salt['file.directory_exists'](abspath + "/" + osrelease) -%}
+    {{ osrelease }}
+  {%- elif salt['file.directory_exists'](abspath + "/" + os) -%}
+    {{ os }}
+  {%- else -%}
+    default
+  {%- endif -%}
+{%- endmacro %}

--- a/srv/salt/ceph/monitoring/prometheus/exporters/ceph_rgw_exporter/init.sls
+++ b/srv/salt/ceph/monitoring/prometheus/exporters/ceph_rgw_exporter/init.sls
@@ -1,20 +1,6 @@
 
-{% set osfinger = grains.get('osfinger') %}
-{% set os = grains.get('os') %}
-{% set osrelease = os + "-" + grains.get('osrelease') %}
-
-{% set abspath = "/srv/salt/" + slspath %}
 {% set custom = salt['pillar.get']('monitoring_prometheus_exporters_ceph_rgw_exporter', 'not a file') %}
+{% from 'ceph/macros/os_switch.sls' import os_switch with context %}
 
 include:
-{% if salt['file.directory_exists'](abspath + "/" +  custom) %}
-  - .{{ custom }}
-{% elif salt['file.directory_exists'](abspath + "/" +  osfinger) %}
-  - .{{ osfinger }}
-{% elif salt['file.directory_exists'](abspath + "/" + osrelease) %}
-  - .{{ osrelease }}
-{% elif salt['file.directory_exists'](abspath + "/" + os) %}
-  - .{{ os }}
-{% else %}
-  - .default
-{% endif %}
+  - .{{ os_switch(custom) }}


### PR DESCRIPTION
An attempt to simplify the new dist switch mechnism introduced in #1016.

Any init.sls can do the import from ```ceph.foo.sls``` (name pending) which should greatly simplify the swithching proposed in #1016. The rest works as before...if a distro specific path is present it is taken. fallback is default.
I think this makes it less painfull to roll out throughout deepsea.

Signed-off-by: Jan Fajerski <jfajerski@suse.com>
