### PR TITLE
Invoke `find` to fix salt job cache permissions

### DIFF
--- a/srv/salt/ceph/configuration/create/default.sls
+++ b/srv/salt/ceph/configuration/create/default.sls
@@ -12,11 +12,7 @@ removing minion cache:
     - makedirs: True
     - fire_event: True
 
-/var/cache/salt/master/jobs:
-  file.directory:
-    - user: {{ salt['deepsea.user']() }}
-    - group: {{ salt['deepsea.group']() }}
-    - recurse:
-      - user
-      - group
+fix salt job cache permissions:
+  cmd.run:
+  - name: "find /var/cache/salt/master/jobs -user root -exec chown {{ salt['deepsea.user']() }}:{{ salt['deepsea.group']() }} {} ';'"
 

--- a/srv/salt/ceph/ganesha/auth/default.sls
+++ b/srv/salt/ceph/ganesha/auth/default.sls
@@ -15,11 +15,7 @@ auth {{ keyring_file }}:
 {% endfor %}
 {% endfor %}
 
-/var/cache/salt/master/jobs:
-  file.directory:
-    - user: {{ salt['deepsea.user']() }}
-    - group: {{ salt['deepsea.group']() }}
-    - recurse:
-      - user
-      - group
+fix salt job cache permissions:
+  cmd.run:
+  - name: "find /var/cache/salt/master/jobs -user root -exec chown {{ salt['deepsea.user']() }}:{{ salt['deepsea.group']() }} {} ';'"
 

--- a/srv/salt/ceph/ganesha/config/default.sls
+++ b/srv/salt/ceph/ganesha/config/default.sls
@@ -37,11 +37,7 @@ check {{ role }}:
 {% endfor %}
 {% endfor %}
 
-/var/cache/salt/master/jobs:
-  file.directory:
-    - user: {{ salt['deepsea.user']() }}
-    - group: {{ salt['deepsea.group']() }}
-    - recurse:
-      - user
-      - group
+fix salt job cache permissions:
+  cmd.run:
+  - name: "find /var/cache/salt/master/jobs -user root -exec chown {{ salt['deepsea.user']() }}:{{ salt['deepsea.group']() }} {} ';'"
 

--- a/srv/salt/ceph/ganesha/key/default.sls
+++ b/srv/salt/ceph/ganesha/key/default.sls
@@ -30,11 +30,7 @@ check {{ role }}:
 {% endfor %}
 {% endfor %}
 
-/var/cache/salt/master/jobs:
-  file.directory:
-    - user: {{ salt['deepsea.user']() }}
-    - group: {{ salt['deepsea.group']() }}
-    - recurse:
-      - user
-      - group
+fix salt job cache permissions:
+  cmd.run:
+  - name: "find /var/cache/salt/master/jobs -user root -exec chown {{ salt['deepsea.user']() }}:{{ salt['deepsea.group']() }} {} ';'"
 

--- a/srv/salt/ceph/igw/auth/default.sls
+++ b/srv/salt/ceph/igw/auth/default.sls
@@ -13,11 +13,7 @@ auth {{ keyring_file }}:
 
 {% endfor %}
 
-/var/cache/salt/master/jobs:
-  file.directory:
-    - user: {{ salt['deepsea.user']() }}
-    - group: {{ salt['deepsea.group']() }}
-    - recurse:
-      - user
-      - group
+fix salt job cache permissions:
+  cmd.run:
+  - name: "find /var/cache/salt/master/jobs -user root -exec chown {{ salt['deepsea.user']() }}:{{ salt['deepsea.group']() }} {} ';'"
 

--- a/srv/salt/ceph/igw/config/default.sls
+++ b/srv/salt/ceph/igw/config/default.sls
@@ -38,11 +38,7 @@ clear master file cache:
 
 {% endif %}
 
-/var/cache/salt/master/jobs:
-  file.directory:
-    - user: {{ salt['deepsea.user']() }}
-    - group: {{ salt['deepsea.group']() }}
-    - recurse:
-      - user
-      - group
+fix salt job cache permissions:
+  cmd.run:
+  - name: "find /var/cache/salt/master/jobs -user root -exec chown {{ salt['deepsea.user']() }}:{{ salt['deepsea.group']() }} {} ';'"
 

