### PR TITLE
build/ops: streamline qa %files section

### DIFF
--- a/deepsea.spec.in
+++ b/deepsea.spec.in
@@ -745,75 +745,7 @@ the README for more information.
 
 %files qa
 %{_libexecdir}/deepsea/qa
-%dir /srv/salt/ceph/functests
-%dir /srv/salt/ceph/functests/1node
-%dir /srv/salt/ceph/functests/1node/apparmor
-%dir /srv/salt/ceph/functests/1node/keyrings
-%dir /srv/salt/ceph/functests/1node/macros
-%dir /srv/salt/ceph/functests/1node/macros/os_switch
-%dir /srv/salt/ceph/functests/1node/openstack
-%dir /srv/salt/ceph/functests/1node/quiescent
-%dir /srv/salt/ceph/functests/1node/restart
-%dir /srv/salt/ceph/functests/1node/tuned
-%dir /srv/salt/ceph/functests/1node/tuned/off
-%dir /srv/salt/ceph/tests
-%dir /srv/salt/ceph/tests/keyrings
-%dir /srv/salt/ceph/tests/openstack
-%dir /srv/salt/ceph/tests/os_switch
-%dir /srv/salt/ceph/tests/quiescent
-%dir /srv/salt/ceph/tests/quiescent/timeout
-%dir /srv/salt/ceph/tests/quiescent
-%dir /srv/salt/ceph/tests/quiescent/timeout
-%dir /srv/salt/ceph/tests/restart
-%dir /srv/salt/ceph/tests/restart/mon
-%dir /srv/salt/ceph/tests/restart/mon/change
-%dir /srv/salt/ceph/tests/restart/mon/forced
-%dir /srv/salt/ceph/tests/restart/mon/nochange
-%dir /srv/salt/ceph/tests/restart/mds
-%dir /srv/salt/ceph/tests/restart/mds/change
-%dir /srv/salt/ceph/tests/restart/mds/forced
-%dir /srv/salt/ceph/tests/restart/mds/nochange
-%dir /srv/salt/ceph/tests/restart/mgr
-%dir /srv/salt/ceph/tests/restart/mgr/change
-%dir /srv/salt/ceph/tests/restart/mgr/forced
-%dir /srv/salt/ceph/tests/restart/mgr/nochange
-%dir /srv/salt/ceph/tests/restart/rgw
-%dir /srv/salt/ceph/tests/restart/rgw/change
-%dir /srv/salt/ceph/tests/restart/rgw/forced
-%dir /srv/salt/ceph/tests/restart/rgw/nochange
-/srv/salt/ceph/functests/1node/*.sls
-/srv/salt/ceph/functests/1node/apparmor/*.sls
-%dir /srv/salt/ceph/tests/tuned
-%dir /srv/salt/ceph/tests/tuned/off
-/srv/salt/ceph/functests/1node/keyrings/*.sls
-/srv/salt/ceph/functests/1node/macros/os_switch/*.sls
-/srv/salt/ceph/functests/1node/openstack/*.sls
-/srv/salt/ceph/functests/1node/quiescent/*.sls
-/srv/salt/ceph/functests/1node/restart/*.sls
-/srv/salt/ceph/functests/1node/tuned/*.sls
-/srv/salt/ceph/functests/1node/tuned/off/*.sls
-/srv/salt/ceph/tests/keyrings/*.sls
-/srv/salt/ceph/tests/openstack/*.sls
-/srv/salt/ceph/tests/os_switch/*.sls
-/srv/salt/ceph/tests/quiescent/*.sls
-/srv/salt/ceph/tests/quiescent/timeout/*.sls
-/srv/salt/ceph/tests/restart/*.sls
-/srv/salt/ceph/tests/restart/mon/*.sls
-/srv/salt/ceph/tests/restart/mon/change/*.sls
-/srv/salt/ceph/tests/restart/mon/forced/*.sls
-/srv/salt/ceph/tests/restart/mon/nochange/*.sls
-/srv/salt/ceph/tests/restart/mds/*.sls
-/srv/salt/ceph/tests/restart/mds/change/*.sls
-/srv/salt/ceph/tests/restart/mds/forced/*.sls
-/srv/salt/ceph/tests/restart/mds/nochange/*.sls
-/srv/salt/ceph/tests/restart/mgr/*.sls
-/srv/salt/ceph/tests/restart/mgr/change/*.sls
-/srv/salt/ceph/tests/restart/mgr/forced/*.sls
-/srv/salt/ceph/tests/restart/mgr/nochange/*.sls
-/srv/salt/ceph/tests/restart/rgw/*.sls
-/srv/salt/ceph/tests/restart/rgw/change/*.sls
-/srv/salt/ceph/tests/restart/rgw/forced/*.sls
-/srv/salt/ceph/tests/restart/rgw/nochange/*.sls
-/srv/salt/ceph/tests/tuned/*.sls
-/srv/salt/ceph/tests/tuned/off/*.sls
+/srv/salt/ceph/functests
+/srv/salt/ceph/tests
+
 %changelog


### PR DESCRIPTION
Merely mentioning the top-level directory is sufficient to bring in that
directory and everything under it.

This is a Big Stick, and not to be used lightly, but since (a) the deepsea-qa
package is not intended for wide consumption and (b) the directories in
question contain only QA-related stuff, it seems OK to use here.