### PR TITLE
[backport][SES5]  Change the default for stage to update no reboot 1255

### DIFF
--- a/srv/salt/ceph/stage/prep/master/default-update-reboot.sls
+++ b/srv/salt/ceph/stage/prep/master/default-update-reboot.sls
@@ -1,5 +1,3 @@
-{% set master = salt['master.minion']() %}
-
 {% if salt['saltutil.runner']('validate.setup') == False %}
 
 validate failed:
@@ -50,7 +48,7 @@ unlock:
 {% if grains.get('os_family', '') == 'Suse' %}
 restart master:
   salt.state:
-    - tgt: {{ master }}
+    - tgt: {{ salt['pillar.get']('master_minion') }}
     - sls: ceph.updates.restart
 {% endif %}
 

--- a/srv/salt/ceph/stage/prep/master/default-update-reboot.sls
+++ b/srv/salt/ceph/stage/prep/master/default-update-reboot.sls
@@ -1,3 +1,5 @@
+{% set master = salt['master.minion']() %}
+
 {% if salt['saltutil.runner']('validate.setup') == False %}
 
 validate failed:
@@ -7,6 +9,7 @@ validate failed:
     - failhard: True
 
 {% endif %}
+
 
 sync master:
   salt.state:
@@ -43,6 +46,13 @@ unlock:
     - queue: 'master'
     - item: 'lock'
     - unless: "rpm -q --last kernel-default | head -1 | grep -q {{ kernel }}"
+
+{% if grains.get('os_family', '') == 'Suse' %}
+restart master:
+  salt.state:
+    - tgt: {{ master }}
+    - sls: ceph.updates.restart
+{% endif %}
 
 complete marker:
   salt.runner:

--- a/srv/salt/ceph/stage/prep/master/default.sls
+++ b/srv/salt/ceph/stage/prep/master/default.sls
@@ -44,11 +44,6 @@ unlock:
     - item: 'lock'
     - unless: "rpm -q --last kernel-default | head -1 | grep -q {{ kernel }}"
 
-restart master:
-  salt.state:
-    - tgt: {{ salt['pillar.get']('master_minion') }}
-    - sls: ceph.updates.restart
-
 complete marker:
   salt.runner:
     - name: filequeue.add

--- a/srv/salt/ceph/stage/prep/minion/default-no-update-no-reboot.sls
+++ b/srv/salt/ceph/stage/prep/minion/default-no-update-no-reboot.sls
@@ -1,29 +1,29 @@
 repo:
   salt.state:
-    - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
+    - tgt: {{ salt['pillar.get']('deepsea_minions') }}
     - tgt_type: compound
     - sls: ceph.repo
 
 metapackage minions:
   salt.state:
-    - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
+    - tgt: {{ salt['pillar.get']('deepsea_minions') }}
     - sls: ceph.metapackage
 
 common packages:
   salt.state:
-    - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
+    - tgt: {{ salt['pillar.get']('deepsea_minions') }}
     - tgt_type: compound
     - sls: ceph.packages.common
 
 sync:
   salt.state:
-    - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
+    - tgt: {{ salt['pillar.get']('deepsea_minions') }}
     - tgt_type: compound
     - sls: ceph.sync
 
 mines:
   salt.state:
-    - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
+    - tgt: {{ salt['pillar.get']('deepsea_minions') }}
     - tgt_type: compound
     - sls: ceph.mines
 

--- a/srv/salt/ceph/stage/prep/minion/default-no-update-reboot.sls
+++ b/srv/salt/ceph/stage/prep/minion/default-no-update-reboot.sls
@@ -1,29 +1,29 @@
 repo:
   salt.state:
-    - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
+    - tgt: {{ salt['pillar.get']('deepsea_minions') }}
     - tgt_type: compound
     - sls: ceph.repo
 
 metapackage minions:
   salt.state:
-    - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
+    - tgt: {{ salt['pillar.get']('deepsea_minions') }}
     - sls: ceph.metapackage
 
 common packages:
   salt.state:
