### PR TITLE
Fix salt-api validation

### DIFF
--- a/srv/modules/runners/validate.py
+++ b/srv/modules/runners/validate.py
@@ -727,7 +727,7 @@ class Validate(Preparation):
                                       '-d', 'eauth=sharedsecret'])
         try:
             result = json.loads(stdout[-1])
-        except ValueError as err:
+        except IndexError as err:
             msg = ("Salt API is failing to authenticate"
                    " - try 'systemctl restart salt-master': {}".format(err))
             self.errors.setdefault('salt-api', []).append(msg)


### PR DESCRIPTION


Signed-off-by: Alexander Graul <agraul@suse.com>

Description:
Previously a ValueError was expected but if salt-api is disabled,
an IndexError is raised.

-----------------

[Please find more information on how to run integration tests here](https://github.com/SUSE/DeepSea/wiki/Integration-tests)