--- a/srv/salt/ceph/igw/key/default.sls
+++ b/srv/salt/ceph/igw/key/default.sls
@@ -21,11 +21,7 @@ prevent empty rendering:
 
 {% endfor %}
 
-/var/cache/salt/master/jobs:
-  file.directory:
-    - user: {{ salt['deepsea.user']() }}
-    - group: {{ salt['deepsea.group']() }}
-    - recurse:
-      - user
-      - group
+fix salt job cache permissions:
+  cmd.run:
+  - name: "find /var/cache/salt/master/jobs -user root -exec chown {{ salt['deepsea.user']() }}:{{ salt['deepsea.group']() }} {} ';'"
 

--- a/srv/salt/ceph/mds/auth/default.sls
+++ b/srv/salt/ceph/mds/auth/default.sls
@@ -13,11 +13,7 @@ auth {{ keyring_file }}:
 
 {% endfor %}
 
-/var/cache/salt/master/jobs:
-  file.directory:
-    - user: {{ salt['deepsea.user']() }}
-    - group: {{ salt['deepsea.group']() }}
-    - recurse:
-      - user
-      - group
+fix salt job cache permissions:
+  cmd.run:
+  - name: "find /var/cache/salt/master/jobs -user root -exec chown {{ salt['deepsea.user']() }}:{{ salt['deepsea.group']() }} {} ';'"
 

--- a/srv/salt/ceph/mds/key/default.sls
+++ b/srv/salt/ceph/mds/key/default.sls
@@ -21,11 +21,7 @@ prevent empty rendering:
 
 {% endfor %}
 
-/var/cache/salt/master/jobs:
-  file.directory:
-    - user: {{ salt['deepsea.user']() }}
-    - group: {{ salt['deepsea.group']() }}
-    - recurse:
-      - user
-      - group
+fix salt job cache permissions:
+  cmd.run:
+  - name: "find /var/cache/salt/master/jobs -user root -exec chown {{ salt['deepsea.user']() }}:{{ salt['deepsea.group']() }} {} ';'"
 

--- a/srv/salt/ceph/mds/pools/default.sls
+++ b/srv/salt/ceph/mds/pools/default.sls
@@ -36,11 +36,7 @@ cephfs:
 
 {% endif %}
 
-/var/cache/salt/master/jobs:
-  file.directory:
-    - user: {{ salt['deepsea.user']() }}
-    - group: {{ salt['deepsea.group']() }}
-    - recurse:
-      - user
-      - group
+fix salt job cache permissions:
+  cmd.run:
+  - name: "find /var/cache/salt/master/jobs -user root -exec chown {{ salt['deepsea.user']() }}:{{ salt['deepsea.group']() }} {} ';'"
 

--- a/srv/salt/ceph/mgr/auth/default.sls
+++ b/srv/salt/ceph/mgr/auth/default.sls
@@ -13,11 +13,7 @@ auth {{ keyring_file }}:
 
 {% endfor %}
 
-/var/cache/salt/master/jobs:
-  file.directory:
-    - user: {{ salt['deepsea.user']() }}
-    - group: {{ salt['deepsea.group']() }}
-    - recurse:
-      - user
-      - group
+fix salt job cache permissions:
+  cmd.run:
+  - name: "find /var/cache/salt/master/jobs -user root -exec chown {{ salt['deepsea.user']() }}:{{ salt['deepsea.group']() }} {} ';'"
 

--- a/srv/salt/ceph/mgr/key/default.sls
+++ b/srv/salt/ceph/mgr/key/default.sls
@@ -21,11 +21,7 @@ prevent empty rendering:
 
 {% endfor %}
 
-/var/cache/salt/master/jobs:
-  file.directory:
-    - user: {{ salt['deepsea.user']() }}
-    - group: {{ salt['deepsea.group']() }}
-    - recurse:
-      - user
-      - group
+fix salt job cache permissions:
+  cmd.run:
+  - name: "find /var/cache/salt/master/jobs -user root -exec chown {{ salt['deepsea.user']() }}:{{ salt['deepsea.group']() }} {} ';'"
 

--- a/srv/salt/ceph/monitoring/default.sls
+++ b/srv/salt/ceph/monitoring/default.sls
@@ -4,11 +4,7 @@ include:
   - .prometheus.alertmanager
   - .grafana
 
