### PR TITLE
Support active+clean checks on empty clusters

### DIFF
--- a/srv/salt/_modules/osd.py
+++ b/srv/salt/_modules/osd.py
@@ -372,7 +372,7 @@ class CephPGs(object):
     def quiescent(self):
         """
         Wait until PGs are active+clean or timeout is reached.  Default is a
-        2 minute sliding window.
+        2 minute sliding window.  Return if no PGs are present.
         """
         i = 0
         last = []
@@ -380,6 +380,9 @@ class CephPGs(object):
             raise ValueError("The delay cannot be 0")
         while i < self.settings['timeout']/self.settings['delay']:
             current = self.pg_states()
+            if not current:
+                log.warning("PGs are not present")
+                return
             if len(current) == 1 and current[0]['name'] == 'active+clean':
                 log.warning("PGs are active+clean")
                 return

--- a/srv/salt/ceph/smoketests/quiescent/init.sls
+++ b/srv/salt/ceph/smoketests/quiescent/init.sls
@@ -4,6 +4,13 @@
 {{ node }}:
   test.nop
 
+PGs greater than zero:
+  salt.state:
+    - tgt: {{ salt['master.minion']() }}
+    - tgt_type: compound
+    - sls: ceph.tests.quiescent.check_pgs
+    - failhard: True
+
 check active+clean:
   salt.state:
     - tgt: {{ node }}

--- a/srv/salt/ceph/tests/quiescent/check_pgs.sls
+++ b/srv/salt/ceph/tests/quiescent/check_pgs.sls
@@ -1,0 +1,4 @@
+
+Check PGs exist:
+  cmd.run:
+    - name: 'test -n "`ceph pg ls`"'

--- a/tests/unit/_modules/test_osd.py
+++ b/tests/unit/_modules/test_osd.py
@@ -2541,6 +2541,17 @@ class TestCephPGS:
             ret = ceph_pgs.quiescent()
             assert ret == None
 
+    @patch('srv.salt._modules.osd.CephPGs.pg_states')
+    def test_quiescent_on_empty_cluster(self, pg_states):
+        """
+        """
+        pg_states.return_value = []
+        with patch.object(osd.CephPGs, "__init__", lambda self: None):
+            ceph_pgs = osd.CephPGs()
+            ceph_pgs.settings = {'timeout': 1, 'delay': 1}
+            ret = ceph_pgs.quiescent()
+            assert ret == None
+
     @patch('time.sleep')
     @patch('srv.salt._modules.osd.CephPGs.pg_states')
     def test_quiescent_timeout(self, pg_states, sleep):


### PR DESCRIPTION
Update smoketest to fail on empty cluster as well.

Signed-off-by: Eric Jackson <ejackson@suse.com>
