### PR TITLE
migrate linter to python3

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -29,8 +29,7 @@ load-plugins=saltpylint.pep8,
   saltpylint.thirdparty
 
 # Use multiple processes to speed up Pylint.
-# Don't bump this values on PyLint 1.4.0 - Know bug that ignores the passed --rcfile
-jobs=1
+jobs=5
 
 # Allow loading of arbitrary C extensions. Extensions are imported into the
 # active Python interpreter and may run arbitrary code.
@@ -81,37 +80,37 @@ confidence=
 # --enable=similarities". If you want to run only the classes checker, but have
 # no Warning level messages displayed, use"--disable=all --enable=classes
 # --disable=W"
-disable=W0142,
+disable = 
+  E1101,
+  E1320,
+  E1323,
+  E8402,
+  E8731, 
+  W0141,
+  W1202,
+  W8470,
   C0330,
   I0011,
   I0012,
-  W1202,
-  E1320,
-  E8402,
-  E8731, 
-  W1202,
-  W0141 
-#  E8121,
-#  E8122,
-#  E8123,
-#  E8124,
-#  E8125,
-#  E8126,
-#  E8127,
-#  E8128
+  I1101
 
 # Disabled Checks
-#
+# Errors
+# E1101 (no-member)
+# E1320 (un-indexed-curly-braces-error)
+# E1323 (str-format-in-logging)
+# E8402 (module-level-import-not-at-top-of-file)
+# E8731 (do-not-assign-a-lambda-expression-use-a-def)
+# Warnings
 # W0142 (star-args)
-# W1202 (logging-format-interpolation) Use % formatting in logging functions but pass the % parameters as arguments
-# E812* All PEP8 E12*
-# E8402 module level import not at top of file
-# E8501 PEP8 line too long
-# E8731 do not assign a lambda expression, use a def
+# W1202 (logging-format-interpolation)
+# W8470 (resource-leakage)
+# Convention
 # C0330 (bad-continuation)
+# Other
 # I0011 (locally-disabling)
 # I0012 (locally-enabling)
-# W1202 (logging-format-interpolation)
+# I1101 (c-extension-no-member)
 
 
 [REPORTS]

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 python:
-  - '2.7'
+  - 2.7
 install:
     - make setup.py
     - pip install tox
@@ -9,10 +9,10 @@ env:
 matrix:
   fast_finish: true
   include:
-    - env: TOXENV=lint
-      python: '2.7'
-    - env: TOXENV=py27
-      python: '2.7'
+    - python: 3.5
+      env: TOXENV=lint
+    - python: 2.7
+      env: TOXENV=py27
 script:
   - tox -e $TOXENV
 cache: pip

--- a/srv/modules/runners/cephprocesses.py
+++ b/srv/modules/runners/cephprocesses.py
@@ -179,6 +179,7 @@ def wait(cluster='ceph', **kwargs):
     return True
 
 
+# pylint: disable=no-else-return
 def _timeout(cluster='ceph'):
     """
     Assume 15 minutes for physical hardware since some hardware has long

--- a/srv/modules/runners/changed.py
+++ b/srv/modules/runners/changed.py
@@ -191,6 +191,7 @@ class Config(object):
             log.info("Change in configuration detected for role {}".format(self.role.name))
             self.write_checksum(current_cs)
             return True
+        return False
 
 
 def help_():

--- a/srv/modules/runners/disengage.py
+++ b/srv/modules/runners/disengage.py
@@ -50,11 +50,11 @@ def check(cluster='ceph'):
     Check that time stamp of file is less than one minute
     """
     sff = SafetyFile(cluster)
+    stamp_recent = False
     if os.path.exists(sff.filename):
         stamp = os.stat(sff.filename).st_mtime