-/var/cache/salt/master/jobs:
-  file.directory:
-    - user: {{ salt['deepsea.user']() }}
-    - group: {{ salt['deepsea.group']() }}
-    - recurse:
-      - user
-      - group
+fix salt job cache permissions:
+  cmd.run:
+  - name: "find /var/cache/salt/master/jobs -user root -exec chown {{ salt['deepsea.user']() }}:{{ salt['deepsea.group']() }} {} ';'"
 

--- a/srv/salt/ceph/remove/ganesha/default.sls
+++ b/srv/salt/ceph/remove/ganesha/default.sls
@@ -15,11 +15,7 @@ auth {{ keyring }}:
 {% endfor %}
 {% endif %}
 
-/var/cache/salt/master/jobs:
-  file.directory:
-    - user: {{ salt['deepsea.user']() }}
-    - group: {{ salt['deepsea.group']() }}
-    - recurse:
-      - user
-      - group
+fix salt job cache permissions:
+  cmd.run:
+  - name: "find /var/cache/salt/master/jobs -user root -exec chown {{ salt['deepsea.user']() }}:{{ salt['deepsea.group']() }} {} ';'"
 

--- a/srv/salt/ceph/remove/mds/default.sls
+++ b/srv/salt/ceph/remove/mds/default.sls
@@ -22,11 +22,7 @@ remove data:
 
 {% endif %}
 
-/var/cache/salt/master/jobs:
-  file.directory:
-    - user: {{ salt['deepsea.user']() }}
-    - group: {{ salt['deepsea.group']() }}
-    - recurse:
-      - user
-      - group
+fix salt job cache permissions:
+  cmd.run:
+  - name: "find /var/cache/salt/master/jobs -user root -exec chown {{ salt['deepsea.user']() }}:{{ salt['deepsea.group']() }} {} ';'"
 

--- a/srv/salt/ceph/remove/mgr/default.sls
+++ b/srv/salt/ceph/remove/mgr/default.sls
@@ -11,11 +11,7 @@ remove mgr auth:
 
 {% endif %}
 
-/var/cache/salt/master/jobs:
-  file.directory:
-    - user: {{ salt['deepsea.user']() }}
-    - group: {{ salt['deepsea.group']() }}
-    - recurse:
-      - user
-      - group
+fix salt job cache permissions:
+  cmd.run:
+  - name: "find /var/cache/salt/master/jobs -user root -exec chown {{ salt['deepsea.user']() }}:{{ salt['deepsea.group']() }} {} ';'"
 

--- a/srv/salt/ceph/remove/migrated/default.sls
+++ b/srv/salt/ceph/remove/migrated/default.sls
@@ -18,11 +18,7 @@ remove id {{ id }}:
 
 {% endfor %}
 
-/var/cache/salt/master/jobs:
-  file.directory:
-    - user: {{ salt['deepsea.user']() }}
-    - group: {{ salt['deepsea.group']() }}
-    - recurse:
-      - user
-      - group
+fix salt job cache permissions:
+  cmd.run:
+  - name: "find /var/cache/salt/master/jobs -user root -exec chown {{ salt['deepsea.user']() }}:{{ salt['deepsea.group']() }} {} ';'"
 

--- a/srv/salt/ceph/remove/mon/default.sls
+++ b/srv/salt/ceph/remove/mon/default.sls
@@ -10,11 +10,7 @@ remove mon.{{ minion }}:
 {% endif %}
 {% endfor %}
 
-/var/cache/salt/master/jobs:
-  file.directory:
-    - user: {{ salt['deepsea.user']() }}
-    - group: {{ salt['deepsea.group']() }}
-    - recurse:
-      - user
-      - group
+fix salt job cache permissions:
+  cmd.run:
+  - name: "find /var/cache/salt/master/jobs -user root -exec chown {{ salt['deepsea.user']() }}:{{ salt['deepsea.group']() }} {} ';'"
 

--- a/srv/salt/ceph/remove/openattic/default.sls
+++ b/srv/salt/ceph/remove/openattic/default.sls
@@ -10,11 +10,7 @@ remove openattic auth:
 
 {% endif %}
 
