### PR TITLE
Fix Makefile on Fedora

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,10 @@ USER=root
 GROUP=root
 ifeq ($(OS), centos)
 PKG_INSTALL=yum install -y
+else
+ifeq ($(OS), fedora)
+PKG_INSTALL=yum install -y
+endif
 endif
 endif
 endif
@@ -792,7 +796,7 @@ copy-files:
 	-chown $(USER):$(GROUP) $(DESTDIR)/srv/salt/ceph/configuration/files/ceph.conf.checksum || true
 
 install-deps:
-	$(PKG_INSTALL) python3-setuptools python3-click
+	$(PKG_INSTALL) python3-setuptools python3-click python3-tox
 
 install: pyc install-deps copy-files
 	sed -i '/^sharedsecret: /s!{{ shared_secret }}!'`cat /proc/sys/kernel/random/uuid`'!' $(DESTDIR)/etc/salt/master.d/sharedsecret.conf


### PR DESCRIPTION
Fixes:

Fix the Makefile for Fedora.

**Description**:

`cd DeepSea && make install` does not work on Fedora.

```              stderr:
                  make: python3-setuptools: Command not found
                  make: *** [Makefile:795: install-deps] Error 127
              stdout:
                  #make sure to create bytecode with the correct version
                  find srv/ -name '*.py' -exec python3 -m py_compile {} \;
                  find cli/ -name '*.py' -exec python3 -m py_compile {} \;
                  python3-setuptools python3-click
```
And `make test` fails.
```
$ sudo make test
tox -e py27
make: tox: Command not found
make: *** [Makefile:830: test] Error 127
```

**version**:

```
$ cat /etc/os-release 
NAME=Fedora
VERSION="27 (Workstation Edition)"
ID=fedora
...
```

**Testing ***

Verified on Fedora 27: See : [junit-py27.out.txt](https://github.com/SUSE/DeepSea/files/1989904/junit-py27.out.txt)

-----------------

[Please find more information on how to run integration tests here](https://github.com/SUSE/DeepSea/wiki/Integration-tests)
