### PR TITLE
qa/common: create btrfs subvolumes after Stage 0

### DIFF
--- a/qa/common/common.sh
+++ b/qa/common/common.sh
@@ -115,6 +115,13 @@ function install_deps {
 
 function run_stage_0 {
     _run_stage 0 "$@"
+    if _root_fs_is_btrfs ; then
+        echo "Root filesystem is btrfs: creating subvolumes for /var/lib/ceph"
+        salt-run state.orch ceph.migrate.subvolume
+    else
+        echo "Root filesystem is *not* btrfs: skipping subvolume creation"
+    fi
+
 }
 
 function run_stage_1 {

--- a/qa/common/common.sh
+++ b/qa/common/common.sh
@@ -69,7 +69,7 @@ function update_salt {
 }
 
 #
-# functions for processing command-line arguments
+# functions that process command-line arguments
 #
 
 function assert_enhanced_getopt {
@@ -86,7 +86,7 @@ function assert_enhanced_getopt {
 }
 
 #
-# functions for setting up the Salt Master node so it can run these tests
+# functions that set up the Salt Master node so it can run these tests
 #
 
 function zypper_ref {
@@ -99,53 +99,53 @@ function zypper_ref {
 }
 
 function install_deps {
-  echo "Installing dependencies on the Salt Master node"
-  local DEPENDENCIES="jq
-  "
-  zypper_ref
-  for d in $DEPENDENCIES ; do
-    zypper --non-interactive install --no-recommends $d
-  done
+    echo "Installing dependencies on the Salt Master node"
+    local DEPENDENCIES="jq
+    "
+    zypper_ref
+    for d in $DEPENDENCIES ; do
+        zypper --non-interactive install --no-recommends $d
+    done
 }
 
 
 #
-# functions for running the DeepSea stages
+# functions that run the DeepSea stages
 #
 
 function run_stage_0 {
-  _run_stage 0 "$@"
+    _run_stage 0 "$@"
 }
 
 function run_stage_1 {
-  _run_stage 1 "$@"
+    _run_stage 1 "$@"
 }
 
 function run_stage_2 {
-  salt '*' cmd.run "for delay in 60 60 60 60 ; do sudo zypper --non-interactive --gpg-auto-import-keys refresh && break ; sleep $delay ; done"
-  _run_stage 2 "$@"
-  salt_pillar_items
+    salt '*' cmd.run "for delay in 60 60 60 60 ; do sudo zypper --non-interactive --gpg-auto-import-keys refresh && break ; sleep $delay ; done"
+    _run_stage 2 "$@"
+    salt_pillar_items
 }
 
 function run_stage_3 {
-  cat_global_conf
-  _run_stage 3 "$@"
-  salt_cmd_run_lsblk
-  cat_ceph_conf
-  admin_auth_status
+    cat_global_conf
+    _run_stage 3 "$@"
+    salt_cmd_run_lsblk
+    cat_ceph_conf
+    admin_auth_status
 }
 
 function run_stage_4 {
-  _run_stage 4 "$@"
+    _run_stage 4 "$@"
 }
 
 function run_stage_5 {
-  _run_stage 5 "$@"
+    _run_stage 5 "$@"
 }
 
 
 #
-# functions for generating ceph.conf
+# functions that generate /etc/ceph/ceph.conf
 # see https://github.com/SUSE/DeepSea/tree/master/srv/salt/ceph/configuration/files/ceph.conf.d
 #
 
@@ -207,20 +207,20 @@ EOF
 
 
 #
-# functions for creating pools
+# functions that create pools
 #
 
 function pgs_per_pool {
-  local TOTALPOOLS=$1
-  test -n "$TOTALPOOLS"
-  local TOTALOSDS=$(json_total_osds)
-  test -n "$TOTALOSDS"
-  # given the total number of pools and OSDs,
-  # assume triple replication and equal number of PGs per pool
-  # and aim for 100 PGs per OSD
-  let "TOTALPGS = $TOTALOSDS * 100"
-  let "PGSPEROSD = $TOTALPGS / $TOTALPOOLS / 3"
-  echo $PGSPEROSD
+    local TOTALPOOLS=$1
+    test -n "$TOTALPOOLS"
+    local TOTALOSDS=$(json_total_osds)
+    test -n "$TOTALOSDS"
+    # given the total number of pools and OSDs,
+    # assume triple replication and equal number of PGs per pool
+    # and aim for 100 PGs per OSD
+    let "TOTALPGS = $TOTALOSDS * 100"
+    let "PGSPEROSD = $TOTALPGS / $TOTALPOOLS / 3"
+    echo $PGSPEROSD
 }
 
 
@@ -229,61 +229,61 @@ function pgs_per_pool {
 #
 
 function cat_deepsea_log {
-  cat /var/log/deepsea.log
+    cat /var/log/deepsea.log
 }
 
 function cat_salt_config {
-  cat /etc/salt/master
-  cat /etc/salt/minion
+    cat /etc/salt/master
+    cat /etc/salt/minion
 }
 
 function cat_policy_cfg {
-  cat /srv/pillar/ceph/proposals/policy.cfg
+    cat /srv/pillar/ceph/proposals/policy.cfg
 }
 
 function salt_pillar_items {
-  salt '*' pillar.items
+    salt '*' pillar.items
 }
 
 function salt_pillar_get_roles {
-  salt '*' pillar.get roles
+    salt '*' pillar.get roles
 }
 
 function salt_cmd_run_lsblk {
-  salt '*' cmd.run lsblk
+    salt '*' cmd.run lsblk
 }
 
 function cat_global_conf {
-  cat /srv/salt/ceph/configuration/files/ceph.conf.d/global.conf || true
+    cat /srv/salt/ceph/configuration/files/ceph.conf.d/global.conf || true
 }
 
 function cat_ceph_conf {
-  salt '*' cmd.run "cat /etc/ceph/ceph.conf"
+    salt '*' cmd.run "cat /etc/ceph/ceph.conf"
 }
 
 function admin_auth_status {
-  ceph auth get client.admin
-  ls -l /etc/ceph/ceph.client.admin.keyring
-  cat /etc/ceph/ceph.client.admin.keyring
+    ceph auth get client.admin
+    ls -l /etc/ceph/ceph.client.admin.keyring
+    cat /etc/ceph/ceph.client.admin.keyring
 }
 
 function ceph_cluster_status {
-  ceph pg stat -f json-pretty
-  _grace_period 1
-  ceph health detail -f json-pretty
-  _grace_period 1
-  ceph osd tree
-  _grace_period 1
-  ceph osd pool ls detail -f json-pretty
-  _grace_period 1
-  ceph -s
+    ceph pg stat -f json-pretty
+    _grace_period 1
+    ceph health detail -f json-pretty
+    _grace_period 1
+    ceph osd tree
+    _grace_period 1
+    ceph osd pool ls detail -f json-pretty
+    _grace_period 1
+    ceph -s
 }
 
 function ceph_log_grep_enoent_eaccess {
-  set +e
-  grep -rH "Permission denied" /var/log/ceph
-  grep -rH "No such file or directory" /var/log/ceph
-  set -e
+    set +e
+    grep -rH "Permission denied" /var/log/ceph
+    grep -rH "No such file or directory" /var/log/ceph
+    set -e
 }
 
 
@@ -294,32 +294,32 @@ function ceph_log_grep_enoent_eaccess {
 function ceph_version_test {
 # test that ceph RPM version matches "ceph --version"
 # for a loose definition of "matches"
-  rpm -q ceph
-  local RPM_NAME=$(rpm -q ceph)
-  local RPM_CEPH_VERSION=$(perl -e '"'"$RPM_NAME"'" =~ m/ceph-(\d+\.\d+\.\d+)/; print "$1\n";')
-  echo "According to RPM, the ceph upstream version is ->$RPM_CEPH_VERSION<-"
-  test -n "$RPM_CEPH_VERSION"
-  ceph --version
-  local BUFFER=$(ceph --version)
-  local CEPH_CEPH_VERSION=$(perl -e '"'"$BUFFER"'" =~ m/ceph version (\d+\.\d+\.\d+)/; print "$1\n";')
-  echo "According to \"ceph --version\", the ceph upstream version is ->$CEPH_CEPH_VERSION<-"
-  test -n "$RPM_CEPH_VERSION"
-  test "$RPM_CEPH_VERSION" = "$CEPH_CEPH_VERSION"
+    rpm -q ceph
+    local RPM_NAME=$(rpm -q ceph)
+    local RPM_CEPH_VERSION=$(perl -e '"'"$RPM_NAME"'" =~ m/ceph-(\d+\.\d+\.\d+)/; print "$1\n";')
+    echo "According to RPM, the ceph upstream version is ->$RPM_CEPH_VERSION<-"
+    test -n "$RPM_CEPH_VERSION"
+    ceph --version
+    local BUFFER=$(ceph --version)
+    local CEPH_CEPH_VERSION=$(perl -e '"'"$BUFFER"'" =~ m/ceph version (\d+\.\d+\.\d+)/; print "$1\n";')
+    echo "According to \"ceph --version\", the ceph upstream version is ->$CEPH_CEPH_VERSION<-"
+    test -n "$RPM_CEPH_VERSION"
+    test "$RPM_CEPH_VERSION" = "$CEPH_CEPH_VERSION"
 }
 
 function ceph_health_test {
-  local LOGFILE=/tmp/ceph_health_test.log
-  echo "Waiting up to 15 minutes for HEALTH_OK..."
-  salt -C 'I@roles:master' wait.until status=HEALTH_OK timeout=900 check=1 | tee $LOGFILE
-  # last line: determines return value of function
-  ! grep -q 'Timeout expired' $LOGFILE
+    local LOGFILE=/tmp/ceph_health_test.log
+    echo "Waiting up to 15 minutes for HEALTH_OK..."
+    salt -C 'I@roles:master' wait.until status=HEALTH_OK timeout=900 check=1 | tee $LOGFILE
+    # last line: determines return value of function
+    ! grep -q 'Timeout expired' $LOGFILE
 }
 
 function salt_api_test {
-  echo "Salt API test: BEGIN"
-  systemctl status salt-api.service
-  curl http://${SALT_MASTER}:8000/ | python3 -m json.tool
-  echo "Salt API test: END"
+    echo "Salt API test: BEGIN"
+    systemctl status salt-api.service
+    curl http://${SALT_MASTER}:8000/ | python3 -m json.tool
+    echo "Salt API test: END"
 }
 
 function rados_write_test {
@@ -343,13 +343,13 @@ EOF
 }
 
 function cephfs_mount_and_sanity_test {
-  #
-  # run cephfs mount test script on the client node
-  # mounts cephfs in /mnt, touches a file, asserts that it exists
-  #
-  local TESTSCRIPT=/tmp/cephfs_test.sh
-  local CLIENTNODE=$(_client_node)
-  cat << 'EOF' > $TESTSCRIPT
+    #
+    # run cephfs mount test script on the client node
+    # mounts cephfs in /mnt, touches a file, asserts that it exists
+    #
+    local TESTSCRIPT=/tmp/cephfs_test.sh
+    local CLIENTNODE=$(_client_node)
+    cat << 'EOF' > $TESTSCRIPT
 set -ex
 trap 'echo "Result: NOT_OK"' ERR
 echo "cephfs mount test script running as $(whoami) on $(hostname --fqdn)"
@@ -364,17 +364,17 @@ test -f /mnt/bubba
 umount /mnt
 echo "Result: OK"
 EOF
-  # FIXME: assert no MDS running on $CLIENTNODE
-  _run_test_script_on_node $TESTSCRIPT $CLIENTNODE
+    # FIXME: assert no MDS running on $CLIENTNODE
+    _run_test_script_on_node $TESTSCRIPT $CLIENTNODE
 }
 
 function iscsi_kludge {
-  #
-  # apply kludge to work around bsc#1049669
-  #
-  local TESTSCRIPT=/tmp/iscsi_kludge.sh
-  local IGWNODE=$(_first_x_node igw)
-  cat << 'EOF' > $TESTSCRIPT
+    #
+    # apply kludge to work around bsc#1049669
+    #
+    local TESTSCRIPT=/tmp/iscsi_kludge.sh
+    local IGWNODE=$(_first_x_node igw)
+    cat << 'EOF' > $TESTSCRIPT
 set -ex
 trap 'echo "Result: NOT_OK"' ERR
 echo "igw kludge script running as $(whoami) on $(hostname --fqdn)"
@@ -385,16 +385,16 @@ systemctl restart lrbd.service
 systemctl status -l lrbd.service
 echo "Result: OK"
 EOF
-  _run_test_script_on_node $TESTSCRIPT $IGWNODE
+    _run_test_script_on_node $TESTSCRIPT $IGWNODE
 }
 
 function igw_info {
-  #
-  # peek at igw information on the igw node
-  #
-  local TESTSCRIPT=/tmp/igw_info.sh
-  local IGWNODE=$(_first_x_node igw)
-  cat << 'EOF' > $TESTSCRIPT
+    #
+    # peek at igw information on the igw node
+    #
+    local TESTSCRIPT=/tmp/igw_info.sh
+    local IGWNODE=$(_first_x_node igw)
+    cat << 'EOF' > $TESTSCRIPT
 set -ex
 trap 'echo "Result: NOT_OK"' ERR
 echo "igw info script running as $(whoami) on $(hostname --fqdn)"
@@ -405,18 +405,18 @@ ss --tcp --numeric state listening
 echo "See 3260 there?"
 echo "Result: OK"
 EOF
-  _run_test_script_on_node $TESTSCRIPT $IGWNODE
+    _run_test_script_on_node $TESTSCRIPT $IGWNODE
 }
 
 function iscsi_mount_and_sanity_test {
-  #
-  # run iscsi mount test script on the client node
-  # mounts iscsi in /mnt, touches a file, asserts that it exists
-  #
-  local TESTSCRIPT=/tmp/iscsi_test.sh
-  local CLIENTNODE=$(_client_node)
-  local IGWNODE=$(_first_x_node igw)
-  cat << EOF > $TESTSCRIPT
+    #
+    # run iscsi mount test script on the client node
+    # mounts iscsi in /mnt, touches a file, asserts that it exists
+    #
+    local TESTSCRIPT=/tmp/iscsi_test.sh
+    local CLIENTNODE=$(_client_node)
+    local IGWNODE=$(_first_x_node igw)
+    cat << EOF > $TESTSCRIPT
 set -e
 trap 'echo "Result: NOT_OK"' ERR
 for delay in 60 60 60 60 ; do
@@ -446,8 +446,8 @@ test -f /mnt/bubba
 umount /mnt
 echo "Result: OK"
 EOF
-  # FIXME: assert script not running on the iSCSI gateway node
-  _run_test_script_on_node $TESTSCRIPT $CLIENTNODE
+    # FIXME: assert script not running on the iSCSI gateway node
+    _run_test_script_on_node $TESTSCRIPT $CLIENTNODE
 }
 
 function validate_rgw_cert_perm {
@@ -467,13 +467,13 @@ EOF
 }
 
 function test_systemd_ceph_osd_target_wants {
-  #
-  # see bsc#1051598 in which ceph-disk was omitting --runtime when it enabled
-  # ceph-osd@$ID.service units
-  #
-  local TESTSCRIPT=/tmp/test_systemd_ceph_osd_target_wants.sh
-  local STORAGENODE=$(_first_x_node storage)
-  cat << 'EOF' > $TESTSCRIPT
+    #
+    # see bsc#1051598 in which ceph-disk was omitting --runtime when it enabled
+    # ceph-osd@$ID.service units
+    #
+    local TESTSCRIPT=/tmp/test_systemd_ceph_osd_target_wants.sh
+    local STORAGENODE=$(_first_x_node storage)
+    cat << 'EOF' > $TESTSCRIPT
 set -x
 CEPH_OSD_WANTS="/systemd/system/ceph-osd.target.wants"
 ETC_CEPH_OSD_WANTS="/etc$CEPH_OSD_WANTS"
@@ -493,9 +493,9 @@ EOF
 }
 
 function configure_all_OSDs_to_filestore {
-	salt-run proposal.populate format=filestore name=filestore 
-	chown salt:salt /srv/pillar/ceph/proposals/policy.cfg
-	sed -i 's/profile-default/profile-filestore/g' /srv/pillar/ceph/proposals/policy.cfg
+    salt-run proposal.populate format=filestore name=filestore 
+    chown salt:salt /srv/pillar/ceph/proposals/policy.cfg
+    sed -i 's/profile-default/profile-filestore/g' /srv/pillar/ceph/proposals/policy.cfg
 }
 
 function verify_OSD_type {
@@ -518,16 +518,15 @@ function check_OSD_type {
 }
 
 function migrate_to_bluestore {
-	salt-run state.orch ceph.migrate.policy
-	sed -i 's/profile-filestore/migrated-profile-filestore/g' /srv/pillar/ceph/proposals/policy.cfg
-	salt-run disengage.safety
-	salt-run state.orch ceph.migrate.osds
+    salt-run state.orch ceph.migrate.policy
+    sed -i 's/profile-filestore/migrated-profile-filestore/g' /srv/pillar/ceph/proposals/policy.cfg
+    salt-run disengage.safety
+    salt-run state.orch ceph.migrate.osds
 }
 
 function disable_restart_in_stage_0 {
-	cp /srv/salt/ceph/stage/prep/master/default.sls /srv/salt/ceph/stage/prep/master/default-orig.sls 
-	cp /srv/salt/ceph/stage/prep/master/default-update-no-reboot.sls /srv/salt/ceph/stage/prep/master/default.sls 
-	cp /srv/salt/ceph/stage/prep/minion/default.sls /srv/salt/ceph/stage/prep/minion/default-orig.sls 
-	cp /srv/salt/ceph/stage/prep/minion/default-update-no-reboot.sls /srv/salt/ceph/stage/prep/minion/default.sls
+    cp /srv/salt/ceph/stage/prep/master/default.sls /srv/salt/ceph/stage/prep/master/default-orig.sls 
+    cp /srv/salt/ceph/stage/prep/master/default-update-no-reboot.sls /srv/salt/ceph/stage/prep/master/default.sls 
+    cp /srv/salt/ceph/stage/prep/minion/default.sls /srv/salt/ceph/stage/prep/minion/default-orig.sls 
+    cp /srv/salt/ceph/stage/prep/minion/default-update-no-reboot.sls /srv/salt/ceph/stage/prep/minion/default.sls
 }
-

--- a/qa/common/helper.sh
+++ b/qa/common/helper.sh
@@ -117,3 +117,7 @@ function _grace_period {
     echo "${SECONDS}-second grace period"
     sleep $SECONDS
 }
+
+function _root_fs_is_btrfs {
+    stat -f / | grep -q 'Type: btrfs'
+}

--- a/qa/common/helper.sh
+++ b/qa/common/helper.sh
@@ -5,115 +5,115 @@
 #
 
 function _report_stage_failure_and_die {
-  local stage_num=$1
-  #local stage_log_path=$2
-  #local number_of_failures=$3
+    local stage_num=$1
+    #local stage_log_path=$2
+    #local number_of_failures=$3
 
-  test -z $number_of_failures && number_of_failures="unknown number of"
-  echo "********** Stage $stage_num failed with $number_of_failures failures **********"
-  echo "Here comes the systemd log:"
-  #cat $stage_log_path
-  journalctl -r | head -n 1000
-  exit 1
+    test -z $number_of_failures && number_of_failures="unknown number of"
+    echo "********** Stage $stage_num failed with $number_of_failures failures **********"
+    echo "Here comes the systemd log:"
+    #cat $stage_log_path
+    journalctl -r | head -n 1000
+    exit 1
 }
 
 function _run_stage {
-  local stage_num=$1
+    local stage_num=$1
 
-  set +x
-  echo ""
-  echo "*********************************************"
-  echo "********** Running DeepSea Stage $stage_num **********"
-  echo "*********************************************"
-  set -x
+    set +x
+    echo ""
+    echo "*********************************************"
+    echo "********** Running DeepSea Stage $stage_num **********"
+    echo "*********************************************"
+    set -x
 
-  # CLI case
-  test -n "$CLI" && _run_stage_cli $stage_num || _run_stage_non_cli $stage_num
+    # CLI case
+    test -n "$CLI" && _run_stage_cli $stage_num || _run_stage_non_cli $stage_num
 }
 
 function _run_stage_cli {
-  local stage_num=$1
-  local deepsea_cli_output_path="/tmp/deepsea.${stage_num}.log"
-  local deepsea_exit_status=""
+    local stage_num=$1
+    local deepsea_cli_output_path="/tmp/deepsea.${stage_num}.log"
+    local deepsea_exit_status=""
 
-  echo "using DeepSea CLI"
-  set +e
-  deepsea \
-      --log-file=/var/log/salt/deepsea.log \
-      --log-level=debug \
-      stage \
-      run \
-      ceph.stage.${stage_num} \
-      --simple-output \
-      2>&1 | tee $deepsea_cli_output_path
-  deepsea_exit_status="${PIPESTATUS[0]}"
-  echo "deepsea exit status: $deepsea_exit_status"
-  echo "WWWW"
-  if [ "$deepsea_exit_status" = "0" ] ; then
-      if grep -q -F "failed=0" $deepsea_cli_output_path ; then
-          echo "********** Stage $stage_num completed successfully **********"
-      else
-          echo "ERROR: deepsea stage returned exit status 0, yet one or more steps failed. Bailing out!"
-          _report_stage_failure_and_die $stage_num
-      fi
-  else
-      _report_stage_failure_and_die $stage_num
-  fi
-  set -e
+    echo "using DeepSea CLI"
+    set +e
+    deepsea \
+        --log-file=/var/log/salt/deepsea.log \
+        --log-level=debug \
+        stage \
+        run \
+        ceph.stage.${stage_num} \
+        --simple-output \
+        2>&1 | tee $deepsea_cli_output_path
+    deepsea_exit_status="${PIPESTATUS[0]}"
+    echo "deepsea exit status: $deepsea_exit_status"
+    echo "WWWW"
+    if [ "$deepsea_exit_status" = "0" ] ; then
+        if grep -q -F "failed=0" $deepsea_cli_output_path ; then
+            echo "********** Stage $stage_num completed successfully **********"
+        else
+            echo "ERROR: deepsea stage returned exit status 0, yet one or more steps failed. Bailing out!"
+            _report_stage_failure_and_die $stage_num
+        fi
+    else
+        _report_stage_failure_and_die $stage_num
+    fi
+    set -e
 }
 
 function _run_stage_non_cli {
-  local stage_num=$1
-  local stage_log_path="/tmp/stage.${stage_num}.log"
+    local stage_num=$1
+    local stage_log_path="/tmp/stage.${stage_num}.log"
 
-  echo -n "" > $stage_log_path
-  salt-run --no-color state.orch ceph.stage.${stage_num} 2>&1 | tee $stage_log_path
-  STAGE_FINISHED=$(grep -F 'Total states run' $stage_log_path)
+    echo -n "" > $stage_log_path
+    salt-run --no-color state.orch ceph.stage.${stage_num} 2>&1 | tee $stage_log_path
+    STAGE_FINISHED=$(grep -F 'Total states run' $stage_log_path)
 
-  if [[ "$STAGE_FINISHED" ]]; then
-    FAILED=$(grep -F 'Failed: ' $stage_log_path | sed 's/.*Failed:\s*//g' | head -1)
-    if [[ "$FAILED" -gt "0" ]]; then
+    if [[ "$STAGE_FINISHED" ]]; then
+      FAILED=$(grep -F 'Failed: ' $stage_log_path | sed 's/.*Failed:\s*//g' | head -1)
+      if [[ "$FAILED" -gt "0" ]]; then
+        _report_stage_failure_and_die $stage_num
+      fi
+      echo "********** Stage $stage_num completed successfully **********"
+    else
       _report_stage_failure_and_die $stage_num
     fi
-    echo "********** Stage $stage_num completed successfully **********"
-  else
-    _report_stage_failure_and_die $stage_num
-  fi
 }
 
 function _client_node {
-  salt --static --out json -C 'not I@roles:storage' test.ping | jq -r 'keys[0]'
+    salt --static --out json -C 'not I@roles:storage' test.ping | jq -r 'keys[0]'
 }
 
 function _first_x_node {
-  local ROLE=$1
-  salt --static --out json -C "I@roles:$ROLE" test.ping | jq -r 'keys[0]'
+    local ROLE=$1
+    salt --static --out json -C "I@roles:$ROLE" test.ping | jq -r 'keys[0]'
 }
 
 function _run_test_script_on_node {
-  local TESTSCRIPT=$1 # on success, TESTSCRIPT must output the exact string
-                      # "Result: OK" on a line by itself, otherwise it will
-                      # be considered to have failed
-  local TESTNODE=$2
-  local ASUSER=$3
-  salt-cp $TESTNODE $TESTSCRIPT $TESTSCRIPT
-  local LOGFILE=/tmp/test_script.log
-  local STDERR_LOGFILE=/tmp/test_script_stderr.log
-  if [ -z "$ASUSER" -o "x$ASUSER" = "xroot" ] ; then
-    salt $TESTNODE cmd.run "sh $TESTSCRIPT" 2>$STDERR_LOGFILE | tee $LOGFILE
-  else
-    salt $TESTNODE cmd.run "sudo su $ASUSER -c \"bash $TESTSCRIPT\"" 2>$STDERR_LOGFILE | tee $LOGFILE
-  fi
-  local RESULT=$(grep -o -P '(?<=Result: )(OK)$' $LOGFILE) # since the script
-                                # is run by salt, the output appears indented
-  test "x$RESULT" = "xOK" && return
-  echo "The test script that ran on $TESTNODE failed. The stderr output was as follows:"
-  cat $STDERR_LOGFILE
-  exit 1
+    local TESTSCRIPT=$1 # on success, TESTSCRIPT must output the exact string
+                        # "Result: OK" on a line by itself, otherwise it will
+                        # be considered to have failed
+    local TESTNODE=$2
+    local ASUSER=$3
+    salt-cp $TESTNODE $TESTSCRIPT $TESTSCRIPT
+    local LOGFILE=/tmp/test_script.log
+    local STDERR_LOGFILE=/tmp/test_script_stderr.log
+    if [ -z "$ASUSER" -o "x$ASUSER" = "xroot" ] ; then
+      salt $TESTNODE cmd.run "sh $TESTSCRIPT" 2>$STDERR_LOGFILE | tee $LOGFILE
+    else
+      salt $TESTNODE cmd.run "sudo su $ASUSER -c \"bash $TESTSCRIPT\"" 2>$STDERR_LOGFILE | tee $LOGFILE
+    fi
+    local RESULT=$(grep -o -P '(?<=Result: )(OK)$' $LOGFILE) # since the script
+                                  # is run by salt, the output appears indented
+    test "x$RESULT" = "xOK" && return
+    echo "The test script that ran on $TESTNODE failed. The stderr output was as follows:"
+    cat $STDERR_LOGFILE
+    exit 1
 }
 
 function _grace_period {
-  local SECONDS=$1
-  echo "${SECONDS}-second grace period"
-  sleep $SECONDS
+    local SECONDS=$1
+    echo "${SECONDS}-second grace period"
+    sleep $SECONDS
 }

--- a/qa/suites/basic/health-ok.sh
+++ b/qa/suites/basic/health-ok.sh
@@ -32,7 +32,7 @@ function usage {
     echo
     echo "Usage:"
     echo "  $SCRIPTNAME [-h,--help] [--cli] [--client-nodes=X]"
-    echo "  [--mds] [--min-nodes=X] [--rgw] [--ssl]"
+    echo "  [--encryption] [--mds] [--min-nodes=X] [--rgw] [--ssl]"
     echo
     echo "Options:"
     echo "    --cli           Use DeepSea CLI"


### PR DESCRIPTION
This adds coverage of `ceph.migrate.subvolume` to the CI.

(Or, rather, it would if our OpenStack images were using btrfs. . . which they aren't . . .)

Backporting note: cherry-pick 40a5177 only