-/var/cache/salt/master/jobs:
-  file.directory:
-    - user: {{ salt['deepsea.user']() }}
-    - group: {{ salt['deepsea.group']() }}
-    - recurse:
-      - user
-      - group
+fix salt job cache permissions:
+  cmd.run:
+  - name: "find /var/cache/salt/master/jobs -user root -exec chown {{ salt['deepsea.user']() }}:{{ salt['deepsea.group']() }} {} ';'"
 

--- a/srv/salt/ceph/remove/rgw/default.sls
+++ b/srv/salt/ceph/remove/rgw/default.sls
@@ -34,11 +34,7 @@ remove rgw users.uid:
 
 {% endif %}
 
-/var/cache/salt/master/jobs:
-  file.directory:
-    - user: {{ salt['deepsea.user']() }}
-    - group: {{ salt['deepsea.group']() }}
-    - recurse:
-      - user
-      - group
+fix salt job cache permissions:
+  cmd.run:
+  - name: "find /var/cache/salt/master/jobs -user root -exec chown {{ salt['deepsea.user']() }}:{{ salt['deepsea.group']() }} {} ';'"
 

--- a/srv/salt/ceph/remove/storage/default.sls
+++ b/srv/salt/ceph/remove/storage/default.sls
@@ -18,11 +18,7 @@ remove id {{ id }}:
 
 {% endfor %}
 
-/var/cache/salt/master/jobs:
-  file.directory:
-    - user: {{ salt['deepsea.user']() }}
-    - group: {{ salt['deepsea.group']() }}
-    - recurse:
-      - user
-      - group
+fix salt job cache permissions:
+  cmd.run:
+  - name: "find /var/cache/salt/master/jobs -user root -exec chown {{ salt['deepsea.user']() }}:{{ salt['deepsea.group']() }} {} ';'"
 

--- a/srv/salt/ceph/rgw/auth/default.sls
+++ b/srv/salt/ceph/rgw/auth/default.sls
@@ -15,13 +15,7 @@ auth {{ keyring_file }}:
 {% endfor %}
 {% endfor %}
 
-/var/cache/salt/master/jobs:
-  file.directory:
-    - user: {{ salt['deepsea.user']() }}
-    - group: {{ salt['deepsea.group']() }}
-    - recurse:
-      - user
-      - group
-
-
+fix salt job cache permissions:
+  cmd.run:
+  - name: "find /var/cache/salt/master/jobs -user root -exec chown {{ salt['deepsea.user']() }}:{{ salt['deepsea.group']() }} {} ';'"
 

--- a/srv/salt/ceph/rgw/key/default.sls
+++ b/srv/salt/ceph/rgw/key/default.sls
@@ -30,11 +30,7 @@ check {{ role }}:
 {% endfor %}
 {% endfor %}
 
-/var/cache/salt/master/jobs:
-  file.directory:
-    - user: {{ salt['deepsea.user']() }}
-    - group: {{ salt['deepsea.group']() }}
-    - recurse:
-      - user
-      - group
+fix salt job cache permissions:
+  cmd.run:
+  - name: "find /var/cache/salt/master/jobs -user root -exec chown {{ salt['deepsea.user']() }}:{{ salt['deepsea.group']() }} {} ';'"
 


### PR DESCRIPTION
When there's a lot of files in the salt job cache, using salt's
builtin file.directory construct is remarkably slow.  Let's start
with about 10,000 files in the cache, all correctly owned:

````
  # find /var/cache/salt/master/jobs | wc -l
  9920
  # find /var/cache/salt/master/jobs -user root | wc -l
  0
````

Then, run ceph.stage.2:

````
  # salt-run state.orch ceph.stage.2
  [...]
  Summary for admin.ceph_master
  -------------
  Succeeded: 14 (changed=10)
  Failed:     0
  -------------
  Total states run:     14
  Total run time:  409.141 s
````

That's 409 seconds, or a bit under seven minutes.  Now, with this
change applied, which instead invokes `find ... -exec chown ...`,
it only takes a minute twenty, which is quite a bit better:

````
  # salt-run state.orch ceph.stage.2
  [...]
  Summary for admin.ceph_master
  -------------
  Succeeded: 14 (changed=10)
  Failed:     0
  -------------
  Total states run:     14
  Total run time:   82.443 s
````

Fixes: https://github.com/SUSE/DeepSea/issues/1131
Signed-off-by: Tim Serong <tserong@suse.com>