### PR TITLE
cli: filter out test.nop steps and don't report [init] step errors

### DIFF
--- a/cli/monitors/terminal_outputter.py
+++ b/cli/monitors/terminal_outputter.py
@@ -151,7 +151,7 @@ class SimplePrinter(MonitorListener):
         self.current_step.append({'endl': False})
 
     def step_runner_finished(self, step):
-        if not step.success:
+        if step.order > 0 and not step.success:
             if step.name not in self.errors:
                 self.errors[step.name] = step.end_event
 
@@ -201,7 +201,7 @@ class SimplePrinter(MonitorListener):
         self.current_step.append({'endl': True})
 
     def step_state_minion_finished(self, step, minion):
-        if not step.targets[minion]['success']:
+        if step.order > 0 and not step.targets[minion]['success']:
             if step.name not in self.errors:
                 self.errors[step.name] = OrderedDict()
             self.errors[step.name][minion] = step.targets[minion]['event']
@@ -810,7 +810,7 @@ class StepListPrinter(MonitorListener):
             self.print_step(self.step)
 
     def step_runner_finished(self, step):
-        if not step.success:
+        if step.order > 0 and not step.success:
             if step.name not in self.errors:
                 self.errors[step.name] = step.end_event
 
@@ -849,7 +849,7 @@ class StepListPrinter(MonitorListener):
             self.print_step(self.step)
 
     def step_state_minion_finished(self, step, minion):
-        if not step.targets[minion]['success']:
+        if step.order > 0 and not step.targets[minion]['success']:
             if step.name not in self.errors:
                 self.errors[step.name] = OrderedDict()
             self.errors[step.name][minion] = step.targets[minion]['event']


### PR DESCRIPTION
Fixes: #1243

Description:

This PR introduces the following changes to fix the problems reported in #1243 
* filter out test.nop states from the execution plan
* [init] step errors are not reported in the failure summary

