### PR TITLE
rescind: prevent empty rendering of ceph.rescind.tuned state file

### DIFF
--- a/srv/salt/ceph/rescind/tuned/default.sls
+++ b/srv/salt/ceph/rescind/tuned/default.sls
@@ -1,3 +1,7 @@
+prevent empty rendering:
+  test.nop:
+    - name: skip
+
 {% set roles = salt['pillar.get']('roles') %}
 
 {% if 'storage' not in roles and 'mon' not in roles and


### PR DESCRIPTION
Without this, Stage 5 fails like so:

```
2018-07-29T01:59:30.330 INFO:teuthology.orchestra.run.target149202182148.stdout:[10/11] Executing state ceph.rescind.tuned...
2018-07-29T01:59:30.330 INFO:teuthology.orchestra.run.target149202182148.stdout:         target149202182148.teuthology... fail
2018-07-29T01:59:30.330 INFO:teuthology.orchestra.run.target149202182148.stdout:         target149202182016.teuthology... fail
2018-07-29T01:59:30.330 INFO:teuthology.orchestra.run.target149202182148.stdout:         target149202182123.teuthology... fail
2018-07-29T01:59:30.331 INFO:teuthology.orchestra.run.target149202182148.stdout:         target149202182166.teuthology... ok
2018-07-29T01:59:30.331 INFO:teuthology.orchestra.run.target149202182148.stdout:[11/11] Executing state ceph.rescind.rgw.monitoring...
2018-07-29T01:59:30.331 INFO:teuthology.orchestra.run.target149202182148.stdout:         target149202182148.teuthology... ok
2018-07-29T01:59:30.331 INFO:teuthology.orchestra.run.target149202182148.stdout:Finished stage ceph.stage.5: succeeded=10/11 failed=1/11
2018-07-29T01:59:30.331 INFO:teuthology.orchestra.run.target149202182148.stdout:
2018-07-29T01:59:30.331 INFO:teuthology.orchestra.run.target149202182148.stdout:Failures summary:
2018-07-29T01:59:30.331 INFO:teuthology.orchestra.run.target149202182148.stdout:ceph.rescind.tuned (/srv/salt/ceph/rescind/tuned):
2018-07-29T01:59:30.331 INFO:teuthology.orchestra.run.target149202182148.stdout:  target149202182148.teuthology:
2018-07-29T01:59:30.331 INFO:teuthology.orchestra.run.target149202182148.stdout:  target149202182016.teuthology:
2018-07-29T01:59:30.331 INFO:teuthology.orchestra.run.target149202182148.stdout:  target149202182123.teuthology:
2018-07-29T01:59:30.460 INFO:teuthology.orchestra.run.target149202182148.stdout:deepsea exit status: 1
```