### PR TITLE
Make salt-api an explicit 'make install' dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -825,16 +825,16 @@ copy-files:
 	-chown $(USER):$(GROUP) $(DESTDIR)/srv/salt/ceph/configuration/files/ceph.conf.checksum || true
 
 install-deps:
-	$(PKG_INSTALL) python3-setuptools python3-click python3-tox
+	$(PKG_INSTALL) python3-setuptools python3-click python3-tox salt-api
 
 install: pyc install-deps copy-files
 	sed -i '/^sharedsecret: /s!{{ shared_secret }}!'`cat /proc/sys/kernel/random/uuid`'!' $(DESTDIR)/etc/salt/master.d/sharedsecret.conf
 	chown $(USER):$(GROUP) $(DESTDIR)/etc/salt/master.d/*
 	echo "deepsea_minions: '*'" > /srv/pillar/ceph/deepsea_minions.sls
 	chown -R $(USER) /srv/pillar/ceph
-	systemctl restart salt-master
-	$(PKG_INSTALL) salt-api
-	systemctl restart salt-api
+	# Use '|| true' to suppress some error output in corner cases
+	systemctl restart salt-master || true
+	systemctl restart salt-api || true
 	# deepsea-cli
 	python3 setup.py install --root=$(DESTDIR)/
 


### PR DESCRIPTION
Fixes #
```
$ sudo make install 
...
...
systemctl restart salt-master
Failed to restart salt-master.service: Unit salt-master.service not found.
make: *** [Makefile:806: install] Error 5
```

Description:

The service `salt-master` may be absent before `salt-api` package gets installed.  Once `salt-api` is installed the `salt-master.service` will definitely exist.  This PR handles the scenario to ensure `salt-master.service` is running and `make install` completes successfully.

Testing: [junit-py27.out.txt](https://github.com/SUSE/DeepSea/files/1996911/junit-py27.out.txt)


-----------------

[Please find more information on how to run integration tests here](https://github.com/SUSE/DeepSea/wiki/Integration-tests)
