### PR TITLE
[Backport] [SES5] Fix salt-api validation

### DIFF
--- a/srv/modules/runners/validate.py
+++ b/srv/modules/runners/validate.py
@@ -630,8 +630,9 @@ class Validate(object):
                                        '-d', 'eauth=sharedsecret' ])
         try:
             result = json.loads(stdout[-1])
-        except ValueError as err:
-            msg = "Salt API is failing to authenticate - try 'systemctl restart salt-master'"
+        except IndexError as err:
+            msg = ("Salt API is failing to authenticate"
+                   " - try 'systemctl restart salt-master': {}".format(err))
             self.errors.setdefault('salt-api', []).append(msg)
             return
         if 'return' in result:


### PR DESCRIPTION
Description:
Previously a ValueError was expected but if salt-api is disabled,
an IndexError is raised.

Signed-off-by: Alexander Graul <agraul@suse.com>
(cherry picked from commit 8c6fed8a5b62d57130932dc06343a38b886a675b)

Backport of #1155

-----------------

[Please find more information on how to run integration tests here](https://github.com/SUSE/DeepSea/wiki/Integration-tests)
