### PR TITLE
[backport][SES4] Implement meta package code on SES4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,6 +104,10 @@ install:
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/mds/restart
 	install -m 644 srv/salt/ceph/mds/restart/*.sls $(DESTDIR)/srv/salt/ceph/mds/restart
 
+	# state files - metapackage
+	install -d -m 755 $(DESTDIR)/srv/salt/ceph/metapackage
+	install -m 644 srv/salt/ceph/metapackage/*.sls $(DESTDIR)/srv/salt/ceph/metapackage
+
 	# state files - mines
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/mines
 	install -m 644 srv/salt/ceph/mines/*.sls $(DESTDIR)/srv/salt/ceph/mines/

--- a/deepsea.spec
+++ b/deepsea.spec
@@ -178,6 +178,7 @@ systemctl try-restart salt-master > /dev/null 2>&1 || :
 %dir /srv/salt/ceph/updates
 %dir /srv/salt/ceph/updates/restart
 %dir /srv/salt/ceph/wait
+%dir /srv/salt/ceph/metapackage
 %config(noreplace) /etc/salt/master.d/*.conf
 %config /srv/modules/runners/*.py
 %config(noreplace) /srv/pillar/top.sls
@@ -301,6 +302,7 @@ systemctl try-restart salt-master > /dev/null 2>&1 || :
 %config /srv/salt/ceph/updates/*.sls
 %config /srv/salt/ceph/updates/restart/*.sls
 %config /srv/salt/ceph/wait/*.sls
+%config /srv/salt/ceph/metapackage/*.sls
 %doc
 %dir %attr(-, root, root) %{_docdir}/%{name}
 %{_docdir}/%{name}/*

--- a/srv/salt/ceph/metapackage/default.sls
+++ b/srv/salt/ceph/metapackage/default.sls
@@ -1,0 +1,7 @@
+
+{% if grains.get('osfullname', '') == 'SLES' %}
+metapackage for salt versioning:
+  pkg.installed:
+    - pkgs:
+      - ses-release
+{% endif %}

--- a/srv/salt/ceph/metapackage/init.sls
+++ b/srv/salt/ceph/metapackage/init.sls
@@ -1,0 +1,3 @@
+
+include:
+  - .{{ salt['pillar.get']('metapackage_init', 'default') }}

--- a/srv/salt/ceph/packages/common/default.sls
+++ b/srv/salt/ceph/packages/common/default.sls
@@ -7,3 +7,13 @@ stage prep dependencies:
       - gptfdisk
     - fire_event: True
 
+{% if grains.get('osfullname', '') == 'SLES' %}
+
+install ses-realease package:
+  pkg.installed:
+    - pkgs:
+      - ses-release
+
+{% endif %}
+
+

--- a/srv/salt/ceph/stage/prep/master/default.sls
+++ b/srv/salt/ceph/stage/prep/master/default.sls
@@ -21,6 +21,12 @@ repo master:
     - tgt: {{ salt['pillar.get']('master_minion') }}
     - sls: ceph.repo
 
+metapackage master:
+  salt.state:
+    - tgt: {{ salt['pillar.get']('master_minion') }}
+    - sls: ceph.metapackage
+
+
 prepare master:
   salt.state:
     - tgt: {{ salt['pillar.get']('master_minion') }}


### PR DESCRIPTION
Signed-off-by: Joshua Schmid <jschmid@suse.de>

original PR #1160 

This cannot be applied onto SES4 due to alot of structural changes in SES5/master. Trying to do adaptive changes to SES4.

Here, we don't need the metapackage to be installed explicitly on the minions as we do call ceph.packages.common before the update.

-----------------

[Please find more information on how to run integration tests here](https://github.com/SUSE/DeepSea/wiki/Integration-tests)
