### PR TITLE
Correct codecov config

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -6,12 +6,15 @@ coverage:
   status:
     project:
       default:
-        target: null
+        target: 0
+        treshold: 0
     patch:
       default:
-        target: null
+        target: 0
+        treshold: 0
     changes: no
 
 comment: 
   layout: "diff"
   behavior: once
+  require_changes: no


### PR DESCRIPTION
Description:
Comments only show diff and checks are non-blocking.

Signed-off-by: Alexander Graul <agraul@suse.com>


An example of this config in action can be see at  https://github.com/alexandergraul/DeepSea/pull/8


-----------------

[Please find more information on how to run integration tests here](https://github.com/SUSE/DeepSea/wiki/Integration-tests)
