### PR TITLE
Force SES5's tox to use salt<2017.0.0

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ envlist = py27,lint
 [base]
 deps =
     ipaddress
-    salt
+    salt<2017.0.0
 
 [testenv:py27]
 commands =  py.test --tb=line -v --junitxml=junit-{envname}.xml {posargs}


### PR DESCRIPTION
salt2018 was pushed onto pip just recently and is somehow messed up.
As SES5 is using salt2016 anyways this is good idea.

Signed-off-by: Joshua Schmid <jschmid@suse.de>


-----------------

[Please find more information on how to run integration tests here](https://github.com/SUSE/DeepSea/wiki/Integration-tests)
