### PR TITLE
Fix ceph_version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -741,6 +741,10 @@ copy-files:
 	install -m 644 srv/salt/ceph/stage/radosgw/core/*.sls $(DESTDIR)/srv/salt/ceph/stage/radosgw/core
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/stage/services
 	install -m 644 srv/salt/ceph/stage/services/*.sls $(DESTDIR)/srv/salt/ceph/stage/services/
+	# state files - orchestrate shared
+	install -d -m 755 $(DESTDIR)/srv/salt/ceph/stage/validate
+	install -m 644 srv/salt/ceph/stage/validate/*.sls $(DESTDIR)/srv/salt/ceph/stage/validate/
+	# state files - sync
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/sync
 	install -m 644 srv/salt/ceph/sync/*.sls $(DESTDIR)/srv/salt/ceph/sync/
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/setosdflags

--- a/deepsea.spec.in
+++ b/deepsea.spec.in
@@ -332,6 +332,7 @@ systemctl try-restart salt-api > /dev/null 2>&1 || :
 %dir /srv/salt/ceph/stage/radosgw/core
 %dir /srv/salt/ceph/stage/removal
 %dir /srv/salt/ceph/stage/services
+%dir /srv/salt/ceph/stage/validate
 %dir /srv/salt/ceph/tools
 %dir /srv/salt/ceph/tools/benchmarks
 %dir /srv/salt/ceph/tools/fio
@@ -643,6 +644,7 @@ systemctl try-restart salt-api > /dev/null 2>&1 || :
 %config /srv/salt/ceph/stage/radosgw/core/*.sls
 %config /srv/salt/ceph/stage/removal/*.sls
 %config /srv/salt/ceph/stage/services/*.sls
+%config /srv/salt/ceph/stage/validate/*.sls
 %config /srv/salt/ceph/sync/*.sls
 %config /srv/salt/ceph/sysctl/*.sls
 %config /srv/salt/ceph/sysctl/files/*.conf

--- a/srv/salt/ceph/stage/discovery/default-nvme.sls
+++ b/srv/salt/ceph/stage/discovery/default-nvme.sls
@@ -1,25 +1,8 @@
 
 {% set master = salt['master.minion']() %}
 
-{% if salt['saltutil.runner']('validate.saltapi') == False %}
-
-salt-api failed:
-  salt.state:
-    - name: just.exit
-    - tgt: {{ master }}
-    - failhard: True
-
-{% endif %}
-
-{% if salt['saltutil.runner']('validate.prep') == False %}
-
-validate failed:
-  salt.state:
-    - name: just.exit
-    - tgt: {{ master }}
-    - failhard: True
-
-{% endif %}
+include:
+  - ..validate
 
 ready:
   salt.runner:

--- a/srv/salt/ceph/stage/discovery/default.sls
+++ b/srv/salt/ceph/stage/discovery/default.sls
@@ -1,25 +1,8 @@
 
 {% set master = salt['master.minion']() %}
 
-{% if salt['saltutil.runner']('validate.saltapi') == False %}
-
-salt-api failed:
-  salt.state:
-    - name: just.exit
-    - tgt: {{ master }}
-    - failhard: True
-
-{% endif %}
-
-{% if salt['saltutil.runner']('validate.prep') == False %}
-
-validate failed:
-  salt.state:
-    - name: just.exit
-    - tgt: {{ master }}
-    - failhard: True
-
-{% endif %}
+include:
+  - ..validate
 
 ready:
   salt.runner:

--- a/srv/salt/ceph/stage/prep/master/default-no-update-no-reboot.sls
+++ b/srv/salt/ceph/stage/prep/master/default-no-update-no-reboot.sls
@@ -5,7 +5,7 @@
 
 validate failed:
   salt.state:
-    - name: just.exit
+    - name: test.fail_without_changes
     - tgt: {{ master }}
     - failhard: True
 

--- a/srv/salt/ceph/stage/prep/master/default-no-update-reboot.sls
+++ b/srv/salt/ceph/stage/prep/master/default-no-update-reboot.sls
@@ -5,7 +5,7 @@
 
 validate failed:
   salt.state:
-    - name: just.exit
+    - name: test.fail_without_changes
     - tgt: {{ master }}
     - failhard: True
 

--- a/srv/salt/ceph/stage/prep/master/default-update-no-reboot.sls
+++ b/srv/salt/ceph/stage/prep/master/default-update-no-reboot.sls
@@ -5,7 +5,7 @@
 
 validate failed:
   salt.state:
-    - name: just.exit
+    - name: test.fail_without_changes
     - tgt: {{ master }}
     - failhard: True
 

--- a/srv/salt/ceph/stage/prep/master/default.sls
+++ b/srv/salt/ceph/stage/prep/master/default.sls
@@ -4,11 +4,12 @@
 
 validate failed:
   salt.state:
-    - name: just.exit
+    - name: test.fail_without_changes
     - tgt: {{ master }}
     - failhard: True
 
 {% endif %}
+
 
 sync master:
   salt.state:

--- a/srv/salt/ceph/stage/validate/default-nobypass.sls
+++ b/srv/salt/ceph/stage/validate/default-nobypass.sls
@@ -1,0 +1,11 @@
+
+{% if salt['saltutil.runner']('validate.setup') == False %}
+
+validate failed:
+  salt.state:
+    - name: test.fail_without_changes
+    - tgt: {{ master }}
+    - failhard: True
+
+{% endif %}
+

--- a/srv/salt/ceph/stage/validate/default.sls
+++ b/srv/salt/ceph/stage/validate/default.sls
@@ -1,0 +1,11 @@
+
+{% if salt['saltutil.runner']('validate.setup', bypass=True) == False %}
+
+validate failed:
+  salt.state:
+    - name: test.fail_without_changes
+    - tgt: {{ master }}
+    - failhard: True
+
+{% endif %}
+

--- a/srv/salt/ceph/stage/validate/init.sls
+++ b/srv/salt/ceph/stage/validate/init.sls
@@ -1,0 +1,4 @@
+
+include:
+  - .{{ salt['pillar.get']('stage_validate', 'default') }}
+


### PR DESCRIPTION
Changed serial salt call to a single call.  Refactored as well.  Added
conditional bypass to skip checks on working clusters.

A new ci_validate.py runner still gives the original behavior but is part of
the qa package.

Signed-off-by: Eric Jackson <ejackson@suse.com>

Fixes #1104 
