### PR TITLE
don't install salt packages in Makefile (revert PR1140)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -841,7 +841,7 @@ copy-files:
 
 install-deps:
 	# Using '|| true' to suppress failure (packages already installed, etc)
-	$(PKG_INSTALL) $(PYTHON_DEPS) salt-api || true
+	$(PKG_INSTALL) $(PYTHON_DEPS) || true
 	$(PIPCMD) >/dev/null 2>&1 || true
 
 install: pyc install-deps copy-files
@@ -850,8 +850,8 @@ install: pyc install-deps copy-files
 	echo "deepsea_minions: '*'" > /srv/pillar/ceph/deepsea_minions.sls
 	chown -R $(USER) /srv/pillar/ceph
 	# Use '|| true' to suppress some error output in corner cases
-	systemctl restart salt-master || true
-	systemctl restart salt-api || true
+	systemctl restart salt-master
+	systemctl restart salt-api
 	# deepsea-cli
 	$(PYTHON) setup.py install --root=$(DESTDIR)/
 


### PR DESCRIPTION
Fixes #

Do not handle salt packages in Makefile.   Reverses #1140 

Description:

I had issues with Salt 2018.3.1 so used Salt 2017.7.6 installed via`salt-bootstrap` script.  Later I ran `salt.highstate` which included DeepSea `cmd.run: make install` step and Salt was having weird errors.

```
2018-06-25 13:35:09,974 [salt.loader      :1718][ERROR   ][1369] Exception raised when processing __virtual__ function for salt.loaded.int.executor.sudo. Module will not be loaded: 'module' object has no attribute 'clean_kwargs'
2018-06-25 13:35:09,975 [salt.loader      :1736][WARNING ][1369] salt.loaded.int.executor.sudo.__virtual__() is wrongly returning `None`. It should either return `True`, `False` or a new name. If you're the developer of the module 'sudo', please fix this.
2018-06-25 13:35:09,975 [salt.minion      :1523][ERROR   ][1369] Problem executing 'state.highstate': Executor 'direct_call.get' is not available
2018-06-25 13:35:10,753 [salt.loader      :1718][ERROR   ][1384] Exception raised when processing __virtual__ function for salt.loaded.int.executor.sudo. Module will not be loaded: 'module' object has no attribute 'clean_kwargs'
2018-06-25 13:35:10,754 [salt.loader      :1736][WARNING ][1384] salt.loaded.int.executor.sudo.__virtual__() is wrongly returning `None`. It should either return `True`, `False` or a new name. If you're the developer of the module 'sudo', please fix this.
2018-06-25 13:35:10,755 [salt.minion      :1523][ERROR   ][1384] Problem executing 'grains.append': Executor 'direct_call.get' is not available
root@gke-kube1-default-pool-00fc1b96-j07f:/var/log/salt# 


root@gke-kube1-default-pool-00fc1b96-j07f:/var/log/salt# tail master 
IOError: [Errno 9] Bad file descriptor
IOError: [Errno 9] Bad file descriptor
2018-06-25 13:27:53,277 [salt.log.setup   :1158][ERROR   ][21831] An un-handled exception was caught by salt's global exception handler:
IOError: [Errno 9] Bad file descriptor
IOError: [Errno 9] Bad file descriptor
2018-06-25 13:31:52,961 [salt.utils.parsers:1051][WARNING ][21911] Master received a SIGTERM. Exiting.
2018-06-25 13:32:00,121 [salt.utils.parsers:1051][WARNING ][25675] Master received a SIGTERM. Exiting.
2018-06-25 13:34:14,421 [salt.client      :1254][ERROR   ][30494] saltutil returning errors on minion gke-kube1-default-pool-00fc1b96-j07f.c.elegant-expanse-204410.internal
2018-06-25 13:34:20,708 [salt.utils.parsers:1051][WARNING ][25950] Master received a SIGTERM. Exiting.
2018-06-25 13:35:09,773 [salt.utils.verify:535 ][WARNING ][1355] Insecure logging configuration detected! Sensitive data may be logged.
```
And my salt version was now 2018.3.1.  After various troubleshooting I realized installing Salt packages via Makefile is BAD idea as too intrusive. This PR reverses #1140 



-----------------

[Please find more information on how to run integration tests here](https://github.com/SUSE/DeepSea/wiki/Integration-tests)
