### PR TITLE
Generate setup.py file before running the tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -758,5 +758,5 @@ tarball:
 	tar -cjf ~/rpmbuild/SOURCES/deepsea-$(VERSION).tar.bz2 -C $(TEMPDIR) .
 	rm -r $(TEMPDIR)
 
-test:
+test: setup.py
 	tox -e py27


### PR DESCRIPTION
Tox seems to need the setup.py file, which is not generated before running the test.

Signed-off-by: Joshua Schmid <jschmid@suse.de>

-----------------

[Please find more information on how to run integration tests here](https://github.com/SUSE/DeepSea/wiki/Integration-tests)