-        return stamp + 60 > time.time()
-    else:
-        return False
+        stamp_recent = stamp + 60 > time.time()
+    return stamp_recent
 
 __func_alias__ = {
                  'help_': 'help',

--- a/srv/modules/runners/filequeue.py
+++ b/srv/modules/runners/filequeue.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=visually-indented-line-with-same-indent-as-next-logical-line
-# pylint: disable=too-few-public-methods,modernize-parse-error
+# pylint: disable=too-few-public-methods,modernize-parse-error,no-else-return
 """
 The queue runner in salt uses sqlite.  While not a problem in general, when
 a few events arrive simultaneously, the last attempts fail.  The contention is
@@ -155,6 +155,7 @@ class FileQueue(object):
                 return False
         else:
             log.debug("filename {} does not exist".format(filename))
+            return None
 
     def check(self, item):
         """
@@ -328,7 +329,7 @@ def enqueue(queue=None, **kwargs):
             ret = filequeue.touch(kwargs['item'])
         else:
             help()
-            return
+            return None
     return ret
 
 
@@ -415,7 +416,7 @@ def check(queue=None, **kwargs):
             return filequeue.check(kwargs['item'])
         else:
             help()
-            return
+            return None
 
 
 def remove(queue=None, **kwargs):
@@ -432,7 +433,7 @@ def remove(queue=None, **kwargs):
             return filequeue.remove(kwargs['item'])
         else:
             help()
-            return
+            return None
 
 
 def vacate(queue=None, **kwargs):
@@ -449,7 +450,7 @@ def vacate(queue=None, **kwargs):
             return filequeue.vacate(kwargs['item'])
         else:
             help()
-            return
+            return None
 
 __func_alias__ = {
                  'help_': 'help',

--- a/srv/modules/runners/proposal.py
+++ b/srv/modules/runners/proposal.py
@@ -207,6 +207,7 @@ def _choose_proposal(node, proposal, args):
                 return _propose(node, proposal[conf], args)
         else:
             log.error("Verify that targeted minions have proposal.generate")
+    return None
 
 
 def help_():
@@ -299,7 +300,7 @@ def _record_filter(args, base_dir):
     pprint.pprint(current_filter)
 
     # filter a bunch of salt content and the target key before writing
-    rec_args = {k: v for k, v in args.items() if k is not 'target' and not
+    rec_args = {k: v for k, v in args.items() if k != 'target' and not
                 k.startswith('__')}
     current_filter[args['target']] = rec_args
 

--- a/srv/modules/runners/push.py
+++ b/srv/modules/runners/push.py
@@ -59,8 +59,8 @@ import sys
 import yaml
 sys.path.append('/srv/modules/pillar')
 # pylint: disable=import-error,3rd-party-module-not-gated,redefined-builtin,wrong-import-position
-from stack import _merge_dict
 import salt.ext.six as six
+from stack import _merge_dict
 
 
 log = logging.getLogger(__name__)
@@ -242,12 +242,12 @@ class PillarData(object):
                     yml.write("# Overwrites configuration in {}\n".format(custom_for))
                     _examples(custom, yml)
 
-    def organize(self, filename):
+    def organize(self, policy_filename):
         """
         Associate all filenames with their common subdirectory.
         """
         common = {}
-        with open(filename, "r") as policy:
+        with open(policy_filename, "r") as policy:
             for line in policy:
                 log.debug(line)
                 # strip comments from the end of the line
@@ -257,27 +257,28 @@ class PillarData(object):
                     log.debug("Ignoring '{}'".format(line))
                     continue
                 try:
-                    files = _parse(self.proposals_dir + "/" + line)
+                    proposal_files = _parse(self.proposals_dir + "/" + line)
                 except ValueError:
                     log.exception('''
                     ERROR: Mailformed {}: {}
-                    '''.format(filename, line))
-                    files = []
-                if not files:
+                    '''.format(policy_filename, line))
+                    proposal_files = []
+                if not proposal_files:
                     log.warning("{} matched no files".format(line))
                 log.debug(line)
-                log.debug(files)
-                for filename in files:
-                    if os.stat(filename).st_size == 0:
-                        log.warning("Skipping empty file {}".format(filename))
+                log.debug(proposal_files)
+                for proposal_file in proposal_files:
+                    if os.stat(proposal_file).st_size == 0:
+                        log.warning("Skipping empty file {}".format(proposal_file))
                         continue
-                    if os.path.isfile(filename):
-                        pathname = _shift_dir(filename.replace(self.proposals_dir, ""))
+                    if os.path.isfile(proposal_file):
+                        pathname = _shift_dir(proposal_file.replace(
+                                              self.proposals_dir, ""))
                         if pathname not in common:
                             common[pathname] = []
-                        common[pathname].append(filename)
+                        common[pathname].append(proposal_file)
                     else:
-                        log.warning("{} does not exist".format(filename))
+                        log.warning("{} does not exist".format(proposal_file))
 
         # This should be in a conditional, but
         # getEffectiveLevel returns 1 no matter setting

--- a/srv/modules/runners/select.py
+++ b/srv/modules/runners/select.py
@@ -91,11 +91,9 @@ def one_minion(**kwargs):
     Some steps only need to be run once, but on any minion in a specific
     search.  Return the first matching key.
     """
+    ret = [None]
     ret = minions(**kwargs)
-    if ret:
-        return ret[0]
-    else:
-        return
+    return ret[0]
 
 
 def public_addresses(tuples=False, host=False, **kwargs):

--- a/srv/modules/runners/status.py
+++ b/srv/modules/runners/status.py
@@ -39,6 +39,7 @@ def help_():
     return ""
 
 
+# pylint: disable=no-else-return
 def report(cluster_name='ceph', stdout=True, return_data=False):
     """
     Creates a report that tries to find the most common versions from:

--- a/srv/modules/runners/ui_ganesha.py
+++ b/srv/modules/runners/ui_ganesha.py
@@ -178,6 +178,7 @@ class GaneshaConfParser(object):
         """
         Return the block body
         """
+        # pylint: disable=no-else-return
         def format_val(key, val):
             """
             Return a comma separated list, raw value or quoted value

--- a/srv/modules/runners/ui_iscsi.py
+++ b/srv/modules/runners/ui_iscsi.py
@@ -56,6 +56,7 @@ class Iscsi(object):
 
         return self.data
 
+    # pylint: disable=no-else-return
     def interfaces(self, wrapped=True):
         """
         Parse grains for all network interfaces on igw roles.  Possibly
@@ -104,15 +105,15 @@ class Iscsi(object):
         """
         Read the existing lrbd.conf
         """
+        lrbd_conf = {
+            'auth': [],
+            'targets': [],
+            'portals': [],
+            'pools': []
+        }
         if os.path.exists(filename):
-            return json.loads(open(filename).read())
-        else:
-            return {
-                'auth': [],
-                'targets': [],
-                'portals': [],
-                'pools': []
-            }
+            lrbd_conf = json.loads(open(filename).read())
+        return lrbd_conf
 
     def save(self, filename="/srv/salt/ceph/igw/cache/lrbd.conf", **kwargs):
         """
@@ -178,6 +179,7 @@ class Iscsi(object):
 
         return self.data
 
+    # pylint: disable=no-else-return
     def canned_images(self, canned, wrapped=True):
         """
         Return canned example for pools and images

--- a/srv/salt/_modules/kernel.py
+++ b/srv/salt/_modules/kernel.py
@@ -69,7 +69,7 @@ def replace(**kwargs):
 
     else:
         log.debug("No matching OS")
-    return
+    return None
 
 
 def _kernel_pkg():
@@ -87,7 +87,7 @@ def _kernel_pkg():
 
         log.info("package: {}".format(package))
         return package
-    return
+    return None
 
 
 def _boot_image(contents):
@@ -115,7 +115,7 @@ def _query_command(filename):
         if os.path.isfile('/usr/bin/dpkg'):
             return ['/usr/bin/dpkg', '--search', filename]
     log.error("Neither rpm nor dpkg found")
-    return
+    return None
 
 
 def installed_kernel_version():

--- a/srv/salt/_modules/keyring.py
+++ b/srv/salt/_modules/keyring.py
@@ -71,7 +71,7 @@ def file_(component, name=None):
     elif component == "nova":
         return "/srv/salt/ceph/openstack/nova/cache/nova.keyring"
 
-    if component == "ganesha":
+    elif component == "ganesha":
         return "/srv/salt/ceph/ganesha/cache/" + name + ".keyring"
 
     elif component == "deepsea_cephfs_bench":
@@ -82,6 +82,8 @@ def file_(component, name=None):
 
     elif component == "deepsea_rbd_bench":
         return "/srv/salt/ceph/rbd/benchmarks/files/cache/deepsea_rbd_bench.keyring"
+
+    return None
 
 __func_alias__ = {
                  'file_': 'file',

--- a/srv/salt/_modules/multi.py
+++ b/srv/salt/_modules/multi.py
@@ -159,17 +159,18 @@ def iperf_client_cmd(server, cpu=0, port=5200):
     salt 'node' multi.iperf_client_cmd <server_name/ip>
             cpu=<which_cpu_core default 0> port=<default 5200>
     '''
-    if IPERF_PATH is None or not server:
-        if not server:
-            return [LOCALHOST_NAME, 2, "0", "Server name is empty"]
-        else:
-            return [LOCALHOST_NAME, 2, "0",
-                    "iperf3 not found in path, please install"]
-    iperf_cmd = ["/usr/bin/iperf3", "-fm", "-A"+str(cpu),
-                 "-t10", "-c"+server, "-p"+str(port)]
-    log.debug('iperf_client_cmd: cmd {}'.format(iperf_cmd))
-    retcode, stdout, stderr = __salt__['helper.run'](iperf_cmd)
-    return server, retcode, stdout, stderr
+    if IPERF_PATH is None:
+        ret = [LOCALHOST_NAME, 2, "0",
+               "iperf3 not found in path, please install"]
+    elif not server:
+        ret = [LOCALHOST_NAME, 2, "0", "Server name is empty"]
+    else:
+        iperf_cmd = ["/usr/bin/iperf3", "-fm", "-A"+str(cpu),
+                     "-t10", "-c"+server, "-p"+str(port)]
+        log.debug('iperf_client_cmd: cmd {}'.format(iperf_cmd))
+        retcode, stdout, stderr = __salt__['helper.run'](iperf_cmd)
+        ret = (server, retcode, stdout, stderr)
+    return ret
 
 
 def iperf_server_cmd(cpu=0, port=5200):

--- a/srv/salt/_modules/packagemanager.py
+++ b/srv/salt/_modules/packagemanager.py
@@ -34,7 +34,6 @@ class PackageManager(object):
             self.pm = Zypper(**kwargs)
         elif "ubuntu" in self.platform or "debian" in self.platform:
             log.info("Found {}. Using {}".format(self.platform, Apt.__name__))
-            # pylint: disable=redefined-variable-type
             self.pm = Apt(**kwargs)
         else:
             raise ValueError("Failed to detect PackageManager for OS."
@@ -47,11 +46,12 @@ class PackageManager(object):
         log.info("The PackageManager asked for a system reboot. Rebooting in 1 Minute")
         if self.debug or not self.reboot:
             log.debug("Faking Reboot")
-            return None
-        log.debug("Initializing Reboot.")
-        __salt__['event.fire_master'](None, 'salt/ceph/set/noout')
-        cmd = "shutdown -r"
-        Popen(cmd, stdout=PIPE, shell=True)
+        else:
+            log.debug("Initializing Reboot.")
+            __salt__['event.fire_master'](None, 'salt/ceph/set/noout')
+            cmd = "shutdown -r"
+            Popen(cmd, stdout=PIPE, shell=True)
+        return None
 
 
 class Apt(PackageManager):
@@ -191,6 +191,7 @@ class Zypper(PackageManager):
             log.error('Refreshing failed. Check the repos')
             log.debug('Executing {}'.format(cmd))
             return False
+        return None
 
     # pylint: disable=no-self-use
     def _upgrades_needed(self):

--- a/srv/salt/_modules/purge.py
+++ b/srv/salt/_modules/purge.py
@@ -10,7 +10,7 @@ import logging
 import os
 import shutil
 import pwd
-import grp
+import grp  # pylint: disable=3rd-party-module-not-gated
 import yaml
 
 log = logging.getLogger(__name__)

--- a/srv/salt/_modules/rgw.py
+++ b/srv/salt/_modules/rgw.py
@@ -58,7 +58,7 @@ def configuration(role):
             for rgw_config in __pillar__['rgw_configurations']:
                 if rgw_config in role:
                     return rgw_config
-    return
+    return None
 
 
 def users(realm='default', contains=None):
@@ -138,7 +138,6 @@ def add_users(pathname="/srv/salt/ceph/rgw/cache", jinja="/srv/salt/ceph/rgw/fil
                 # when the RGW user was manually created beforehand.
                 # pylint: disable=useless-else-on-loop
                 if not os.path.exists(filename):
-                    # pylint: disable=redefined-variable-type
                     args = ['radosgw-admin', 'user', 'info']
                     args.extend(['--uid', user['uid']])
                     args.extend(['--rgw-realm', realm])
@@ -164,7 +163,7 @@ def _key(user, field, pathname):
         with open(filename, 'r') as user_file:
             data = json.load(user_file)
     else:
-        return
+        return None
 
     return data['keys'][0][field]
 
@@ -245,7 +244,6 @@ def endpoints(cluster='ceph'):
                 if line:
                     match = re.search(r'rgw.*frontends.*=.*port=(\d+)(s?)', line)
                     if match:
-                        # pylint: disable=redefined-variable-type
                         port = int(match.group(1))
                         ssl = match.group(2)
 
@@ -273,7 +271,7 @@ def s3connect(user):
     Return an S3 connection
     """
     if access_key(user) is None or secret_key(user) is None:
-        return
+        return None
     endpoint = endpoints()[0]
 
     s3conn = boto.connect_s3(

--- a/tests/unit/_modules/test_cephdisks.py
+++ b/tests/unit/_modules/test_cephdisks.py
@@ -89,7 +89,7 @@ class TestHardwareDetections():
     def test_is_removable_not(self, hwd):
         read_data = "0"
         with patch("srv.salt._modules.cephdisks.open", mock_open(read_data=read_data)) as mock_file:
-            expect = None
+            expect = False
             out = hwd.HardwareDetections()._is_removable('disk/in/question')
             assert expect == out
 

--- a/tox.ini
+++ b/tox.ini
@@ -24,10 +24,8 @@ deps =
     boto
 
 [testenv:lint]
-basepython = python2.7
-commands = pylint --rcfile=.pylintrc --jobs=5 srv/
+basepython = python3
+commands = pylint --rcfile=.pylintrc  srv/
 deps =
     {[base]deps}
-    saltpylint<2017.4.5
-    # ^ saltpylint 2017.4.5 does not automatically import its own requirements
-    # Freeze version prior until this is fixed
+    saltpylint


### PR DESCRIPTION
This is the follow up on https://github.com/SUSE/DeepSea/pull/1110 which migrates the lint environment from python2 to python3. This change introduced new messages, most reports were about `return` statements. 
I got rid of implicit `return None`s and extracted `return` statements from `if-else` branches where it made sense to me. I also refactored some code (e.g. `_hw_raid_ctrl_detection` in cephdisks.py [0]) and the unittests are all passing, but please double check that I did not introduce new bugs.

---
[0] - https://github.com/alexandergraul/DeepSea/blob/2cf5c74c7b2f1e44dc652a8ead8b78e682f2a8e0/srv/salt/_modules/cephdisks.py#L185


-----------------

[Please find more information on how to run integration tests here](https://github.com/SUSE/DeepSea/wiki/Integration-tests)
