### PR TITLE
qa: add functional.sh integration test script

### DIFF
--- a/qa/common/helper.sh
+++ b/qa/common/helper.sh
@@ -4,15 +4,11 @@
 # helper functions (not to be called directly from test scripts)
 #
 
-function _report_stage_failure_and_die {
-  local stage_num=$1
-  #local stage_log_path=$2
-  #local number_of_failures=$3
+function _report_orch_failure_and_die {
+  local orch_name=$1
 
-  test -z $number_of_failures && number_of_failures="unknown number of"
-  echo "********** Stage $stage_num failed with $number_of_failures failures **********"
+  echo "********** $orch_name failed **********"
   echo "Here comes the systemd log:"
-  #cat $stage_log_path
   journalctl -r | head -n 1000
   exit 1
 }
@@ -55,10 +51,10 @@ function _run_stage {
               echo "DeepSea stage OK"
           else
               echo "ERROR: deepsea stage returned exit status 0, yet one or more steps failed. Bailing out!"
-              _report_stage_failure_and_die $stage_num
+              _report_orch_failure_and_die "Stage $stage_num"
           fi
       else
-          _report_stage_failure_and_die $stage_num
+          _report_orch_failure_and_die "Stage $stage_num"
       fi
       set -e
       return
@@ -72,11 +68,11 @@ function _run_stage {
   if [[ "$STAGE_FINISHED" ]]; then
     FAILED=$(grep -F 'Failed: ' $stage_log_path | sed 's/.*Failed:\s*//g' | head -1)
     if [[ "$FAILED" -gt "0" ]]; then
-      _report_stage_failure_and_die $stage_num
+      _report_orch_failure_and_die "Stage $stage_num"
     fi
     echo "********** Stage $stage_num completed successfully **********"
   else
-    _report_stage_failure_and_die $stage_num
+    _report_orch_failure_and_die "Stage $stage_num"
   fi
 }
 

--- a/qa/suites/basic/functional.sh
+++ b/qa/suites/basic/functional.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+#
+# DeepSea integration test "suites/basic/functional.sh"
+#
+# This script runs DeepSea stages 0-3 to deploy a Ceph cluster on all available
+# nodes (each node should have 4 external disk drives). After stage 3
+# completes, the script checks for HEALTH_OK and triggers the "ceph.smoketests"
+# orchestration.
+#
+# In addition to the assumptions listed in qa/README, this script assumes that
+# all test nodes will have four external disk drives (i.e. in addition to the 
+# drive containing the root filesystem).
+#
+# On success (HEALTH_OK is reached and "ceph.smoketests" orchestration behaves
+# as expected), the script returns 0. On failure, for whatever reason, the
+# script returns non-zero.
+#
+# The script produces verbose output on stdout, which can be captured for later
+# forensic analysis.
+#
+
+set -ex
+
+SCRIPTNAME=$(basename ${0})
+BASEDIR=$(readlink -f "$(dirname ${0})/../..")
+test -d $BASEDIR
+[[ $BASEDIR =~ \/qa$ ]]
+
+source $BASEDIR/common/common.sh
+
+function usage {
+    set +x
+    echo "$SCRIPTNAME - script for testing HEALTH_OK deployment"
+    echo "for use in SUSE Enterprise Storage testing"
+    echo
+    echo "Usage:"
+    echo "  $SCRIPTNAME [-h,--help]"
+    echo
+    echo "Options:"
+    echo "    --cli         Use DeepSea CLI"
+    echo "    --help        Display this usage message"
+    exit 1
+}
+
+assert_enhanced_getopt
+
+TEMP=$(getopt -o h \
+--long "cli,help" \
+-n 'functional.sh' -- "$@")
+
+if [ $? != 0 ] ; then echo "Terminating..." >&2 ; exit 1 ; fi
+
+# Note the quotes around TEMP': they are essential!
+eval set -- "$TEMP"
+
+# process command-line options
+CLI=""
+while true ; do
+    case "$1" in
+        --cli) CLI="$1" ; shift ;;
+        -h|--help) usage ;;    # does not return
+        --) shift ; break ;;
+        *) echo "Internal error" ; exit 1 ;;
+    esac
+done
+echo "WWWW"
+echo "Running $SCRIPTNAME with options $CLI"
+
+# deploy phase
+MIN_NODES=1
+CLIENT_NODES=0
+deploy_ceph
+
+# test phase
+ceph_health_test
+run_orchestration 'ceph.smoketests'
+
+echo "$SCRIPTNAME result: PASS"


### PR DESCRIPTION
The new "functional.sh" integration test script runs Stages 0-3
followed by the "ceph.smoketests" orchestration.

Signed-off-by: Nathan Cutler <ncutler@suse.com>