### PR TITLE
passed arg was not changed in sls file after changed in function header

### DIFF
--- a/srv/salt/ceph/remove/storage/drain/default.sls
+++ b/srv/salt/ceph/remove/storage/drain/default.sls
@@ -6,7 +6,7 @@ reweight nop:
 drain osd.{{ id }}:
   module.run:
     - name: osd.zero_weight
-    - id: {{ id }}
+    - osd_id: {{ id }}
 
 set osd {{ id }} out:
   cmd.run:


### PR DESCRIPTION
Signed-off-by: Joshua Schmid <jschmid@suse.de>

Description:

Stage.5 reports:

> drain osd.6: The following arguments are missing: osd_id

which comes from ` ceph.remove.storage.drain (/srv/salt/ceph/remove/storage/drain)`

~dd688e193~  was changing the func header but we missed to change that also in the sls files

EDIT: it was actually fa78d09df00d3197ecc6d084c186514e82569311

-----------------


[Please find more information on how to run integration tests here](https://github.com/SUSE/DeepSea/wiki/Integration-tests)
