### PR TITLE
Change the default for stage to update no reboot

### DIFF
--- a/man/deepsea-customization.7
+++ b/man/deepsea-customization.7
@@ -63,7 +63,9 @@ will now load your custom.sls.
 .SH More examples
 
 
-DeepSea ships a number of non-default states that can be used. For example we offer alternating stage.0s which 
+The default state is update-no-reboot, 
+but DeepSea ships a number of non-default states that can be used.
+For example we offer alternating stage.0s which 
 have either updates or reboots (or both) disabled.
 
 To apply those you'd have to add 

--- a/man/deepsea-customization.7
+++ b/man/deepsea-customization.7
@@ -63,10 +63,9 @@ will now load your custom.sls.
 .SH More examples
 
 
-The default state is update-no-reboot, 
-but DeepSea ships a number of non-default states that can be used.
+DeepSea ships a number of non-default states that can be used.
 For example we offer alternating stage.0s which 
-have either updates or reboots (or both) disabled.
+have either updates or reboots (or both) enabled.
 
 To apply those you'd have to add 
 

--- a/man/deepsea-stage-0.7
+++ b/man/deepsea-stage-0.7
@@ -45,7 +45,9 @@ The master minion will be patched.
 .B Reboot
 .RS
 By default the master will not reboot. 
-This can be changed by adjusting
+If you still need a reboot you can modify stage 0 defaults to "default-update-reboot"
+or any other available option.
+This can be done by adjusting
 
 .B stage_prep_master. See also deepsea-customization (7) 
 for more information on how to change the default behavior

--- a/man/deepsea-stage-0.7
+++ b/man/deepsea-stage-0.7
@@ -44,7 +44,7 @@ The master minion will be patched.
 .RE
 .B Reboot
 .RS
-If DeepSea detects the need for a reboot, the master will reboot. 
+By default the master will not reboot. 
 This can be changed by adjusting
 
 .B stage_prep_master. See also deepsea-customization (7) 

--- a/qa/common/common.sh
+++ b/qa/common/common.sh
@@ -498,13 +498,6 @@ function migrate_to_bluestore {
     salt-run state.orch ceph.migrate.osds 2>/dev/null
 }
 
