### PR TITLE
build/ops: add jq runtime dependency to spec file

### DIFF
--- a/deepsea.spec.in
+++ b/deepsea.spec.in
@@ -36,6 +36,7 @@ Requires:       salt-master
 Requires:       salt-minion
 Requires:       salt-api
 Requires:       iputils
+Requires:       jq
 Requires:       python3-netaddr
 Requires:       python3-rados
 Requires:       python3-configobj


### PR DESCRIPTION
Fixes: https://github.com/SUSE/DeepSea/issues/1218
Signed-off-by: Nathan Cutler <ncutler@suse.com>