### PR TITLE
Fix initial mgr keyring creation failure in ceph.stage.2

### DIFF
--- a/srv/salt/ceph/maintenance/upgrade/cleanup/default.sls
+++ b/srv/salt/ceph/maintenance/upgrade/cleanup/default.sls
@@ -1,9 +1,7 @@
   
-{% set master = salt['master.minion']() %}
-
 remove packages:
   salt.state:
-    - tgt: '{{ master }}'
+    - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
     - sls: ceph.packages.remove
     - failhard: True
 

--- a/srv/salt/ceph/stage/configure/default.sls
+++ b/srv/salt/ceph/stage/configure/default.sls
@@ -17,7 +17,7 @@ push proposals:
 
 refresh_pillar1:
   salt.state:
-    - tgt: '{{ master }}'
+    - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
     - tgt_type: compound
     - sls: ceph.refresh
 


### PR DESCRIPTION
This is a partial reversion of https://github.com/SUSE/DeepSea/pull/1101.
Since that commit, there's been a problem running ceph.stage.2, where the
first time you run it, the mon, osd, admin and openattic keys are created,
but mgr, rgw, and any other role-based keys are not created until you
run ceph.stage.2 a *second* time.

It turns out that refresh_pillar1 in configure/default.sls was previously
targeting all minions, which updated all roles in the pillar data correctly.
PR #1101 changed this to only target the master, which means only the roles
for the master were present in the pillar data, not the roles for any other
nodes, which caused select.minions in the various role-based key state files
to return nothing.  By some sort of miracle, applying
ceph.monitoring.prometheus.exporters.node_exporter (which is the last thing
that happens in stage 2) results in enough of a refresh that a *second*
run of stage 2 would then see the roles correctly, and create the keys.

By changing refresh_pillar1 to target all minions, we fix the problem and
only need to run ceph.stage.2 once to get the keys created.  I've also
made the same change to maintenance/upgrade/cleanup/default.sls, because
it seemed like the right thing to do, but have *not* tested that myself.

Signed-off-by: Tim Serong <tserong@suse.com>