-    - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
+    - tgt: {{ salt['pillar.get']('deepsea_minions') }}
     - tgt_type: compound
     - sls: ceph.packages.common
 
 sync:
   salt.state:
-    - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
+    - tgt: {{ salt['pillar.get']('deepsea_minions') }}
     - tgt_type: compound
     - sls: ceph.sync
 
 mines:
   salt.state:
-    - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
+    - tgt: {{ salt['pillar.get']('deepsea_minions') }}
     - tgt_type: compound
     - sls: ceph.mines
 
@@ -50,7 +50,7 @@ wait until the cluster has recovered before processing {{ host }}:
 
 check if all processes are still running after processing {{ host }}:
   salt.state:
-    - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
+    - tgt: {{ salt['pillar.get']('deepsea_minions') }}
     - tgt_type: compound
     - sls: ceph.processes
     - failhard: True
@@ -118,7 +118,7 @@ finishing remaining minions:
 
 restart:
   salt.state:
-    - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
+    - tgt: {{ salt['pillar.get']('deepsea_minions') }}
     - tgt_type: compound
     - sls: ceph.updates.restart
 

--- a/srv/salt/ceph/stage/prep/minion/default-update-reboot.sls
+++ b/srv/salt/ceph/stage/prep/minion/default-update-reboot.sls
@@ -1,29 +1,29 @@
 repo:
   salt.state:
-    - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
+    - tgt: {{ salt['pillar.get']('deepsea_minions') }}
     - tgt_type: compound
     - sls: ceph.repo
 
 metapackage minions:
   salt.state:
-    - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
+    - tgt: {{ salt['pillar.get']('deepsea_minions') }}
     - sls: ceph.metapackage
 
 common packages:
   salt.state:
-    - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
+    - tgt: {{ salt['pillar.get']('deepsea_minions') }}
     - tgt_type: compound
     - sls: ceph.packages.common
 
 sync:
   salt.state:
-    - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
+    - tgt: {{ salt['pillar.get']('deepsea_minions') }}
     - tgt_type: compound
     - sls: ceph.sync
 
 mines:
   salt.state:
-    - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
+    - tgt: {{ salt['pillar.get']('deepsea_minions') }}
     - tgt_type: compound
     - sls: ceph.mines
 
@@ -50,7 +50,7 @@ wait until the cluster has recovered before processing {{ host }}:
 
 check if all processes are still running after processing {{ host }}:
   salt.state:
-    - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
+    - tgt: {{ salt['pillar.get']('deepsea_minions') }}
     - tgt_type: compound
     - sls: ceph.processes
     - failhard: True
@@ -136,14 +136,14 @@ finishing remaining minions:
 
 updates:
   salt.state:
-    - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
+    - tgt: {{ salt['pillar.get']('deepsea_minions') }}
     - tgt_type: compound
     - sls: ceph.updates
 
 {% if grains.get('os_family', '') == 'Suse' %}
 restart:
   salt.state:
-    - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
+    - tgt: {{ salt['pillar.get']('deepsea_minions') }}
     - tgt_type: compound
     - sls: ceph.updates.restart
 {% endif %}

--- a/srv/salt/ceph/stage/prep/minion/default-update-reboot.sls
+++ b/srv/salt/ceph/stage/prep/minion/default-update-reboot.sls
@@ -74,6 +74,15 @@ set noout {{ host }}:
     - tgt: {{ salt['pillar.get']('master_minion') }}
     - failhard: True
 
+{% if grains.get('os_family', '') == 'Suse' %}
+restart {{ host }} if updates require:
+  salt.state:
+    - tgt: {{ host }}
+    - tgt_type: compound
+    - sls: ceph.updates.restart
+    - failhard: True
+{% endif %}
+
 finished {{ host }}:
   salt.runner:
     - name: minions.message
@@ -81,7 +90,7 @@ finished {{ host }}:
 
 {% endfor %}
 
-unset noout after final iteration: 
+unset noout after final iteration:
   salt.state:
     - sls: ceph.noout.unset
     - tgt: {{ salt['pillar.get']('master_minion') }}
@@ -98,6 +107,15 @@ updating minions without roles:
     - tgt_type: compound
     - sls: ceph.updates
     - failhard: True
