### PR TITLE
qa: add all possible dummy osd-configurations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,10 +71,12 @@ copy-files:
 	install -m 600 srv/salt/ceph/salt-api/files/sharedsecret.conf.j2 $(DESTDIR)/etc/salt/master.d/sharedsecret.conf
 	# qa
 	install -d -m 755 $(DESTDIR)/usr/lib/deepsea/qa/common
+	install -d -m 755 $(DESTDIR)/usr/lib/deepsea/qa/osd-config/ovh
 	install -d -m 755 $(DESTDIR)/usr/lib/deepsea/qa/suites/basic
 	install -d -m 755 $(DESTDIR)/usr/lib/deepsea/qa/suites/ceph-test
 	install -m 644 qa/README $(DESTDIR)/usr/lib/deepsea/qa/
 	install -m 644 qa/common/*.sh $(DESTDIR)/usr/lib/deepsea/qa/common/
+	install -m 644 qa/osd-config/ovh/*.yaml $(DESTDIR)/usr/lib/deepsea/qa/osd-config/ovh/
 	install -m 755 qa/suites/basic/*.sh $(DESTDIR)/usr/lib/deepsea/qa/suites/basic/
 	install -m 755 qa/suites/ceph-test/*.sh $(DESTDIR)/usr/lib/deepsea/qa/suites/ceph-test/
 	# tests

--- a/qa/osd-config/ovh/README.md
+++ b/qa/osd-config/ovh/README.md
@@ -1,0 +1,24 @@
+These files contain all the permuations for possible OSD configrations.
+
+The files were generated according to the following matrix.
+
+
+
++-------------+        +------------+         +------------------+      +-------------------------+
+|             |        |            |         |                  |      |                         |
+|             |        |            |         |                  |      |                         |
+|             |        |   db       |         |  encrypted       |      | all have sizes          |
+|   bluestore +-------->   wal      +--------->  not encrypted   +------> mixed size definition   |
+|             |        |   db_wal   |         |                  |      | none have size defined  |
+|             |        |            |         |                  |      |                         |
+|             |        |            |         |                  |      |                         |
++-------------+        +------------+         +------------------+      +-------------------------+
+
+
++-------------+        +------------+        +-----------------+
+|             |        |            |        |                 |
+|  filestore  +--------> journal    +-------->  encrypted      |
+|             |        |            |        |  not encrypted  |
+|             |        |            |        |                 |
++-------------+        +------------+        +-----------------+
+

--- a/qa/osd-config/ovh/bs_dedicated_db.yaml
+++ b/qa/osd-config/ovh/bs_dedicated_db.yaml
@@ -1,0 +1,12 @@
+ceph:
+  storage:
+    osds:
+      /dev/vdb:
+        format: bluestore
+        db: /dev/vde
+      /dev/vdc:
+        format: bluestore
+        db: /dev/vde
+      /dev/vdd:
+        format: bluestore
+        db: /dev/vde

--- a/qa/osd-config/ovh/bs_dedicated_db_crypt.yaml
+++ b/qa/osd-config/ovh/bs_dedicated_db_crypt.yaml
@@ -1,0 +1,15 @@
+ceph:
+  storage:
+    osds:
+      /dev/vdb:
+        format: bluestore
+        encryption: dmcrypt
+        db: /dev/vde
+      /dev/vdc:
+        format: bluestore
+        encryption: dmcrypt
+        db: /dev/vde
+      /dev/vdd:
+        format: bluestore
+        encryption: dmcrypt
+        db: /dev/vde

--- a/qa/osd-config/ovh/bs_dedicated_db_sizes.yaml
+++ b/qa/osd-config/ovh/bs_dedicated_db_sizes.yaml
@@ -1,0 +1,15 @@
+ceph:
+  storage:
+    osds:
+      /dev/vdb:
+        format: bluestore
+        db: /dev/vde
+        db_size: 1G
+      /dev/vdc:
+        format: bluestore
+        db: /dev/vde
+        db_size: 2G
+      /dev/vdd:
+        format: bluestore
+        db: /dev/vde
+        db_size: 3G

--- a/qa/osd-config/ovh/bs_dedicated_db_sizes_crypt.yaml
+++ b/qa/osd-config/ovh/bs_dedicated_db_sizes_crypt.yaml
@@ -1,0 +1,18 @@
+ceph:
+  storage:
+    osds:
+      /dev/vdb:
+        format: bluestore
+        encryption: dmcrypt
+        db: /dev/vde
+        db_size: 1G
+      /dev/vdc:
+        format: bluestore
+        encryption: dmcrypt
+        db: /dev/vde
+        db_size: 2G
+      /dev/vdd:
+        format: bluestore
+        encryption: dmcrypt
+        db: /dev/vde
+        db_size: 3G

--- a/qa/osd-config/ovh/bs_dedicated_db_sizes_mixed.yaml
+++ b/qa/osd-config/ovh/bs_dedicated_db_sizes_mixed.yaml
@@ -1,0 +1,14 @@
+ceph:
+  storage:
+    osds:
+      /dev/vdb:
+        format: bluestore
+        db: /dev/vde
+        db_size: 1G
+      /dev/vdc:
+        format: bluestore
+        db: /dev/vde
+        db_size: 2G
+      /dev/vdd:
+        format: bluestore
+        db: /dev/vde

--- a/qa/osd-config/ovh/bs_dedicated_db_sizes_mixed_crypt.yaml
+++ b/qa/osd-config/ovh/bs_dedicated_db_sizes_mixed_crypt.yaml
@@ -1,0 +1,17 @@
+ceph:
+  storage:
+    osds:
+      /dev/vdb:
+        format: bluestore
+        encryption: dmcrypt
+        db: /dev/vde
+        db_size: 1G
+      /dev/vdc:
+        format: bluestore
+        encryption: dmcrypt
+        db: /dev/vde
+        db_size: 2G
+      /dev/vdd:
+        format: bluestore
+        encryption: dmcrypt
+        db: /dev/vde

--- a/qa/osd-config/ovh/bs_dedicated_wal.yaml
+++ b/qa/osd-config/ovh/bs_dedicated_wal.yaml
@@ -1,0 +1,12 @@
+ceph:
+  storage:
+    osds:
+      /dev/vdb:
+        format: bluestore
+        wal: /dev/vde
+      /dev/vdc:
+        format: bluestore
+        wal: /dev/vde
+      /dev/vdd:
+        format: bluestore
+        wal: /dev/vde

--- a/qa/osd-config/ovh/bs_dedicated_wal_crypt.yaml
+++ b/qa/osd-config/ovh/bs_dedicated_wal_crypt.yaml
@@ -1,0 +1,15 @@
+ceph:
+  storage:
+    osds:
+      /dev/vdb:
+        format: bluestore
+        encryption: dmcrypt
+        wal: /dev/vde
+      /dev/vdc:
+        format: bluestore
+        encryption: dmcrypt
+        wal: /dev/vde
+      /dev/vdd:
+        format: bluestore
+        encryption: dmcrypt
+        wal: /dev/vde

--- a/qa/osd-config/ovh/bs_dedicated_wal_db.yaml
+++ b/qa/osd-config/ovh/bs_dedicated_wal_db.yaml
@@ -1,0 +1,11 @@
+ceph:
+  storage:
+    osds:
+      /dev/vdb:
+        format: bluestore
+        wal: /dev/vde
+        db: /dev/vdd
+      /dev/vdc:
+        format: bluestore
+        wal: /dev/vde
+        db: /dev/vdd

--- a/qa/osd-config/ovh/bs_dedicated_wal_db_crypt.yaml
+++ b/qa/osd-config/ovh/bs_dedicated_wal_db_crypt.yaml
@@ -1,0 +1,13 @@
+ceph:
+  storage:
+    osds:
+      /dev/vdb:
+        format: bluestore
+        encryption: dmcrypt
+        wal: /dev/vde
+        db: /dev/vdd
+      /dev/vdc:
+        format: bluestore
+        encryption: dmcrypt
+        wal: /dev/vde
+        db: /dev/vdd

--- a/qa/osd-config/ovh/bs_dedicated_wal_db_sizes_all.yaml
+++ b/qa/osd-config/ovh/bs_dedicated_wal_db_sizes_all.yaml
@@ -1,0 +1,15 @@
+ceph:
+  storage:
+    osds:
+      /dev/vdb:
+        format: bluestore
+        wal_size: 1G
+        wal: /dev/vde
+        db: /dev/vdd
+        db_size: 2G
+      /dev/vdc:
+        format: bluestore
+        wal: /dev/vde
+        db: /dev/vdd
+        wal_size: 3G
+        db_size: 4G

--- a/qa/osd-config/ovh/bs_dedicated_wal_db_sizes_all_crypt.yaml
+++ b/qa/osd-config/ovh/bs_dedicated_wal_db_sizes_all_crypt.yaml
@@ -1,0 +1,17 @@
+ceph:
+  storage:
+    osds:
+      /dev/vdb:
+        format: bluestore
+        encryption: dmcrypt
+        wal_size: 1G
+        wal: /dev/vde
+        db: /dev/vdd
+        db_size: 2G
+      /dev/vdc:
+        format: bluestore
+        encryption: dmcrypt
+        wal: /dev/vde
+        db: /dev/vdd
+        wal_size: 3G
+        db_size: 4G

--- a/qa/osd-config/ovh/bs_dedicated_wal_db_sizes_mixed.yaml
+++ b/qa/osd-config/ovh/bs_dedicated_wal_db_sizes_mixed.yaml
@@ -1,0 +1,13 @@
+ceph:
+  storage:
+    osds:
+      /dev/vdb:
+        format: bluestore
+        wal: /dev/vde
+        db: /dev/vdd
+      /dev/vdc:
+        format: bluestore
+        wal: /dev/vde
+        db: /dev/vdd
+        wal_size: 3G
+        db_size: 4G

--- a/qa/osd-config/ovh/bs_dedicated_wal_db_sizes_mixed_crypt.yaml
+++ b/qa/osd-config/ovh/bs_dedicated_wal_db_sizes_mixed_crypt.yaml
@@ -1,0 +1,15 @@
+ceph:
+  storage:
+    osds:
+      /dev/vdb:
+        format: bluestore
+        encryption: dmcrypt
+        wal: /dev/vde
+        db: /dev/vdd
+      /dev/vdc:
+        format: bluestore
+        encryption: dmcrypt
+        wal: /dev/vde
+        db: /dev/vdd
+        wal_size: 3G
+        db_size: 4G

--- a/qa/osd-config/ovh/bs_dedicated_wal_sizes.yaml
+++ b/qa/osd-config/ovh/bs_dedicated_wal_sizes.yaml
@@ -1,0 +1,15 @@
+ceph:
+  storage:
+    osds:
+      /dev/vdb:
+        format: bluestore
+        wal_size: 1G
+        wal: /dev/vde
+      /dev/vdc:
+        format: bluestore
+        wal: /dev/vde
+        wal_size: 2G
+      /dev/vdd:
+        format: bluestore
+        wal: /dev/vde
+        wal_size: 3G

--- a/qa/osd-config/ovh/bs_dedicated_wal_sizes_crypt.yaml
+++ b/qa/osd-config/ovh/bs_dedicated_wal_sizes_crypt.yaml
@@ -1,0 +1,18 @@
+ceph:
+  storage:
+    osds:
+      /dev/vdb:
+        format: bluestore
+        encryption: dmcrypt
+        wal_size: 1G
+        wal: /dev/vde
+      /dev/vdc:
+        format: bluestore
+        encryption: dmcrypt
+        wal: /dev/vde
+        wal_size: 2G
+      /dev/vdd:
+        format: bluestore
+        encryption: dmcrypt
+        wal: /dev/vde
+        wal_size: 3G

--- a/qa/osd-config/ovh/bs_dedicated_wal_sizes_mixed.yaml
+++ b/qa/osd-config/ovh/bs_dedicated_wal_sizes_mixed.yaml
@@ -1,0 +1,14 @@
+ceph:
+  storage:
+    osds:
+      /dev/vdb:
+        format: bluestore
+        wal_size: 1G
+        wal: /dev/vde
+      /dev/vdc:
+        format: bluestore
+        wal: /dev/vde
+        wal_size: 2G
+      /dev/vdd:
+        format: bluestore
+        wal: /dev/vde

--- a/qa/osd-config/ovh/bs_dedicated_wal_sizes_mixed_crypt.yaml
+++ b/qa/osd-config/ovh/bs_dedicated_wal_sizes_mixed_crypt.yaml
@@ -1,0 +1,17 @@
+ceph:
+  storage:
+    osds:
+      /dev/vdb:
+        format: bluestore
+        encryption: dmcrypt
+        wal_size: 1G
+        wal: /dev/vde
+      /dev/vdc:
+        format: bluestore
+        encryption: dmcrypt
+        wal: /dev/vde
+        wal_size: 2G
+      /dev/vdd:
+        format: bluestore
+        encryption: dmcrypt
+        wal: /dev/vde

--- a/qa/osd-config/ovh/fs_dedicated_journal.yaml
+++ b/qa/osd-config/ovh/fs_dedicated_journal.yaml
@@ -1,0 +1,12 @@
+ceph:
+  storage:
+    osds:
+      /dev/vdb:
+        format: filestore
+        journal: /dev/vde
+      /dev/vdc:
+        format: filestore
+        journal: /dev/vde
+      /dev/vdd:
+        format: filestore
+        journal: /dev/vde

--- a/qa/osd-config/ovh/fs_dedicated_journal_crypt.yaml
+++ b/qa/osd-config/ovh/fs_dedicated_journal_crypt.yaml
@@ -1,0 +1,15 @@
+ceph:
+  storage:
+    osds:
+      /dev/vdb:
+        format: filestore
+        encryption: dmcrypt
+        journal: /dev/vde
+      /dev/vdc:
+        format: filestore
+        encryption: dmcrypt
+        journal: /dev/vde
+      /dev/vdd:
+        format: filestore
+        encryption: dmcrypt
+        journal: /dev/vde


### PR DESCRIPTION
Description:

This PR $subject in order to feed them to teuthology-ovh ( for now ). That enables us to test all the possible configurations we support with deepsea. 

-----------------

[Please find more information on how to run integration tests here](https://github.com/SUSE/DeepSea/wiki/Integration-tests)
