### PR TITLE
[RFC] Trigger reactor on inode events

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,9 @@ pyc: setup.py
 	find cli/ -name '*.py' -exec python3 -m py_compile {} \;
 
 copy-files:
+	# salt-minion config files
+	install -d -m 755 $(DESTDIR)/etc/salt/minion.d
+	install -m 644 etc/salt/minion.d/beacons.conf $(DESTDIR)/etc/salt/minion.d/
 	# salt-master config files
 	install -d -m 755 $(DESTDIR)/etc/salt/master.d
 	install -m 644 etc/salt/master.d/modules.conf $(DESTDIR)/etc/salt/master.d/

--- a/deepsea.spec.in
+++ b/deepsea.spec.in
@@ -397,6 +397,7 @@ systemctl try-restart salt-api > /dev/null 2>&1 || :
 %{_mandir}/man5/deepsea*.5.gz
 %{_mandir}/man1/deepsea*.1.gz
 %config(noreplace) %attr(-, salt, salt) /etc/salt/master.d/*.conf
+%config(noreplace) %attr(-, salt, salt) /etc/salt/minion.d/*.conf
 /srv/modules/modules/*.py*
 /srv/modules/runners/*.py*
 /srv/modules/utils/*.py*

--- a/etc/salt/master.d/reactor.conf
+++ b/etc/salt/master.d/reactor.conf
@@ -7,3 +7,7 @@ reactor:
     - /srv/salt/ceph/reactor/set_noout.sls
   - 'salt/run/*/salt/ceph/set/noout':
     - /srv/salt/ceph/reactor/set_noout.sls
+  - 'salt/beacon/*/inotify//srv/salt/_modules':
+    - /srv/salt/ceph/reactor/sync.sls
+  - 'salt/beacon/*/inotify//srv/salt/_states':
+    - /srv/salt/ceph/reactor/sync.sls

--- a/etc/salt/minion.d/beacons.conf
+++ b/etc/salt/minion.d/beacons.conf
@@ -1,0 +1,10 @@
+beacons:
+  inotify:
+    - files:
+        /srv/salt/:
+          mask:
+            - create
+            - modify
+          recurse: True
+          auto_add: True
+    - coalesce: True

--- a/srv/salt/ceph/reactor/sync.sls
+++ b/srv/salt/ceph/reactor/sync.sls
@@ -1,0 +1,6 @@
+ceph.sync:
+  local.state.apply:
+    - tgt: '*'
+    - arg:
+      - ceph.sync
+# really all?


### PR DESCRIPTION
Description:

In the past we encountered quite some issues with 'missing modules' which could've been solved by running salt \* saltutil.sync_all. To avoid the resulting frustration we can use a beacon to monitor the relevant directories ( /srv/salt/_modules and /srv/salt/_states ) for modifications and creations and trigger the needed `saltutil.sync_all` using salt's reactor system.

-----------------

[Please find more information on how to run integration tests here](https://github.com/SUSE/DeepSea/wiki/Integration-tests)
