### PR TITLE
Refactor cephprocesses module and add tests for it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -224,6 +224,7 @@ copy-files:
 	install -m 644 srv/pillar/ceph/benchmarks/templates/*.j2 $(DESTDIR)/srv/pillar/ceph/benchmarks/templates/
 	install -m 644 srv/pillar/ceph/init.sls $(DESTDIR)/srv/pillar/ceph/
 	install -m 644 srv/pillar/ceph/deepsea_minions.sls $(DESTDIR)/srv/pillar/ceph/
+	install -m 644 srv/pillar/ceph/blacklist.sls $(DESTDIR)/srv/pillar/ceph/
 	install -d -m 755 $(DESTDIR)/srv/pillar/ceph/stack
 	install -m 644 srv/pillar/ceph/stack/stack.cfg $(DESTDIR)/srv/pillar/ceph/stack/stack.cfg
 	install -m 644 srv/pillar/top.sls $(DESTDIR)/srv/pillar/

--- a/deepsea.spec.in
+++ b/deepsea.spec.in
@@ -420,6 +420,7 @@ systemctl try-restart salt-api > /dev/null 2>&1 || :
 %config %attr(-, salt, salt) /srv/pillar/ceph/benchmarks/fio/*.yml
 %config %attr(-, salt, salt) /srv/pillar/ceph/benchmarks/templates/*.j2
 %config(noreplace) %attr(-, salt, salt) /srv/pillar/ceph/deepsea_minions.sls
+%config(noreplace) %attr(-, salt, salt) /srv/pillar/ceph/blacklist.sls
 %config %attr(-, salt, salt) /srv/pillar/ceph/stack/stack.cfg
 /srv/salt/_modules/*.py*
 /srv/salt/_states/*.py*

--- a/srv/modules/runners/cephprocesses.py
+++ b/srv/modules/runners/cephprocesses.py
@@ -213,10 +213,12 @@ def wait(cluster='ceph', **kwargs):
 
     status = {}
     local = salt.client.LocalClient()
+    timeout = settings['timeout']
+    delay = settings['delay']
     status = local.cmd(search,
                        'cephprocesses.wait',
-                       ['timeout={}'.format(settings['timeout']),
-                        'delay={}'.format(settings['delay'])],
+                       kwarg={'timeout': timeout,
+                              'delay': delay},
                        tgt_type="compound")
 
     sys.stdout = _stdout

--- a/srv/pillar/ceph/blacklist.sls
+++ b/srv/pillar/ceph/blacklist.sls
@@ -1,0 +1,16 @@
+# This is an example file to give you some hints on how the strucutre should look like
+# By adjusting this file you can prevent the 'cephprocesses' module from failing if a
+# specified OSD is down. This can come in handy when you have a OSD/device that is known
+# the be failing but can't be removed for whatever reason.
+
+# Example:
+#
+#blacklist:
+#  ceph-osd:
+#    - 0
+#    - 223
+#    - 72
+#
+# This would exclude OSDs with ids 0, 223 and 72 from the checks.
+#
+# Currently there is only support for blacklisting OSDs.

--- a/srv/pillar/ceph/init.sls
+++ b/srv/pillar/ceph/init.sls
@@ -2,5 +2,6 @@
 {% include 'ceph/cluster/' + grains['id'] + '.sls' ignore missing %}
 
 {% include 'ceph/deepsea_minions.sls' ignore missing %}
+{% include 'ceph/blacklist.sls' ignore missing %}
 
 

--- a/srv/salt/_modules/cephprocesses.py
+++ b/srv/salt/_modules/cephprocesses.py
@@ -9,6 +9,7 @@ import logging
 import time
 import os
 import pwd
+import re
 import shlex
 # pylint: disable=import-error,3rd-party-module-not-gated
 from subprocess import Popen, PIPE
@@ -49,101 +50,274 @@ processes = {'mon': ['ceph-mon'],
 absent_processes = {'igw': ['lrbd']}
 
 
-def check(results=False, quiet=False, **kwargs):
+# pylint: disable=too-many-instance-attributes, too-few-public-methods
+class ProcInfo(object):
+    """
+    Maps processes to a helper class and tries to deduce
+    the osd_ids from the process.
+    """
+
+    def __init__(self, proc):
+        # the proc object
+        self.proc = proc
+        # e.g. python3, perl, etc
+        self.exe = os.path.basename(proc.exe())
+        # e.g. salt-call, ceph-osd
+        self.name = proc.name()
+        # e.g. systems pid
+        self.pid = proc.pid
+        # uid the proc is running under.
+        self.uid = proc.uids().real
+        # uid to name. (root, salt.. etc)
+        self.uid_name = pwd.getpwuid(self.uid).pw_name
+        if self.name == 'ceph-osd':
+            self.osd_id = self._map_osd_proc_to_osd_id()
+        else:
+            self.osd_id = None
+        if 'python' in self.exe:
+            self.exe = self.name
+        if self.proc.status() == 'running':
+            self.up = False
+
+    def __repr__(self):
+        """
+        custom __repr__ to identify the class a bit easier while debugging
+        """
+        return "Process <{}>".format(self.name)
+
+    def _map_osd_proc_to_osd_id(self):
+        """
+        Looking in the list of open_files you can _often_ see
+        that a log file is open which indicates which OSD_ID is
+        being used. This avoids the necessity to do a reverse lookup
+        for the OSD_ID
+        """
+        osd_id = set()
+        for open_file in self.proc.open_files():
+            mo = re.search('[0-9]+', open_file.path)
+            if mo:
+                osd_id.add(mo.group())
+            else:
+                raise NoOSDIDFound
+        return osd_id.pop()
+
+
+class NoOSDIDFound(Exception):
+    """
+    Custom Exception to raise when no OSD ID is found.
+    """
+    pass
+
+
+class MetaCheck(object):
+    """
+    Class to handle checks of Processes
+    """
+
+    def __init__(self, **kwargs):
+        self.up = list()
+        self.down = list()
+        self.running = True
+        self.quiet = kwargs.get('quiet', False)
+        self.insufficient_osd_count = False
+        self.__blacklist = kwargs.get('blacklist', dict())
+
+    @property
+    def blacklist(self):
+        """
+        The blacklist gets sourced from kwargs.
+        In our usecase we get the data from the salt-master
+        as a central place to annotate blacklisted OSDs
+        The current implementation only allows OSDs.
+        Other functionality such as MON/MDS etc needs to be
+        discussed and implemented. Explanation in comments
+        below.
+        """
+        # Imho the __blacklist struct is not ideal..
+        # the problem we are facing here is that you can't say;
+        # blacklist mon-1 (by dns-name) and then map this to a process
+        # What we might do is allowing to set a upper and lower limit?
+        # That'd look like this:
+        # ceph-mon:
+        #   - max_down: 1
+        # it's easier for OSDs because you can identify them by ID
+        # we can just say:
+        # ceph-osd:
+        #   - 1
+        #   - 2
+        #   - 3
+        # This is still to be done and discussed.
+        if self.__blacklist:
+            return self.__blacklist
+        return __salt__['pillar.get']('blacklist')
+
+    @blacklist.setter
+    def blacklist(self, bl):
+        """
+        For testing purposes
+        """
+        self.__blacklist = bl
+
+    @property
+    def expected_osds(self):
+        """
+        Return the expected OSDs ( Minus the blacklisted )
+        """
+        blacklisted_osds = []
+        blacklist = self.blacklist
+        if 'ceph-osd' in blacklist:
+            if blacklist['ceph-osd']:
+                blacklisted_osds = [str(x) for x in blacklist['ceph-osd']]
+                log.warning("You configured OSDs to be blacklisted. {}".format(blacklisted_osds))
+        return list(set(__salt__['osd.list']()) - set(blacklisted_osds))
+
+    def filter_for(self, prc_name):
+        """
+        utils method to filter for process names
+        """
+        return [x for x in self.up if x.exe == prc_name]
+
+    def add(self, prc, role):
+        """
+        Add a role to the self.up list if it's process is found
+        in the process dict.
+        Also do a special check for oA
+        """
+        if prc.exe in processes[role] or prc.name in processes[role]:
+            # Verify httpd-worker pid belongs to openattic.
+            if (role != 'openattic') or (role == 'openattic' and prc.uid_name == 'openattic'):
+                self.up.append(prc)
+
+    def check_inverts(self, role):
+        """
+        Running indicates whether the service is in its expected state
+        while here the logic is inverted.
+        If the process is considered 'running' it means that it has not
+        finished yet and is still 'working'
+        """
+        if role in absent_processes.keys():
+            for proc in absent_processes[role]:
+                if proc in [prc.name for prc in self.up]:
+                    self.running = False
+                    # pylint: disable=line-too-long
+                    log.error("ERROR: process {} for role {} is pending(working)".format(proc, role))
+
+    def check_absents(self, role):
+        """
+        If found processes are not in the list of required
+        processes, set running to False and mark as down
+        """
+        for proc in processes[role]:
+            if proc not in [prc.name for prc in self.up]:
+                if not self.quiet:
+                    # pylint: disable=line-too-long
+                    log.error("ERROR: process {} for role {} is not running".format(proc, role))
+                self.running = False
+                self.down.append(proc)
+
+    @property
+    def _up_osds(self):
+        """
+        Property that returns a str(osd_id) of filtered ceph-osd processes
+        """
+        return [str(x.osd_id) for x in self.filter_for('ceph-osd')]
+
+    @property
+    def _missing_osds(self):
+        """
+        Property that returns the diff between expected and up osds
+        """
+        return list(set(self.expected_osds) - set(self._up_osds))
+
+    def _insufficient_osd_count(self):
+        """
+        Check if the sufficient number of OSDs are up
+        """
+        if len(self.expected_osds) > len(self._up_osds):
+            if not self.quiet:
+                # pylint: disable=line-too-long
+                log.error("{} OSDs not running: {}".format(len(self._missing_osds), self._missing_osds))
+                log.error("Found less OSDs then expected. Expected {} | Found {}".format(len(self.expected_osds), len(self._up_osds)))
+            self.insufficient_osd_count = True
+        else:
+            self.insufficient_osd_count = False
+
+    def check_osds(self):
+        """
+        Check the count of OSDs
+        """
+        self._insufficient_osd_count()
+        if self.filter_for('ceph-osd'):
+            if self.insufficient_osd_count:
+                self.running = False
+
+    def report(self):
+        """
+        Format the structures so that salt understands it
+
+        {'up':   {'ceph-osd': [1,2,3],
+                  'ceph-mon': [1]
+                 },
+         'down': {'ceph-osd': [4],
+                  'lrbd': ['lrbd']
+                 }
+        }
+        In the down->ceph-osd case, the key describes the
+        osd_id which is down as opposed to the up->ceph-osd
+        where the key describes the process id.
+        """
+        res = {'up': {}, 'down': {}}
+        # initialize
+        for proc in self.up:
+            res['up'][proc.exe] = list()
+        for proc in self.down:
+            res['down'][proc] = proc
+
+        for proc in self.up:
+            res['up'][proc.exe].append(proc.pid)
+        if self.insufficient_osd_count:
+            res['down']['ceph-osd'] = self._missing_osds
+        return res
+
+
+def _extend_processes():
+    """
+    Extend the processes by rgw_configurations
+    """
+    if 'rgw_configurations' in __pillar__:
+        for rgw_config in __pillar__['rgw_configurations']:
+            processes[rgw_config] = ['radosgw']
+
+
+def check(results=False, **kwargs):
 
     """
     Query the status of running processes for each role.  Return False if any
     fail.  If results flag is set, return a dictionary of the form:
       { 'down': [ process, ... ], 'up': { process: [ pid, ... ], ...} }
     """
-    running = True
-    res = {'up': {}, 'down': []}
+    _extend_processes()
+    res = MetaCheck(**kwargs)
 
-    if 'rgw_configurations' in __pillar__:
-        for rgw_config in __pillar__['rgw_configurations']:
-            processes[rgw_config] = ['radosgw']
-
-    # pylint: disable=too-many-nested-blocks
-    if 'roles' in __pillar__:
-        for role in kwargs.get('roles', __pillar__['roles']):
-            # Checking running first.
-            for running_proc in psutil.process_iter():
-                # NOTE about `ps` and psutils.Process():
-                # `ps -e` determines process names by examining
-                # /proc/PID/stat,status files.  The name derived
-                # there is also found in psutil.Process.name.
-                # `ps -ef`, according to strace, appears to also reference
-                # /proc/PID/cmdline when determining
-                # process names.  We have found that some processes (ie.
-                # ceph-mgr was noted) will _sometimes_
-                # contain a process name in /proc/PIDstat/stat,status that does
-                # not match that found in /proc/PID/cmdline.
-                # In our ceph-mgr example, the process name was found to be
-                # 'exe' (which happens to also be the name a of
-                # symlink in /proc/PID that points to the executable) while the
-                # cmdline entry contained 'ceph-mgr' etc.
-                # As such, we've decided that a check based on executable
-                # path is more reliable.
-                pdict = running_proc.as_dict(attrs=['pid', 'name', 'exe', 'uids'])
-                pdict_exe = os.path.basename(pdict['exe'])
-                pdict_name = pdict['name']
-                pdict_pid = pdict['pid']
-                # Convert the numerical UID to name.
-                pdict_uid = pwd.getpwuid(pdict['uids'].real).pw_name
-                if pdict_exe in processes[role] or pdict_name in processes[role]:
-                    # When we don't have a binary but a python program
-                    # we want to use it's name for the 'exe'
-                    # Example:
-                    # pdict_exe for a lrbd is '/usr/bin/python2.7'
-                    # pdict['name'] is the actual name of the .py file to be executed
-                    if 'python' in pdict_exe:
-                        pdict_exe = pdict_name
-                    # Verify httpd-worker pid belongs to openattic.
-                    if (role != 'openattic') or (role == 'openattic' and pdict_uid == 'openattic'):
-                        if pdict_exe in res['up']:
-                            res['up'][pdict_exe] = res['up'][pdict_exe] + [pdict_pid]
-                        else:
-                            res['up'][pdict_exe] = [pdict_pid]
-
-            if role in absent_processes.keys():
-                for proc in absent_processes[role]:
-                    if proc in res['up']:
-                        # running is deceptive here
-                        # running indicates wheter the service is in it's expected state
-                        running = False
-                        # pylint: disable=line-too-long
-                        log.error("ERROR: process {} for role {} is pending(working)".format(proc, role))
-            else:
-                for proc in processes[role]:
-                    if proc not in res['up']:
-                        if not quiet:
-                            # pylint: disable=line-too-long
-                            log.error("ERROR: process {} for role {} is not running".format(proc, role))
-                        running = False
-                        res['down'] += [proc]
-
-            # pylint: disable=fixme
-            # FIXME: Map osd.ids to processes.pid to improve qualitify of logging
-            # currently you can only say how many osds/ if any are down, but not
-            # which osd is down exactly.
-            if role == 'storage':
-                if 'ceph-osd' in res['up']:
-                    if len(__salt__['osd.list']()) > len(res['up']['ceph-osd']):
-                        if not quiet:
-                            log.error("ERROR: At least one OSD is not running")
-                        res = {'up': {}, 'down': {'ceph-osd': 'ceph-osd'}}
-                        running = False
-
-    return res if results else running
+    if 'roles' not in __pillar__:
+        log.error("Did not find _roles_ in pillar. Aborting")
+        return False
+    for role in kwargs.get('roles', __pillar__['roles']):
+        for running_proc in psutil.process_iter():
+            res.add(ProcInfo(running_proc), role)
+        res.check_inverts(role)
+        res.check_absents(role)
+        if role == 'storage':
+            res.check_osds()
+    return res.report() if results else res.running
 
 
-# pylint: disable=unused-argument
-def down(**kwargs):
+def down():
     """
     Based on check(), return True/False if all Ceph processes that are meant
     to be running on a node are down.
     """
-    return True if not list(check(True, True)['up'].values()) else False
+    return True if not list(check(True)['up'].values()) else False
 
 
 def wait(**kwargs):

--- a/tests/unit/_modules/test_cephprocesses.py
+++ b/tests/unit/_modules/test_cephprocesses.py
@@ -1,0 +1,484 @@
+import pytest
+import sys
+sys.path.insert(0, 'srv/salt/_modules')
+from srv.salt._modules import cephprocesses, helper
+from mock import MagicMock, patch, mock_open, mock, create_autospec, ANY
+from tests.unit.helper.output import OutputHelper
+from tests.unit.helper.fixtures import helper_specs
+from collections import namedtuple
+
+DEFAULT_MODULE=cephprocesses
+
+class MockedPsUtil(object):
+
+    def __init__(self, name, pid, uid, exe, osd_id=0):
+        self._name = name
+        self._uid = uid
+        self._exe = exe
+        self.pid = pid
+        self.osd_id = osd_id
+
+    def name(self):
+        return self._name
+
+    def exe(self):
+        return self._exe
+
+    def uids(self):
+        Puids = namedtuple('Puids', 'real effective saved')
+        return Puids(self._uid, 0, 0)
+
+    def open_files(self):
+        Popenfile = namedtuple('Popenfile', 'path')
+        f1 = Popenfile('/var/log/ceph/ceph-osd.{}.log'.format(self.osd_id))
+        f2 = Popenfile('/var/lib/ceph/osd/ceph-{}/fsid'.format(self.osd_id))
+        return [f1, f2]
+
+    def status(self):
+        return 'running'
+
+class TestCephprocessesProcInfo():
+
+    @pytest.fixture(scope='class')
+    def cpr(self):
+        yield MockedPsUtil('ceph-osd', 0, 0, '/usr/bin/ceph-osd')
+
+    def test_map_open_proc_to_osd_id_1(self, cpr):
+        """
+        passing a osd_id of 1 to the process, it also mocks the 'open_files'
+        namedtuple to match that ID. This tests the regex.
+        """
+        proc = MockedPsUtil('ceph-osd', 0, 0, '/usr/bin/ceph-osd', osd_id=1)
+        procinfo = cephprocesses.ProcInfo(proc)
+        assert procinfo.osd_id == '1'
+
+    def test_map_open_proc_to_osd_id_2digits(self):
+        """
+        passing a osd_id of 20 to the process, it also mocks the 'open_files'
+        namedtuple to match that ID. This tests the regex.
+        """
+        proc = MockedPsUtil('ceph-osd', 0, 0, '/usr/bin/ceph-osd', osd_id=20)
+        procinfo = cephprocesses.ProcInfo(proc)
+        assert procinfo.osd_id == '20'
+
+    def test_map_open_proc_to_osd_id_multiple_digits(self):
+        """
+        passing a osd_id of 99999 to the process, it also mocks the 'open_files'
+        namedtuple to match that ID. This tests the regex.
+        """
+        proc = MockedPsUtil('ceph-osd', 0, 0, '/usr/bin/ceph-osd', osd_id=99999)
+        procinfo = cephprocesses.ProcInfo(proc)
+        assert procinfo.osd_id == '99999'
+
+    def test_map_open_proc_to_osd_id_multiple_raises(self):
+        """
+        passing a osd_id of None  to the process, it also mocks the 'open_files'
+        namedtuple to match that ID. This tests the Exception
+        """
+        proc = MockedPsUtil('ceph-osd', 0, 0, '/usr/bin/ceph-osd', osd_id=None)
+        with pytest.raises(cephprocesses.NoOSDIDFound):
+            procinfo = cephprocesses.ProcInfo(proc)
+
+class TestMetaCheck():
+
+    @pytest.fixture(scope='class')
+    def mc(self):
+        self.set_osd_list([])
+        yield cephprocesses.MetaCheck()
+
+    def set_osd_list(self, osd_list):
+        cephprocesses.__salt__ = {'osd.list': lambda : osd_list}
+
+    @pytest.mark.skip(reason='Not fully implemented yet')
+    def test_blacklist(self):
+        pass
+
+    @pytest.mark.skip(reason='Not fully implemented yet')
+    def test_expected_osds(self, mc):
+        """
+        If no blacklist is set, expected OSDs are the osds that
+        are returned from __salt__['osd.list']
+        """
+        expect = ['1', '2']
+        self.set_osd_list(expect)
+        assert mc.expected_osds == expect
+
+    @pytest.mark.skip(reason='Not fully implemented yet')
+    def test_expected_osds_blacklist(self, mc):
+        """
+        if OSDs are blacklisted, expect to see it removed
+        from the list
+        """
+        expect = ['1', '2', '3']
+        mc.blacklist = {'ceph-osd': ['2']}
+        self.set_osd_list(expect)
+        assert mc.expected_osds == ['1', '3']
+
+    def mock_up(self):
+        ups = []
+        for prc_name, bin_names in cephprocesses.processes.items():
+            for bin_name in bin_names:
+                proc = MockedPsUtil(bin_name, 0, 0, '/usr/bin/{}'.format(bin_name))
+                procinfo = cephprocesses.ProcInfo(proc)
+                ups.append(procinfo)
+        return ups
+
+    def test_filter_ceph_osd(self, mc):
+        """
+        Len = 1 because we source from processes list
+        """
+        mc.up = self.mock_up()
+        expected_len = 1
+        ret = mc.filter_for('ceph-osd')
+        assert len(ret) == expected_len
+        assert ret[0].name == 'ceph-osd'
+
+    def test_filter_ceph_mon(self, mc):
+        mc.up = self.mock_up()
+        expected_len = 1
+        ret = mc.filter_for('ceph-mon')
+        assert len(ret) == expected_len
+        assert ret[0].name == 'ceph-mon'
+
+    def test_filter_ceph_osd_multiple(self, mc):
+        expected_len = 10
+        for i in range(1, expected_len):
+            mc.up.extend(self.mock_up())
+        ret = mc.filter_for('ceph-osd')
+        assert len(ret) == expected_len
+        assert ret[0].name == 'ceph-osd'
+
+    def build_proc(self, role_name, proc_name, uid=0):
+        proc = MockedPsUtil(proc_name, 0, uid, '/usr/bin/{}'.format(proc_name))
+        return cephprocesses.ProcInfo(proc)
+
+    def test_add_storage(self, mc):
+        mc.up = []
+        role_name = 'storage'
+        proc_name = 'ceph-osd'
+        mc.add(self.build_proc(role_name, proc_name), role_name)
+        assert len(mc.up) == 1
+        assert mc.up[0].name == 'ceph-osd'
+
+    def test_add_mon(self, mc):
+        mc.up = []
+        role_name = 'mon'
+        proc_name = 'ceph-mon'
+
+        mc.add(self.build_proc(role_name, proc_name), role_name)
+        assert len(mc.up) == 1
+        assert mc.up[0].name == proc_name
+
+    def test_add_mgr(self, mc):
+        mc.up = []
+        role_name = 'mgr'
+        proc_name = 'ceph-mgr'
+        mc.add(self.build_proc(role_name, proc_name), role_name)
+        assert len(mc.up) == 1
+        assert mc.up[0].name == proc_name
+
+    def test_add_mds(self, mc):
+        mc.up = []
+        role_name = 'mds'
+        proc_name = 'ceph-mds'
+        mc.add(self.build_proc(role_name, proc_name), role_name)
+        assert len(mc.up) == 1
+        assert mc.up[0].name == proc_name
+
+    def test_add_igw(self, mc):
+        mc.up = []
+        role_name = 'mds'
+        proc_name = 'ceph-mds'
+        mc.add(self.build_proc(role_name, proc_name), role_name)
+        assert len(mc.up) == 1
+        assert mc.up[0].name == proc_name
+
+    def test_add_rgw(self, mc):
+        mc.up = []
+        role_name = 'rgw'
+        proc_name = 'radosgw'
+        mc.add(self.build_proc(role_name, proc_name), role_name)
+        assert len(mc.up) == 1
+        assert mc.up[0].name == proc_name
+
+    def test_add_igw(self, mc):
+        mc.up = []
+        role_name = 'igw'
+        proc_name = 'lrbd'
+        mc.add(self.build_proc(role_name, proc_name), role_name)
+        assert len(mc.up) == 1
+        assert mc.up[0].name == proc_name
+
+    def test_add_ganesha(self, mc):
+        mc.up = []
+        role_name = 'ganesha'
+        proc_name = 'ganesha.nfsd'
+        proc_name2 = 'rpcbind'
+        proc_name3 = 'rpc.statd'
+        mc.add(self.build_proc(role_name, proc_name), role_name)
+        mc.add(self.build_proc(role_name, proc_name2), role_name)
+        mc.add(self.build_proc(role_name, proc_name3), role_name)
+        assert len(mc.up) == 3
+        assert mc.up[0].name == proc_name
+        assert mc.up[1].name == proc_name2
+        assert mc.up[2].name == proc_name3
+
+    def test_add_openattic(self, mc):
+        mc.up = []
+        role_name = 'openattic'
+        proc_name = 'httpd-prefork'
+        proc = self.build_proc(role_name, proc_name)
+        proc.uid_name = 'openattic'
+        mc.add(proc, role_name)
+        assert len(mc.up) == 1
+        assert mc.up[0].name == proc_name
+
+    def test_add_openattic_negative(self, mc):
+        mc.up = []
+        role_name = 'openattic'
+        proc_name = 'httpd-prefork'
+        proc = self.build_proc(role_name, proc_name)
+        # not fulfilled the if branch
+        proc.uid_name = 'openatticNOTNOT'
+        mc.add(proc, role_name)
+        assert len(mc.up) == 0
+
+    def test_check_inverts_positive(self, mc):
+        mc.up = []
+        role_name = 'igw'
+        proc_name = 'lrbd'
+        proc = self.build_proc(role_name, proc_name)
+        assert mc.running == True
+        mc.up.append(proc)
+        mc.check_inverts(role_name)
+        # TODO: Expect a log.error
+        assert mc.running == False
+
+    def test_check_inverts_negative(self, mc):
+        mc.up = []
+        mc.running = True
+        role_name = 'mds'
+        proc_name = 'ceph-mds'
+        proc = self.build_proc(role_name, proc_name)
+        assert mc.running == True
+        mc.up.append(proc)
+        mc.check_inverts(role_name)
+        assert mc.running == True
+
+    def test_check_absents(self, mc):
+        role_name = 'mds'
+        proc_name = 'ceph-mds'
+        proc = self.build_proc(role_name, proc_name)
+        mc.up = [proc]
+        mc.check_absents(role_name)
+        assert len(mc.down) == 0
+
+    def test_check_absents_negative(self, mc):
+        mc.up = []
+        role_name = 'mds'
+        mc.check_absents(role_name)
+        assert len(mc.down) == 1
+
+    def test_check_absents_negative_ganesha(self, mc):
+        mc.down = []
+        role_name = 'ganesha'
+        proc_name1 = 'ganesha.nfsd'
+        proc_name2 = 'rpcbind'
+        # expect to miss rpc.statd
+        proc1 = self.build_proc(role_name, proc_name1)
+        proc2 = self.build_proc(role_name, proc_name2)
+        mc.up = [proc1, proc2]
+        mc.check_absents(role_name)
+        assert len(mc.down) == 1
+        assert mc.down[0] == 'rpc.statd'
+
+    @mock.patch('srv.salt._modules.cephprocesses.MetaCheck.filter_for')
+    def test_missing_osds(self, filter_mock, mc):
+        """
+        osd.list return 1,2,3
+        blacklist holds 2
+        expected_osds will be 1,3
+        Now only 1 can be found in filter_for(ceph-osd)
+        Expect to return 3
+        """
+        self.set_osd_list(['1', '2', '3'])
+        mc.blacklist = {'ceph-osd': ['2']}
+        proc = MockedPsUtil('ceph-osd', 0, 0, '/usr/bin/ceph-osd', osd_id=1)
+        filter_mock.return_value = [proc]
+        assert mc._missing_osds == ['3']
+
+    @mock.patch('srv.salt._modules.cephprocesses.MetaCheck.filter_for')
+    def test_missing_osds_no_return(self, filter_mock, mc):
+        """
+        osd.list return 1,2,3
+        blacklist holds 2
+        expected_osds will be 1,3
+        1,3 can be found in filter_for(ceph-osd)
+        Expect to return 3
+        """
+        proc = MockedPsUtil('ceph-osd', 0, 0, '/usr/bin/ceph-osd', osd_id=1)
+        proc1 = MockedPsUtil('ceph-osd', 0, 0, '/usr/bin/ceph-osd', osd_id=3)
+        filter_mock.return_value = [proc, proc1]
+        assert mc._missing_osds == []
+
+    @mock.patch('srv.salt._modules.cephprocesses.MetaCheck.filter_for')
+    def test_insufficient_osd_count(self, filter_mock, mc):
+        """
+        expected_osds will be 1,3 -> len == 2
+        """
+        proc = MockedPsUtil('ceph-osd', 0, 0, '/usr/bin/ceph-osd', osd_id=1)
+        filter_mock.return_value = [proc]
+        # TODO: check for logging
+        assert mc.insufficient_osd_count == False
+        mc._insufficient_osd_count()
+        assert mc.insufficient_osd_count == True
+
+    @mock.patch('srv.salt._modules.cephprocesses.MetaCheck.filter_for')
+    def test_insufficient_osd_count_positive(self, filter_mock, mc):
+        """
+        expected_osds will be 1,3 -> len == 2
+        """
+        mc.insufficient_osd_count = False
+        proc = MockedPsUtil('ceph-osd', 0, 0, '/usr/bin/ceph-osd', osd_id=1)
+        proc1 = MockedPsUtil('ceph-osd', 0, 0, '/usr/bin/ceph-osd', osd_id=1)
+        filter_mock.return_value = [proc, proc1]
+        # TODO: check for logging
+        assert mc.insufficient_osd_count == False
+        mc._insufficient_osd_count()
+        assert mc.insufficient_osd_count == False
+
+    @mock.patch('srv.salt._modules.cephprocesses.MetaCheck.filter_for')
+    @mock.patch('srv.salt._modules.cephprocesses.MetaCheck._insufficient_osd_count')
+    def test_check_osd(self, insuf_mock, filter_mock, mc):
+        """
+        Filter for returns something
+        insuff is True
+        """
+        mc.running = True
+        filter_mock.return_value = ['notnull']
+        mc.insufficient_osd_count = True
+        mc.check_osds()
+        assert mc.running == False
+
+    @mock.patch('srv.salt._modules.cephprocesses.MetaCheck.filter_for')
+    @mock.patch('srv.salt._modules.cephprocesses.MetaCheck._insufficient_osd_count')
+    def test_check_osd_1(self, insuf_mock, filter_mock, mc):
+        """
+        filter_for does not return
+        """
+        mc.running = True
+        filter_mock.return_value = []
+        mc.check_osds()
+        assert mc.running == True
+
+    @mock.patch('srv.salt._modules.cephprocesses.MetaCheck.filter_for')
+    @mock.patch('srv.salt._modules.cephprocesses.MetaCheck._insufficient_osd_count')
+    def test_check_osd_2(self, insuf_mock, filter_mock, mc):
+        """
+        filter_for does return something
+        but isuff is False
+        """
+        mc.running = True
+        filter_mock.return_value = ['notnull']
+        mc.insufficient_osd_count = False
+        mc.check_osds()
+        assert mc.running == True
+
+    def test_report_empty(self, mc):
+        mc.up = []
+        mc.down = []
+        assert mc.report() == {'up': {}, 'down': {}}
+
+    def test_report_up(self, mc):
+        role_name = 'mds'
+        proc_name = 'ceph-mds'
+        proc = self.build_proc(role_name, proc_name)
+        mc.up = [proc]
+        mc.down = []
+        assert mc.report() == {'up': {'ceph-mds': [0]}, 'down': {}}
+
+    def test_report_down(self, mc):
+        role_name = 'mds'
+        proc_name = 'ceph-mds'
+        mc.up = []
+        mc.down = [proc_name]
+        assert mc.report() == {'up': {}, 'down': {'ceph-mds': 'ceph-mds'}}
+
+    def test_report_up_down(self, mc):
+        role_name = 'storage'
+        proc_name = 'ceph-osd'
+        proc_name_down = 'ceph-mds'
+        proc = self.build_proc(role_name, proc_name)
+        mc.up = [proc]
+        mc.down = [proc_name_down]
+        assert mc.report() == {'up': {'ceph-osd': [0]}, 'down': {'ceph-mds': 'ceph-mds'}}
+
+    @mock.patch('srv.salt._modules.cephprocesses.MetaCheck._missing_osds', new_callable=mock.PropertyMock)
+    def test_report_up_down_down(self, missing_mock, mc):
+        """
+        expected 1,3 up
+        0 is down
+        """
+        # 2 is blacklisted
+        missing_mock.return_value = ['1', '3']
+        role_name = 'storage'
+        proc_name = 'ceph-osd'
+        proc_name_down = 'ceph-mds'
+        mc.insufficient_osd_count = True
+        proc = self.build_proc(role_name, proc_name)
+        mc.up = [proc]
+        mc.down = [proc_name_down]
+        assert mc.report() == {'up': {'ceph-osd': [0]}, 'down': {'ceph-mds': 'ceph-mds', 'ceph-osd': ['1', '3']}}
+
+
+class TestInstanceMethods():
+
+    def test_check(self):
+        """
+        Exit if there is no pillar data
+        """
+        cephprocesses.__pillar__ = {}
+        assert cephprocesses.check() == False
+
+    @mock.patch('srv.salt._modules.cephprocesses.psutil')
+    @mock.patch('srv.salt._modules.cephprocesses.MetaCheck')
+    @mock.patch('srv.salt._modules.cephprocesses.ProcInfo')
+    def test_check_1(self, proc_mock, meta_mock, psutil_mock):
+        """
+        Exit if there is pillar data but no roles in it
+        """
+        cephprocesses.__pillar__ = {'NOroles': ['dummy']}
+        assert cephprocesses.check() == False
+
+    @pytest.mark.parametrize("test_input,expected", [
+        ("mgr", 'mgr'),
+        ("mon", 'mon'),
+        ("mds", 'mds'),
+        ("openattic", 'openattic'),
+        ("rgw", 'rgw'),
+        ("benchmark-rbd", 'benchmark-rbd'),
+        ("storage", 'storage'),
+        ("ganesha", 'ganesha')
+    ])
+    @mock.patch('srv.salt._modules.cephprocesses.psutil.process_iter')
+    @mock.patch('srv.salt._modules.cephprocesses.MetaCheck.report')
+    @mock.patch('srv.salt._modules.cephprocesses.MetaCheck.check_absents')
+    @mock.patch('srv.salt._modules.cephprocesses.MetaCheck.check_inverts')
+    @mock.patch('srv.salt._modules.cephprocesses.MetaCheck.check_osds')
+    @mock.patch('srv.salt._modules.cephprocesses.MetaCheck.add')
+    @mock.patch('srv.salt._modules.cephprocesses.ProcInfo')
+    def test_check_2(self, proc_mock, meta_mock, mock_check_osds, meta_check_invert, meta_check_absent, mock_report, psutil_mock, test_input, expected):
+        """
+        Parameterized test to verify that roles get passed down to methods
+        """
+        role = [test_input]
+        cephprocesses.__pillar__ = {'roles': role}
+        psutil_mock.return_value = ['proc1']
+        cephprocesses.check()
+        proc_mock.assert_called_with('proc1')
+        # ANY instance of ProcInfo
+        meta_mock.assert_called_with(ANY, expected)
+        meta_check_invert.assert_called_with(expected)
+        meta_check_absent.assert_called_with(expected)
+        mock_check_osds.assert_called_once is False
+        mock_report.assert_called

--- a/tox.ini
+++ b/tox.ini
@@ -21,6 +21,7 @@ passenv = CI TRAVIS TRAVIS_*
 deps =
     {[base]deps}
     mock
+    psutil
     pytest-cov
     pyfakefs<3.3
     pytest


### PR DESCRIPTION
Signed-off-by: Joshua Schmid <jschmid@suse.de>

Targets #1150 
Fixes #1157 


Description:

The cephprocesses module existed to identify 'down' services in order to stop deepsea form causing harm to the cluster in a sequential orchestration run. The reporting just works fine for all services besides the OSDs. If you happen to have 1k+ OSDs and Deepsea tells you 'There is at least one OSD down' you are kind of puzzled. This patch tries to find the osd_id from the psutil object to identify 'down' OSDs better.

The old implementation was also not really unit-testable, so I made some adjustments to make it more readable and testable. Added 40-45~ tests to the module.

~The implementation of the blacklist feature needs some more discussion though..~


make test:
  - successful

make lint:
  - successful

smoketests:
  - successful

Sidenote:

~Added a fix for the smoketests/init.sls file for RPMs~ rebased

-----------------

[Please find more information on how to run integration tests here](https://github.com/SUSE/DeepSea/wiki/Integration-tests)
