### PR TITLE
[backport][ses5] build/ops: add jq runtime dependency to spec file

### DIFF
--- a/deepsea.spec.in
+++ b/deepsea.spec.in
@@ -41,6 +41,7 @@ Requires:       python-netaddr
 Requires:       python-rados
 Requires:       python-setuptools
 Requires:       python-click
+Requires:       jq
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 BuildArch:      noarch
 


### PR DESCRIPTION
Fixes: https://github.com/SUSE/DeepSea/issues/1218
Signed-off-by: Nathan Cutler <ncutler@suse.com>
(cherry picked from commit adca7b300ad4d1f6b15757bb7f2559799f2fd8e0)

-----------------

[Please find more information on how to run integration tests here](https://github.com/SUSE/DeepSea/wiki/Integration-tests)
