### PR TITLE
Change log level to info for the ready message

### DIFF
--- a/srv/modules/runners/minions.py
+++ b/srv/modules/runners/minions.py
@@ -84,7 +84,7 @@ def ready(**kwargs):
             expected = set(key.list_keys()['minions'])
 
         if actual == expected:
-            log.warning("All minions are ready")
+            log.info("All minions are ready")
             break
         log.warning("Waiting on {}".format(",".join(list(expected - actual))))
         if end_time:


### PR DESCRIPTION

Description: This is warning was a confusing message for one of the users. Perhaps and info level is more appropriate.


-----------------

[Please find more information on how to run integration tests here](https://github.com/SUSE/DeepSea/wiki/Integration-tests)
