### PR TITLE
runners/populate.py: uuid.py only takes ascii

### DIFF
--- a/srv/modules/runners/populate.py
+++ b/srv/modules/runners/populate.py
@@ -611,7 +611,7 @@ class CephRoles(object):
                 _create_dirs(cluster_dir, self.root_dir)
             filename = "{}/cluster.yml".format(cluster_dir)
             contents = {}
-            random_string = b64encode(os.urandom(64)).decode('utf-8')
+            random_string = b64encode(os.urandom(64))
             contents['fsid'] = str(uuid.uuid3(uuid.NAMESPACE_DNS, random_string))
 
             public_networks_str = ", ".join([str(n) for n in self.public_networks])


### PR DESCRIPTION
Fixes #1201


Description:

`uuid.py` does not understand utf-8 encoding.

-----------------

[Please find more information on how to run integration tests here](https://github.com/SUSE/DeepSea/wiki/Integration-tests)

Tested locally and resolves #1201 
```
$ sudo salt-run state.orch ceph.stage.discovery
[WARNING ] All minions are ready
[ERROR   ] Verify that targeted minions have proposal.generate
[ERROR   ] Verify that targeted minions have proposal.generate
[ERROR   ] Verify that targeted minions have proposal.generate
[ERROR   ] Verify that targeted minions have proposal.generate
[ERROR   ] Verify that targeted minions have proposal.generate
{u'*': {'data': 0,
        'db-ratio': 5,
        'db-size': '500m',
        'encryption': '',
        'format': 'bluestore',
        'journal': 0,
        'journal-size': '5g',
        'leftovers': False,
        'name': 'default',
        'nvme-spinner': False,
        'nvme-ssd': False,
        'nvme-ssd-spinner': False,
        'ratio': 5,
        'ssd-spinner': False,
        'standalone': False,
        'wal': 0,
        'wal-size': '500m'}}
masterminion_master:
  Name: minions.ready - Function: salt.runner - Result: Changed Started: - 23:26:59.084713 Duration: 623.57 ms
  Name: refresh_pillar0 - Function: salt.state - Result: Changed Started: - 23:26:59.708443 Duration: 582.669 ms
  Name: populate.proposals - Function: salt.runner - Result: Changed Started: - 23:27:00.291645 Duration: 3705.673 ms
  Name: proposal.populate - Function: salt.runner - Result: Changed Started: - 23:27:03.997612 Duration: 1673.421 ms

Summary for masterminion_master
------------
Succeeded: 4 (changed=4)
Failed:    0
------------
Total states run:     4
Total run time:   6.585 s
```