-function _disable_restart_in_stage_0_with_update {
-    cp /srv/salt/ceph/stage/prep/master/default.sls /srv/salt/ceph/stage/prep/master/default-orig.sls 
-    cp /srv/salt/ceph/stage/prep/master/default-update-no-reboot.sls /srv/salt/ceph/stage/prep/master/default.sls 
-    cp /srv/salt/ceph/stage/prep/minion/default.sls /srv/salt/ceph/stage/prep/minion/default-orig.sls 
-    cp /srv/salt/ceph/stage/prep/minion/default-update-no-reboot.sls /srv/salt/ceph/stage/prep/minion/default.sls
-}
-
 function _disable_restart_in_stage_0_without_update {
     cp /srv/salt/ceph/stage/prep/master/default.sls /srv/salt/ceph/stage/prep/master/default-orig.sls 
     cp /srv/salt/ceph/stage/prep/master/default-no-update-no-reboot.sls /srv/salt/ceph/stage/prep/master/default.sls 

--- a/srv/salt/ceph/stage/prep/master/default-update-reboot.sls
+++ b/srv/salt/ceph/stage/prep/master/default-update-reboot.sls
@@ -1,4 +1,3 @@
-
 {% set master = salt['master.minion']() %}
 
 {% if salt['saltutil.runner']('validate.setup') == False %}
@@ -10,6 +9,7 @@ validate failed:
     - failhard: True
 
 {% endif %}
+
 
 sync master:
   salt.state:
@@ -46,6 +46,13 @@ unlock:
     - queue: 'master'
     - item: 'lock'
     - unless: "rpm -q --last kernel-default | head -1 | grep -q {{ kernel }}"
+
+{% if grains.get('os_family', '') == 'Suse' %}
+restart master:
+  salt.state:
+    - tgt: {{ master }}
+    - sls: ceph.updates.restart
+{% endif %}
 
 complete marker:
   salt.runner:

--- a/srv/salt/ceph/stage/prep/master/default.sls
+++ b/srv/salt/ceph/stage/prep/master/default.sls
@@ -47,13 +47,6 @@ unlock:
     - item: 'lock'
     - unless: "rpm -q --last kernel-default | head -1 | grep -q {{ kernel }}"
 
-{% if grains.get('os_family', '') == 'Suse' %}
-restart master:
-  salt.state:
-    - tgt: {{ master }}
-    - sls: ceph.updates.restart
-{% endif %}
-
 complete marker:
   salt.runner:
     - name: filequeue.enqueue

--- a/srv/salt/ceph/stage/prep/minion/default-no-update-no-reboot.sls
+++ b/srv/salt/ceph/stage/prep/minion/default-no-update-no-reboot.sls
@@ -1,30 +1,30 @@
 repo:
   salt.state:
-    - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
+    - tgt: {{ salt['pillar.get']('deepsea_minions') }}
     - tgt_type: compound
     - sls: ceph.repo
 
 metapackage minions:
   salt.state:
-    - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
+    - tgt: {{ salt['pillar.get']('deepsea_minions') }}
     - sls: ceph.metapackage
 
 common packages:
   salt.state:
-    - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
+    - tgt: {{ salt['pillar.get']('deepsea_minions') }}
     - tgt_type: compound
     - sls: ceph.packages.common
     - failhard: True
 
 sync:
   salt.state:
-    - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
+    - tgt: {{ salt['pillar.get']('deepsea_minions') }}
     - tgt_type: compound
     - sls: ceph.sync
 
 mines:
   salt.state:
-    - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
+    - tgt: {{ salt['pillar.get']('deepsea_minions') }}
     - tgt_type: compound
     - sls: ceph.mines
 

--- a/srv/salt/ceph/stage/prep/minion/default-no-update-reboot.sls
+++ b/srv/salt/ceph/stage/prep/minion/default-no-update-reboot.sls
@@ -3,31 +3,31 @@
 
 repo:
   salt.state:
-    - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
+    - tgt: {{ salt['pillar.get']('deepsea_minions') }}
     - tgt_type: compound
     - sls: ceph.repo
 
 metapackage minions:
   salt.state:
-    - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
+    - tgt: {{ salt['pillar.get']('deepsea_minions') }}
     - sls: ceph.metapackage
 
 common packages:
   salt.state:
-    - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
+    - tgt: {{ salt['pillar.get']('deepsea_minions') }}
     - tgt_type: compound
     - sls: ceph.packages.common
     - failhard: True
 
 sync:
   salt.state:
-    - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
+    - tgt: {{ salt['pillar.get']('deepsea_minions') }}
     - tgt_type: compound
     - sls: ceph.sync
 
 mines:
   salt.state:
-    - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
+    - tgt: {{ salt['pillar.get']('deepsea_minions') }}
     - tgt_type: compound
     - sls: ceph.mines
 
@@ -54,7 +54,7 @@ wait until the cluster has recovered before processing {{ host }}:
 
 check if all processes are still running after processing {{ host }}:
   salt.state:
-    - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
+    - tgt: {{ salt['pillar.get']('deepsea_minions') }}
     - tgt_type: compound
     - sls: ceph.processes
     - failhard: True
@@ -122,7 +122,7 @@ finishing remaining minions:
 
 restart:
   salt.state:
-    - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
+    - tgt: {{ salt['pillar.get']('deepsea_minions') }}
     - tgt_type: compound
     - sls: ceph.updates.restart
 

--- a/srv/salt/ceph/stage/prep/minion/default-update-reboot.sls
+++ b/srv/salt/ceph/stage/prep/minion/default-update-reboot.sls
@@ -3,31 +3,31 @@
 
 repo:
   salt.state:
-    - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
+    - tgt: {{ salt['pillar.get']('deepsea_minions') }}
     - tgt_type: compound
     - sls: ceph.repo
 
 metapackage minions:
   salt.state:
-    - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
+    - tgt: {{ salt['pillar.get']('deepsea_minions') }}
     - sls: ceph.metapackage
 
 common packages:
   salt.state:
-    - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
+    - tgt: {{ salt['pillar.get']('deepsea_minions') }}
     - tgt_type: compound
     - sls: ceph.packages.common
     - failhard: True
 
 sync:
   salt.state:
-    - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
+    - tgt: {{ salt['pillar.get']('deepsea_minions') }}
     - tgt_type: compound
     - sls: ceph.sync
 
 mines:
   salt.state:
-    - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
+    - tgt: {{ salt['pillar.get']('deepsea_minions') }}
     - tgt_type: compound
     - sls: ceph.mines
 
@@ -54,7 +54,7 @@ wait until the cluster has recovered before processing {{ host }}:
 
 check if all processes are still running after processing {{ host }}:
   salt.state:
-    - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
+    - tgt: {{ salt['pillar.get']('deepsea_minions') }}
     - tgt_type: compound
     - sls: ceph.processes
     - failhard: True
@@ -62,7 +62,7 @@ check if all processes are still running after processing {{ host }}:
 unset noout {{ host }}:
   salt.state:
     - sls: ceph.noout.unset
-    - tgt: '{{ master }}'
+    - tgt: {{ master }}
     - failhard: True
 
 updating {{ host }}:
@@ -140,14 +140,14 @@ finishing remaining minions:
 
 updates:
   salt.state:
-    - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
+    - tgt: {{ salt['pillar.get']('deepsea_minions') }}
     - tgt_type: compound
     - sls: ceph.updates
 
 {% if grains.get('os_family', '') == 'Suse' %}
 restart:
   salt.state:
-    - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
+    - tgt: {{ salt['pillar.get']('deepsea_minions') }}
     - tgt_type: compound
     - sls: ceph.updates.restart
 {% endif %}

--- a/srv/salt/ceph/stage/prep/minion/default-update-reboot.sls
+++ b/srv/salt/ceph/stage/prep/minion/default-update-reboot.sls
@@ -62,7 +62,7 @@ check if all processes are still running after processing {{ host }}:
 unset noout {{ host }}:
   salt.state:
     - sls: ceph.noout.unset
-    - tgt: {{ master }}
+    - tgt: '{{ master }}'
     - failhard: True
 
 updating {{ host }}:
@@ -78,6 +78,15 @@ set noout {{ host }}:
     - tgt: {{ master }}
     - failhard: True
 
+{% if grains.get('os_family', '') == 'Suse' %}
+restart {{ host }} if updates require:
+  salt.state:
+    - tgt: {{ host }}
+    - tgt_type: compound
+    - sls: ceph.updates.restart
+    - failhard: True
+{% endif %}
+
 finished {{ host }}:
   salt.runner:
     - name: minions.message
@@ -85,7 +94,7 @@ finished {{ host }}:
 
 {% endfor %}
 
-unset noout after final iteration: 
+unset noout after final iteration:
   salt.state:
     - sls: ceph.noout.unset
     - tgt: {{ master }}
@@ -102,6 +111,15 @@ updating minions without roles:
     - tgt_type: compound
     - sls: ceph.updates
     - failhard: True
+
+{% if grains.get('os_family', '') == 'Suse' %}
+restarting minions without roles:
+  salt.state:
+    - tgt: I@cluster:ceph
+    - tgt_type: compound
+    - sls: ceph.updates.restart
+    - failhard: True
+{% endif %}
 
 finishing remaining minions:
   salt.runner:
@@ -125,5 +143,13 @@ updates:
     - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
     - tgt_type: compound
     - sls: ceph.updates
+
+{% if grains.get('os_family', '') == 'Suse' %}
+restart:
+  salt.state:
+    - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
+    - tgt_type: compound
+    - sls: ceph.updates.restart
+{% endif %}
 
 {% endif %}

--- a/srv/salt/ceph/stage/prep/minion/default.sls
+++ b/srv/salt/ceph/stage/prep/minion/default.sls
@@ -62,7 +62,7 @@ check if all processes are still running after processing {{ host }}:
 unset noout {{ host }}:
   salt.state:
     - sls: ceph.noout.unset
-    - tgt: '{{ master }}'
+    - tgt: {{ master }}
     - failhard: True
 
 updating {{ host }}:
@@ -78,15 +78,6 @@ set noout {{ host }}:
     - tgt: {{ master }}
     - failhard: True
 
-{% if grains.get('os_family', '') == 'Suse' %}
-restart {{ host }} if updates require:
-  salt.state:
-    - tgt: {{ host }}
-    - tgt_type: compound
-    - sls: ceph.updates.restart
-    - failhard: True
-{% endif %}
-
 finished {{ host }}:
   salt.runner:
     - name: minions.message
@@ -94,7 +85,7 @@ finished {{ host }}:
 
 {% endfor %}
 
-unset noout after final iteration:
+unset noout after final iteration: 
   salt.state:
     - sls: ceph.noout.unset
     - tgt: {{ master }}
@@ -111,15 +102,6 @@ updating minions without roles:
     - tgt_type: compound
     - sls: ceph.updates
     - failhard: True
-
-{% if grains.get('os_family', '') == 'Suse' %}
-restarting minions without roles:
-  salt.state:
-    - tgt: I@cluster:ceph
-    - tgt_type: compound
-    - sls: ceph.updates.restart
-    - failhard: True
-{% endif %}
 
 finishing remaining minions:
   salt.runner:
@@ -143,13 +125,5 @@ updates:
     - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
     - tgt_type: compound
     - sls: ceph.updates
-
-{% if grains.get('os_family', '') == 'Suse' %}
-restart:
-  salt.state:
-    - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
-    - tgt_type: compound
-    - sls: ceph.updates.restart
-{% endif %}
 
 {% endif %}

--- a/srv/salt/ceph/stage/prep/minion/default.sls
+++ b/srv/salt/ceph/stage/prep/minion/default.sls
@@ -3,31 +3,31 @@
 
 repo:
   salt.state:
-    - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
+    - tgt: {{ salt['pillar.get']('deepsea_minions') }}
     - tgt_type: compound
     - sls: ceph.repo
 
 metapackage minions:
   salt.state:
-    - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
+    - tgt: {{ salt['pillar.get']('deepsea_minions') }}
     - sls: ceph.metapackage
 
 common packages:
   salt.state:
-    - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
+    - tgt: {{ salt['pillar.get']('deepsea_minions') }}
     - tgt_type: compound
     - sls: ceph.packages.common
     - failhard: True
 
 sync:
   salt.state:
-    - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
+    - tgt: {{ salt['pillar.get']('deepsea_minions') }}
     - tgt_type: compound
     - sls: ceph.sync
 
 mines:
   salt.state:
-    - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
+    - tgt: {{ salt['pillar.get']('deepsea_minions') }}
     - tgt_type: compound
     - sls: ceph.mines
 
@@ -54,7 +54,7 @@ wait until the cluster has recovered before processing {{ host }}:
 
 check if all processes are still running after processing {{ host }}:
   salt.state:
-    - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
+    - tgt: {{ salt['pillar.get']('deepsea_minions') }}
     - tgt_type: compound
     - sls: ceph.processes
     - failhard: True
@@ -122,7 +122,7 @@ finishing remaining minions:
 
 updates:
   salt.state:
-    - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
+    - tgt: {{ salt['pillar.get']('deepsea_minions') }}
     - tgt_type: compound
     - sls: ceph.updates
 


### PR DESCRIPTION
Fixes #1254 


Description: The current default for stage.0 is to always update and restart( if needed ) the node. To be less aggressive, we change the default to no-reboot-update.

Also update stage 0 and customization man pages.

Also created doc bugs: 1103242, 1103247, 1103248 and 1103249
Please advise for which version of ses doc bug must exist? 5 or 6 or both?


-----------------

[Please find more information on how to run integration tests here](https://github.com/SUSE/DeepSea/wiki/Integration-tests)
