### PR TITLE
enforce pylint version 1.9.x

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -34,4 +34,5 @@ basepython = python3
 commands = pylint --rcfile=.pylintrc  srv/
 deps =
     {[base]deps}
+    pylint<2.0
     saltpylint


### PR DESCRIPTION
Signed-off-by: Alexander Graul <agraul@suse.com>

Fixes #1224 


Description: enforces the working version of pylint (1.9) which is supported until 2020


-----------------

[Please find more information on how to run integration tests here](https://github.com/SUSE/DeepSea/wiki/Integration-tests)
