### PR TITLE
Catch only one exception

### DIFF
--- a/srv/salt/_modules/multi.py
+++ b/srv/salt/_modules/multi.py
@@ -73,8 +73,7 @@ def _summarize_iperf(result):
             msg['filter'] = re.match(
                 r'.*0.00-10.00.*sec\s(.*Bytes)\s+(.*Mbits/sec)',
                 out, re.DOTALL).group(2)
-        # pylint: disable=bare-except
-        except:
+        except AttributeError:
             msg['filter'] = '0 Mbits/sec'
         msg['failed'] = False
         msg['errored'] = False


### PR DESCRIPTION
Remove bare except clause. If MatchObject is
None the group method will raise an AttributeError
in both py2 and py3

Description:


-----------------

[Please find more information on how to run integration tests here](https://github.com/SUSE/DeepSea/wiki/Integration-tests)
