### PR TITLE
Add py-coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,2 @@
+[run]
+omit = tests/*, .tox/*, cli/*

--- a/tox.ini
+++ b/tox.ini
@@ -13,10 +13,11 @@ deps =
 
 [testenv:py27]
 basepython = python2.7
-commands =  py.test --tb=line -v --junitxml=junit-{envname}.xml {posargs}
+commands =  py.test --cov=. --cov-report html --cov-report term --tb=line -v --ignore=cli/ --junitxml=junit-{envname}.xml {posargs}
 deps =
     {[base]deps}
     mock
+    pytest-cov
     pyfakefs<3.3
     pytest
     salttesting


### PR DESCRIPTION
Signed-off-by: Joshua Schmid <jschmid@suse.de>

Description:

Ricardo used this in his PR #1149. Nice addon, we might want to have that too.

We still have to re-add the travis checks via the new 'checks api'. Issue for this is here: (#1128)

-----------------

[Please find more information on how to run integration tests here](https://github.com/SUSE/DeepSea/wiki/Integration-tests)
