### PR TITLE
build/ops: install top-level smoketests state file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,6 +121,8 @@ copy-files:
 	install -m 644 srv/salt/ceph/tests/restart/rgw/forced/*.sls $(DESTDIR)/srv/salt/ceph/tests/restart/rgw/forced
 	install -m 644 srv/salt/ceph/tests/restart/rgw/nochange/*.sls $(DESTDIR)/srv/salt/ceph/tests/restart/rgw/nochange
 	# smoketests
+	install -d -m 755 $(DESTDIR)/srv/salt/ceph/smoketests
+	install -m 644 srv/salt/ceph/smoketests/*.sls $(DESTDIR)/srv/salt/ceph/smoketests
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/smoketests/apparmor
 	install -m 644 srv/salt/ceph/smoketests/apparmor/*.sls $(DESTDIR)/srv/salt/ceph/smoketests/apparmor
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/smoketests/keyrings

--- a/deepsea.spec.in
+++ b/deepsea.spec.in
@@ -755,6 +755,7 @@ the README for more information.
 %dir /srv/salt/ceph/tests/restart/rgw/change
 %dir /srv/salt/ceph/tests/restart/rgw/forced
 %dir /srv/salt/ceph/tests/restart/rgw/nochange
+/srv/salt/ceph/smoketests/*.sls
 /srv/salt/ceph/smoketests/apparmor/*.sls
 /srv/salt/ceph/smoketests/keyrings/*.sls
 /srv/salt/ceph/smoketests/macros/os_switch/*.sls


### PR DESCRIPTION
Top-level smoketests state file is not installed, either by Makefile or by spec file.