### PR TITLE
cli: common: fix terminal utf-8 support detector

### DIFF
--- a/cli/common.py
+++ b/cli/common.py
@@ -72,6 +72,8 @@ def check_terminal_utf8_support():
     Checks whether the terminal supports UTF-8 glyphs.
     """
     symbol = u"\u23F3"
+    if sys.stdout.encoding is None:
+        return False
     try:
         symbol.encode(sys.stdout.encoding)
         return True


### PR DESCRIPTION
Description:

It appears that in some terminals the `sys.stdout.encoding` returns `None`. This PR fixes the utf-8 support detector for this scenario.


-----------------

[Please find more information on how to run integration tests here](https://github.com/SUSE/DeepSea/wiki/Integration-tests)

Signed-off-by: Ricardo Dias <rdias@suse.com>