+
+{% if grains.get('os_family', '') == 'Suse' %}
+restarting minions without roles:
+  salt.state:
+    - tgt: I@cluster:ceph
+    - tgt_type: compound
+    - sls: ceph.updates.restart
+    - failhard: True
+{% endif %}
 
 finishing remaining minions:
   salt.runner:
@@ -121,5 +139,13 @@ updates:
     - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
     - tgt_type: compound
     - sls: ceph.updates
+
+{% if grains.get('os_family', '') == 'Suse' %}
+restart:
+  salt.state:
+    - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
+    - tgt_type: compound
+    - sls: ceph.updates.restart
+{% endif %}
 
 {% endif %}

--- a/srv/salt/ceph/stage/prep/minion/default.sls
+++ b/srv/salt/ceph/stage/prep/minion/default.sls
@@ -74,13 +74,6 @@ set noout {{ host }}:
     - tgt: {{ salt['pillar.get']('master_minion') }}
     - failhard: True
 
-restart {{ host }} if updates required:
-  salt.state:
-    - tgt: {{ host }}
-    - tgt_type: compound
-    - sls: ceph.updates.restart
-    - failhard: True
-
 finished {{ host }}:
   salt.runner:
     - name: minions.message
@@ -106,13 +99,6 @@ updating minions without roles:
     - sls: ceph.updates
     - failhard: True
 
-restarting minions without roles:
-  salt.state:
-    - tgt: I@cluster:ceph
-    - tgt_type: compound
-    - sls: ceph.updates.restart
-    - failhard: True
-
 finishing remaining minions:
   salt.runner:
     - name: minions.message
@@ -135,11 +121,5 @@ updates:
     - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
     - tgt_type: compound
     - sls: ceph.updates
-
-restart:
-  salt.state:
-    - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
-    - tgt_type: compound
-    - sls: ceph.updates.restart
 
 {% endif %}

--- a/srv/salt/ceph/stage/prep/minion/default.sls
+++ b/srv/salt/ceph/stage/prep/minion/default.sls
@@ -1,29 +1,29 @@
 repo:
   salt.state:
-    - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
+    - tgt: {{ salt['pillar.get']('deepsea_minions') }}
     - tgt_type: compound
     - sls: ceph.repo
 
 metapackage minions:
   salt.state:
-    - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
+    - tgt: {{ salt['pillar.get']('deepsea_minions') }}
     - sls: ceph.metapackage
 
 common packages:
   salt.state:
-    - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
+    - tgt: {{ salt['pillar.get']('deepsea_minions') }}
     - tgt_type: compound
     - sls: ceph.packages.common
 
 sync:
   salt.state:
-    - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
+    - tgt: {{ salt['pillar.get']('deepsea_minions') }}
     - tgt_type: compound
     - sls: ceph.sync
 
 mines:
   salt.state:
-    - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
+    - tgt: {{ salt['pillar.get']('deepsea_minions') }}
     - tgt_type: compound
     - sls: ceph.mines
 
@@ -50,7 +50,7 @@ wait until the cluster has recovered before processing {{ host }}:
 
 check if all processes are still running after processing {{ host }}:
   salt.state:
-    - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
+    - tgt: {{ salt['pillar.get']('deepsea_minions') }}
     - tgt_type: compound
     - sls: ceph.processes
     - failhard: True
@@ -118,7 +118,7 @@ finishing remaining minions:
 
 updates:
   salt.state:
-    - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
+    - tgt: {{ salt['pillar.get']('deepsea_minions') }}
     - tgt_type: compound
     - sls: ceph.updates
 


### PR DESCRIPTION
~Fixes #1255~
backport of #1255 


Description: The current default for stage.0 is to always update and restart( if needed ) the node. To be less aggressive, we change the default to no-reboot-update.

Also update stage 0 and customization man pages.

Also created doc bugs: 1103242, 1103247, 1103248 and 1103249


-----------------

[Please find more information on how to run integration tests here](https://github.com/SUSE/DeepSea/wiki/Integration-tests)
