### PR TITLE
Add ceph/test/restart/$role sub-directories to make/spec files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,14 +65,38 @@ copy-files:
 	install -m 644 srv/salt/ceph/tests/quiescent/timeout/*.sls $(DESTDIR)/srv/salt/ceph/tests/quiescent/timeout
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/tests/restart
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/tests/restart/mon
+	install -d -m 755 $(DESTDIR)/srv/salt/ceph/tests/restart/mon/change
+	install -d -m 755 $(DESTDIR)/srv/salt/ceph/tests/restart/mon/forced
+	install -d -m 755 $(DESTDIR)/srv/salt/ceph/tests/restart/mon/nochange
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/tests/restart/mds
+	install -d -m 755 $(DESTDIR)/srv/salt/ceph/tests/restart/mds/change
+	install -d -m 755 $(DESTDIR)/srv/salt/ceph/tests/restart/mds/forced
+	install -d -m 755 $(DESTDIR)/srv/salt/ceph/tests/restart/mds/nochange
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/tests/restart/mgr
+	install -d -m 755 $(DESTDIR)/srv/salt/ceph/tests/restart/mgr/change
+	install -d -m 755 $(DESTDIR)/srv/salt/ceph/tests/restart/mgr/forced
+	install -d -m 755 $(DESTDIR)/srv/salt/ceph/tests/restart/mgr/nochange
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/tests/restart/rgw
+	install -d -m 755 $(DESTDIR)/srv/salt/ceph/tests/restart/rgw/change
+	install -d -m 755 $(DESTDIR)/srv/salt/ceph/tests/restart/rgw/forced
+	install -d -m 755 $(DESTDIR)/srv/salt/ceph/tests/restart/rgw/nochange
 	install -m 644 srv/salt/ceph/tests/restart/*.sls $(DESTDIR)/srv/salt/ceph/tests/restart
 	install -m 644 srv/salt/ceph/tests/restart/mon/*.sls $(DESTDIR)/srv/salt/ceph/tests/restart/mon
+	install -m 644 srv/salt/ceph/tests/restart/mon/change/*.sls $(DESTDIR)/srv/salt/ceph/tests/restart/mon/change
+	install -m 644 srv/salt/ceph/tests/restart/mon/forced/*.sls $(DESTDIR)/srv/salt/ceph/tests/restart/mon/forced
+	install -m 644 srv/salt/ceph/tests/restart/mon/nochange/*.sls $(DESTDIR)/srv/salt/ceph/tests/restart/mon/nochange
 	install -m 644 srv/salt/ceph/tests/restart/mds/*.sls $(DESTDIR)/srv/salt/ceph/tests/restart/mds
+	install -m 644 srv/salt/ceph/tests/restart/mds/change/*.sls $(DESTDIR)/srv/salt/ceph/tests/restart/mds/change
+	install -m 644 srv/salt/ceph/tests/restart/mds/forced/*.sls $(DESTDIR)/srv/salt/ceph/tests/restart/mds/forced
+	install -m 644 srv/salt/ceph/tests/restart/mds/nochange/*.sls $(DESTDIR)/srv/salt/ceph/tests/restart/mds/nochange
 	install -m 644 srv/salt/ceph/tests/restart/mgr/*.sls $(DESTDIR)/srv/salt/ceph/tests/restart/mgr
+	install -m 644 srv/salt/ceph/tests/restart/mgr/change/*.sls $(DESTDIR)/srv/salt/ceph/tests/restart/mgr/change
+	install -m 644 srv/salt/ceph/tests/restart/mgr/forced/*.sls $(DESTDIR)/srv/salt/ceph/tests/restart/mgr/forced
+	install -m 644 srv/salt/ceph/tests/restart/mgr/nochange/*.sls $(DESTDIR)/srv/salt/ceph/tests/restart/mgr/nochange
 	install -m 644 srv/salt/ceph/tests/restart/rgw/*.sls $(DESTDIR)/srv/salt/ceph/tests/restart/rgw
+	install -m 644 srv/salt/ceph/tests/restart/rgw/change/*.sls $(DESTDIR)/srv/salt/ceph/tests/restart/rgw/change
+	install -m 644 srv/salt/ceph/tests/restart/rgw/forced/*.sls $(DESTDIR)/srv/salt/ceph/tests/restart/rgw/forced
+	install -m 644 srv/salt/ceph/tests/restart/rgw/nochange/*.sls $(DESTDIR)/srv/salt/ceph/tests/restart/rgw/nochange
 	# smoketests
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/smoketests/keyrings
 	install -m 644 srv/salt/ceph/smoketests/keyrings/*.sls $(DESTDIR)/srv/salt/ceph/smoketests/keyrings

--- a/deepsea.spec.in
+++ b/deepsea.spec.in
@@ -740,9 +740,21 @@ the README for more information.
 %dir /srv/salt/ceph/tests/quiescent/timeout
 %dir /srv/salt/ceph/tests/restart
 %dir /srv/salt/ceph/tests/restart/mon
+%dir /srv/salt/ceph/tests/restart/mon/change
+%dir /srv/salt/ceph/tests/restart/mon/forced
+%dir /srv/salt/ceph/tests/restart/mon/nochange
 %dir /srv/salt/ceph/tests/restart/mds
+%dir /srv/salt/ceph/tests/restart/mds/change
+%dir /srv/salt/ceph/tests/restart/mds/forced
+%dir /srv/salt/ceph/tests/restart/mds/nochange
 %dir /srv/salt/ceph/tests/restart/mgr
+%dir /srv/salt/ceph/tests/restart/mgr/change
+%dir /srv/salt/ceph/tests/restart/mgr/forced
+%dir /srv/salt/ceph/tests/restart/mgr/nochange
 %dir /srv/salt/ceph/tests/restart/rgw
+%dir /srv/salt/ceph/tests/restart/rgw/change
+%dir /srv/salt/ceph/tests/restart/rgw/forced
+%dir /srv/salt/ceph/tests/restart/rgw/nochange
 /srv/salt/ceph/smoketests/keyrings/*.sls
 /srv/salt/ceph/smoketests/quiescent/*.sls
 /srv/salt/ceph/smoketests/restart/*.sls
@@ -751,8 +763,20 @@ the README for more information.
 /srv/salt/ceph/tests/quiescent/timeout/*.sls
 /srv/salt/ceph/tests/restart/*.sls
 /srv/salt/ceph/tests/restart/mon/*.sls
+/srv/salt/ceph/tests/restart/mon/change/*.sls
+/srv/salt/ceph/tests/restart/mon/forced/*.sls
+/srv/salt/ceph/tests/restart/mon/nochange/*.sls
 /srv/salt/ceph/tests/restart/mds/*.sls
+/srv/salt/ceph/tests/restart/mds/change/*.sls
+/srv/salt/ceph/tests/restart/mds/forced/*.sls
+/srv/salt/ceph/tests/restart/mds/nochange/*.sls
 /srv/salt/ceph/tests/restart/mgr/*.sls
+/srv/salt/ceph/tests/restart/mgr/change/*.sls
+/srv/salt/ceph/tests/restart/mgr/forced/*.sls
+/srv/salt/ceph/tests/restart/mgr/nochange/*.sls
 /srv/salt/ceph/tests/restart/rgw/*.sls
+/srv/salt/ceph/tests/restart/rgw/change/*.sls
+/srv/salt/ceph/tests/restart/rgw/forced/*.sls
+/srv/salt/ceph/tests/restart/rgw/nochange/*.sls
 
 %changelog

--- a/srv/salt/ceph/smoketests/restart/common.sls
+++ b/srv/salt/ceph/smoketests/restart/common.sls
@@ -1,3 +1,4 @@
+{% set master = salt['master.minion']() %}
 
 reset systemctl initially:
   salt.state:
@@ -35,19 +36,19 @@ check {{ service }} no restart:
 {# Check service restarts with change #}
 change {{ service }}.conf:
   salt.state:
-    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt: {{ master }}
     - tgt_type: compound
     - sls: ceph.tests.restart.{{ service }}.setup
 
 create ceph.conf:
   salt.state:
-    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt: {{ master }}
     - tgt_type: compound
     - sls: ceph.configuration.create
 
 distribute ceph.conf:
   salt.state:
-    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt: {{ master }}
     - tgt_type: compound
     - sls: ceph.configuration
 
@@ -66,7 +67,7 @@ check {{ service }}:
 {# Check service restarts with change removed #}
 remove {{ service }}.conf:
   salt.state:
-    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt: {{ master }}
     - tgt_type: compound
     - sls: ceph.tests.restart.{{ service }}.teardown
 
@@ -78,13 +79,13 @@ reset systemctl:
 
 reset ceph.conf:
   salt.state:
-    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt: {{ master }}
     - tgt_type: compound
     - sls: ceph.configuration.create
 
 redistribute ceph.conf:
   salt.state:
-    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - tgt: {{ master }}
     - tgt_type: compound
     - sls: ceph.configuration
 


### PR DESCRIPTION
Signed-off-by: Joshua Schmid <jschmid@suse.de>

Pr that introduced smoketests: https://github.com/SUSE/DeepSea/pull/1054

Description:

If you try to run the smoketests.restart you get the following error:

```
             mon1.ceph:
                  Data failed to compile:
              ----------
                  No matching sls found for 'ceph.tests.restart.mds.forced' in env 'base'

Summary for admin.ceph_master
------------
Succeeded: 2 (changed=2)
Failed:    1

```

Which is due to the missing directives in the spec/makefile for the subdirectories under `ceph/test/restart/$role`

-----------------

[Please find more information on how to run integration tests here](https://github.com/SUSE/DeepSea/wiki/Integration-tests)
