### PR TITLE
qa: ensure ceph-test RPM is installed

### DIFF
--- a/qa/common/rbd.sh
+++ b/qa/common/rbd.sh
@@ -15,8 +15,14 @@ function ceph_test_librbd_can_be_run {
   local TESTSCRIPT=/tmp/rbd_api_test.sh
   local CLIENTNODE=$(_client_node)
   cat << 'EOF' > $TESTSCRIPT
-set -ex
+set -e
 trap 'echo "Result: NOT_OK"' ERR
+for delay in 60 60 60 60 ; do
+    sudo zypper --non-interactive --gpg-auto-import-keys refresh && break
+    sleep $delay
+done
+set -x
+zypper --non-interactive install --no-recommends ceph-test
 rpm -V ceph-test
 type ceph_test_librbd
 echo "Result: OK"


### PR DESCRIPTION
Before, we were relying on teuthology's install task to install the ceph-test
package. We (recently) turned that behavior off and began relying on DeepSea's
Stage 0 to install the ceph RPMs, but that doesn't install ceph-test.

Fixes: https://github.com/SUSE/DeepSea/issues/1124
Signed-off-by: Nathan Cutler <ncutler@suse.com>