### PR TITLE
apparmor: install apparmor-utils package on SUSE

### DIFF
--- a/srv/salt/ceph/apparmor/install/SUSE.sls
+++ b/srv/salt/ceph/apparmor/install/SUSE.sls
@@ -1,6 +1,9 @@
 
-patterns-base-apparmor:
-  pkg.installed
+install apparmor:
+  pkg.installed:
+    - pkgs:
+      - patterns-base-apparmor
+      - apparmor-utils
 
 apparmor:
   service.running:


### PR DESCRIPTION
On SLE15 at least, installing "patterns-base-apparmor" does not cause
apparmor-utils to be installed, and apparmor/default-enforce.sls fails
due to missing executable "aa-enforce".

Fixes: https://github.com/SUSE/DeepSea/issues/1234
Signed-off-by: Nathan Cutler <ncutler@suse.com>