### PR TITLE
Add codecov integration to Travis CI

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,17 @@
+coverage:
+  precision: 2
+  round: down
+  range: 25..30
+
+  status:
+    project:
+      default:
+        target: null
+    patch:
+      default:
+        target: null
+    changes: no
+
+comment: 
+  layout: "diff"
+  behavior: once

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,11 @@ deps =
 
 [testenv:py27]
 basepython = python2.7
-commands =  py.test --cov=. --cov-report html --cov-report term --tb=line -v --ignore=cli/ --junitxml=junit-{envname}.xml {posargs}
+commands =
+    py.test --cov=. --tb=line -v --ignore=cli/ --junitxml=junit-{envname}.xml {posargs}
+    codecov
+# the environment variables are needed by codecov
+passenv = CI TRAVIS TRAVIS_*
 deps =
     {[base]deps}
     mock
@@ -23,6 +27,8 @@ deps =
     salttesting
     configobj
     boto
+    codecov
+    pytest-cov
 
 [testenv:lint]
 basepython = python3


### PR DESCRIPTION

Signed-off-by: Alexander Graul <agraul@suse.com>

Description:
Codecov uses code coverage generated by pytest-cov and generates stats
and rich diffs for PRs.
Before we can use this, two things have to happen:
1. We need to discuss the numbers (how much % drop do we allow before the check fails) [[docs](https://docs.codecov.io/docs/commit-status)]
2. Someone with admin rights needs to enable [Travis](https://github.com/marketplace/travis-ci/plan/MDIyOk1hcmtldHBsYWNlTGlzdGluZ1BsYW43MA==#pricing-and-setupl) (see #1128) and [Codecov](https://github.com/marketplace/codecov/plan/MDIyOk1hcmtldHBsYWNlTGlzdGluZ1BsYW4xNg==#pricing-and-setup)


-----------------

[Please find more information on how to run integration tests here](https://github.com/SUSE/DeepSea/wiki/Integration-tests)
