### PR TITLE
Remove _minion_check since it is superceded my minions.ready

### DIFF
--- a/srv/modules/runners/validate.py
+++ b/srv/modules/runners/validate.py
@@ -242,7 +242,6 @@ class Validate(Preparation):
         self.warnings = OrderedDict()
         if search:
             self.search = search
-        # self._minion_check()
 
         # Ceph version
         self.package = 'ceph-common'
@@ -269,16 +268,6 @@ class Validate(Preparation):
             if 'DEV_ENV' in self.data[any_minion]:
                 return self.data[any_minion]['DEV_ENV']
         return False
-
-    def _minion_check(self):
-        """
-        Originally here to stop the process, but commented out.
-        Intend to remove since we have minions.ready
-        """
-        if not self.data:
-            log.error("No minions responded")
-            # pylint: disable=protected-access
-            os._exit(1)
 
     def _set_pass_status(self, key):
         """


### PR DESCRIPTION
Fixes # similar to 1189


Description:
This is in a similar lane as an issue: 1189.
The method is there but the call is commented out and the doc string explains why:  "Originally here to stop the process, but commented out. Intend to remove since we have minions.ready"


-----------------

[Please find more information on how to run integration tests here](https://github.com/SUSE/DeepSea/wiki/Integration-tests)
