### PR TITLE
Drop scsi prefixed devices

### DIFF
--- a/srv/salt/_modules/osd.py
+++ b/srv/salt/_modules/osd.py
@@ -1773,10 +1773,15 @@ class OSDDevices(object):
     def _uuid_device(self, device, pathname="/dev/disk/by-id"):
         """
         Return the uuid device, prefer the most descriptive
+
+        Note for future refactor:  Consider using
+          udevadm info -q symlink -n /dev/sdb
+        for discovering alternate device names.  The cephdisks and
+        proposal module share similar functionality.
         """
         if os.path.exists(device):
             if os.path.exists(pathname):
-                cmd = (r"find -L {} -samefile {} \( -name ata* -o -name scsi* "
+                cmd = (r"find -L {} -samefile {} \( -name ata* -o -name wwn* "
                        r"-o -name nvme* \)".format(pathname, device))
                 _, _stdout, _stderr = __salt__['helper.run'](cmd)
                 if _stdout:

--- a/srv/salt/_modules/proposal.py
+++ b/srv/salt/_modules/proposal.py
@@ -238,10 +238,13 @@ def _device(drive):
     """
     if 'Device Files' in drive:
         devices = drive['Device Files'].split(', ')
+        # Exclude scsi devices since 58-scsi-sg3_symlink.rules will
+        # create symlinks that are neither unique nor persistent
+        devices = [device for device in devices
+                   if (device.startswith('/dev/disk/by-id') and
+                       not device.startswith('/dev/disk/by-id/scsi-'))]
         index = _prefer_underscores(devices)
-        # Prefer 'Device File' over last item
-        if index > -1:
-            return devices[index]
+        return devices[index]
     return drive['Device File']
 
 

--- a/tests/unit/_modules/test_osd.py
+++ b/tests/unit/_modules/test_osd.py
@@ -2039,18 +2039,13 @@ class TestOSDDevices():
     def test_prefer_underscores(self):
         devices = [
             '/dev/disk/by-id/wwn-0x5002538d70022771',
-            '/dev/disk/by-id/scsi-SATA_Samsung_SSD_850_S24CNWAG402893J',
-            '/dev/disk/by-id/scsi-SATA_Samsung_SSD_850S24CNWAG402893J',
-            '/dev/disk/by-id/scsi-35002538d70022771',
-            '/dev/disk/by-id/scsi-1ATA_Samsung_SSD_850_EVO_M.2_500GB_S24CNWAG402893J',
-            '/dev/disk/by-id/scsi-0ATA_Samsung_SSD_850_S24CNWAG402893J',
             '/dev/disk/by-id/ata-Samsung_SSD_850_EVO_M.2_500GB_S24CNWAG402893J'
         ]
 
         with patch.object(osd.OSDDevices, "__init__", lambda self: None):
             osddevices = osd.OSDDevices()
             ret = osddevices._prefer_underscores(devices)
-            assert ret == 4
+            assert ret == 1
 
     def test_prefer_underscores_no_match(self):
         devices = [


### PR DESCRIPTION
The udev rules in 58-scsi-sg3_symlink.rules will produce symlinks
that are not persistent nor unique.  Rely on the remaining devices
such as ata* and wwn*.

Signed-off-by: Eric Jackson <ejackson@suse.com>

Fixes #1203 
bsc#1097914
