### PR TITLE
be able to run condensed smoketests

### DIFF
--- a/srv/salt/ceph/smoketests/init.sls
+++ b/srv/salt/ceph/smoketests/init.sls
@@ -1,0 +1,7 @@
+include:
+  - .keyrings
+  - .quiescent
+  - .restart.mds
+  - .restart.mgr
+  - .restart.mon
+  - .restart.rgw

--- a/srv/salt/ceph/smoketests/restart/common.sls
+++ b/srv/salt/ceph/smoketests/restart/common.sls
@@ -1,5 +1,6 @@
+{% set master = salt['master.minion']() %}
 
-reset systemctl initially:
+reset systemctl initially for {{ service }}:
   salt.state:
     - tgt: {{ test_node }}
     - tgt_type: compound
@@ -39,19 +40,19 @@ change {{ service }}.conf:
     - tgt_type: compound
     - sls: ceph.tests.restart.{{ service }}.setup
 
-create ceph.conf:
+create ceph.conf {{ service }}:
   salt.state:
     - tgt: {{ salt['pillar.get']('master_minion') }}
     - tgt_type: compound
     - sls: ceph.configuration.create
 
-distribute ceph.conf:
+distribute ceph.conf {{ service }}:
   salt.state:
     - tgt: {{ salt['pillar.get']('master_minion') }}
     - tgt_type: compound
     - sls: ceph.configuration
 
-check changes:
+check changes {{ service }}:
   salt.runner:
     - name: changed.{{ service }}
 
@@ -70,25 +71,25 @@ remove {{ service }}.conf:
     - tgt_type: compound
     - sls: ceph.tests.restart.{{ service }}.teardown
 
-reset systemctl:
+reset systemctl {{ service }}:
   salt.state:
     - tgt: {{ test_node }}
     - tgt_type: compound
     - sls: ceph.tests.restart.{{ service }}.reset
 
-reset ceph.conf:
+reset ceph.conf {{ service }}:
   salt.state:
     - tgt: {{ salt['pillar.get']('master_minion') }}
     - tgt_type: compound
     - sls: ceph.configuration.create
 
-redistribute ceph.conf:
+redistribute ceph.conf {{ service }}:
   salt.state:
     - tgt: {{ salt['pillar.get']('master_minion') }}
     - tgt_type: compound
     - sls: ceph.configuration
 
-check changes again:
+check changes again {{ service }}:
   salt.runner:
     - name: changed.{{ service }}
 


### PR DESCRIPTION
Signed-off-by: Joshua Schmid <jschmid@suse.de>

Depended on: https://github.com/SUSE/DeepSea/pull/1133

Description:

Instead of running:

```
salt-run state.orch ceph.smoketest.restart.mds
salt-run state.orch ceph.smoketest.restart.mgr
salt-run state.orch ceph.smoketest.restart.mon
salt-run state.orch ceph.smoketest.restart.rgw
salt-run state.orch ceph.smoketest.quiescient
salt-run state.orch ceph.smoketest.keyrings
```

this patch allows you to do:

```
salt-run state.orch ceph.smoketest
```

in case you want to run _all_ tests



-----------------

[Please find more information on how to run integration tests here](https://github.com/SUSE/DeepSea/wiki/Integration-tests)
