### PR TITLE
[RFC] Test determinism for proposal.generate

### DIFF
--- a/tests/unit/_modules/test_proposal.py
+++ b/tests/unit/_modules/test_proposal.py
@@ -182,24 +182,23 @@ class TestProposal(object):
         new_prop = replaced_disk[1]
         wal_db_replaced = replaced_disk[3]
 
-        results = list()
         for prop_name, prop in new_prop.items():
             for new_disk_set in prop:
                 matching_old_disk_set = [
-                    x for x in old_prop[prop_name] if x == new_disk_set
+                    x
+                    for x in old_prop[prop_name]
+                    if x.keys()[0] == new_disk_set.keys()[0]
                 ]
                 osd_disk = new_disk_set.keys()[0]
                 wal_db = new_disk_set.values()[0]
                 if matching_old_disk_set:
-                    assert osd_disk == matching_old_disk_set[0].keys()[0]
-                    assert wal_db == matching_old_disk_set[0].values()[0]
+                    old_disk = matching_old_disk_set[0].keys()[0]
+                    old_wal_db = matching_old_disk_set[0].values()[0]
+                    assert osd_disk == old_disk
+                    assert wal_db == old_wal_db
                 if "GENERATED" in osd_disk:
                     if prop_name != "standalone":
                         assert wal_db == wal_db_replaced[prop_name]
-
-        for res in results:
-            assert res is True
-        return True, [], osd_disk, wal_db, wal_db_replaced
 
     @pytest.mark.parametrize("execution_number", range(1, 1000))
     def test_determ_hdd(self, execution_number, replaced_disk_hdd):
@@ -243,10 +242,7 @@ class TestProposal(object):
         :param replaced_disk_hdd:
         :return:
         """
-        ret, found, osd_disk, wal_db, wal_db_replaced = self.is_deterministic(
-            replaced_disk_hdd
-        )
-        assert ret is True
+        self.is_deterministic(replaced_disk_hdd)
 
     @pytest.mark.parametrize("execution_number", range(1, 1000))
     def test_determ_ssd(self, execution_number, replaced_disk_ssd):
@@ -257,10 +253,7 @@ class TestProposal(object):
         :param replaced_disk_ssd:
         :return:
         """
-        ret, found, osd_disk, wal_db, wal_db_replaced = self.is_deterministic(
-            replaced_disk_ssd
-        )
-        assert ret is True
+        self.is_deterministic(replaced_disk_ssd)
 
     @pytest.mark.parametrize("execution_number", range(1, 1000))
     def test_determ_hdd_ratio_4(self, execution_number, replaced_disk_hdd_ratio_4):
@@ -271,10 +264,7 @@ class TestProposal(object):
         :param replaced_disk_ssd:
         :return:
         """
-        ret, found, osd_disk, wal_db, wal_db_replaced = self.is_deterministic(
-            replaced_disk_hdd_ratio_4
-        )
-        assert ret is True
+        self.is_deterministic(replaced_disk_hdd_ratio_4)
 
     @pytest.mark.parametrize("execution_number", range(1, 1000))
     def test_determ_nvme(self, execution_number, replaced_disk_nvme):
@@ -285,7 +275,4 @@ class TestProposal(object):
         :param replaced_disk_nvme:
         :return:
         """
-        ret, found, osd_disk, wal_db, wal_db_replaced = self.is_deterministic(
-            replaced_disk_nvme
-        )
-        assert ret is True
+        self.is_deterministic(replaced_disk_nvme)

--- a/tests/unit/_modules/test_proposal.py
+++ b/tests/unit/_modules/test_proposal.py
@@ -3,15 +3,15 @@
 import pytest
 import sys
 import random
-sys.path.insert(0, 'srv/salt/_modules')
+
+sys.path.insert(0, "srv/salt/_modules")
 from srv.salt._modules import proposal
 from srv.salt._modules import helper
 from tests.unit.helper.output import OutputHelper, GenHwinfo
 
 
 class TestProposal(object):
-
-    @pytest.fixture(scope='module')
+    @pytest.fixture(scope="module")
     def output_helper(self):
         yield OutputHelper()
 
@@ -25,33 +25,30 @@ class TestProposal(object):
 
     @pytest.fixture()
     def replaced_disk_ssd(self):
-        return self.replace_disk(type='ssd')
+        return self.replace_disk(type="ssd")
 
     @pytest.fixture()
     def replaced_disk_nvme(self):
-        return self.replace_disk(type='nvme')
+        return self.replace_disk(type="nvme")
 
     def test_parse_filter(self, output_helper):
         # test defaults
         p = proposal.Proposal([])
         self.check_proposal_init(p, 5, 5, 0, 0, 0, 0)
 
-        p = proposal.Proposal([], ratio=2, db_ratio=1,
-                              data='50', journal='20')
+        p = proposal.Proposal([], ratio=2, db_ratio=1, data="50", journal="20")
         self.check_proposal_init(p, 2, 1, 50, 0, 20, 0)
 
-        p = proposal.Proposal([], ratio=2, db_ratio=1,
-                              data='20-50', journal='5-20')
+        p = proposal.Proposal([], ratio=2, db_ratio=1, data="20-50", journal="5-20")
         self.check_proposal_init(p, 2, 1, 20, 50, 5, 20)
 
-        p = proposal.Proposal([], ratio=2, db_ratio=2,
-                              data='20-50', journal='5-20')
+        p = proposal.Proposal([], ratio=2, db_ratio=2, data="20-50", journal="5-20")
         self.check_proposal_init(p, 2, 2, 20, 50, 5, 20)
 
         with pytest.raises(AssertionError):
-            proposal.Proposal([], ratio=-3, data='20-50', journal='5-20')
-            proposal.Proposal([], ratio=2, data='50-20', journal='5-20')
-            proposal.Proposal([], ratio=2, data='50-60', journal='20-5')
+            proposal.Proposal([], ratio=-3, data="20-50", journal="5-20")
+            proposal.Proposal([], ratio=2, data="50-20", journal="5-20")
+            proposal.Proposal([], ratio=2, data="50-60", journal="20-5")
 
         p = proposal.Proposal(output_helper.cephdisks_output)
         assert len(p.nvme) is 1
@@ -59,12 +56,12 @@ class TestProposal(object):
         assert len(p.spinner) is 12
 
     def check_proposal_init(self, p, dr, dbr, dmi, dma, jmi, jma):
-        assert p.data_r is dr, 'data_r not correct'
-        assert p.db_r is dbr, 'db_r not correct'
-        assert p.data_max is dma, 'data_max not correct'
-        assert p.data_min is dmi, 'data_min not correct'
-        assert p.journal_max is jma, 'journal_max not correct'
-        assert p.journal_min is jmi, 'journal_min not correct'
+        assert p.data_r is dr, "data_r not correct"
+        assert p.db_r is dbr, "db_r not correct"
+        assert p.data_max is dma, "data_max not correct"
+        assert p.data_min is dmi, "data_min not correct"
+        assert p.journal_max is jma, "journal_max not correct"
+        assert p.journal_min is jmi, "journal_min not correct"
 
     def test_propose_standalone(self, output_helper):
         p = proposal.Proposal(output_helper.cephdisks_output)
@@ -103,8 +100,7 @@ class TestProposal(object):
         assert len(prop) is p.DEFAULT_DATA_R
 
         r = 4
-        p = proposal.Proposal(output_helper.cephdisks_output, ratio=r,
-                              leftovers=True)
+        p = proposal.Proposal(output_helper.cephdisks_output, ratio=r, leftovers=True)
         expected_len = r + (len(p.ssd) - r)
         prop = p._propose(p.ssd, p.nvme)
         assert len(prop) is expected_len
@@ -114,45 +110,42 @@ class TestProposal(object):
         # spinners: 1862 GB
         # ssds:     372 GB
         # nvme:     745 GB
-        p = proposal.Proposal(output_helper.cephdisks_output, ratio=3,
-                              data='500')
-        filtered = p._filter(p.spinner, 'data')
+        p = proposal.Proposal(output_helper.cephdisks_output, ratio=3, data="500")
+        filtered = p._filter(p.spinner, "data")
         assert len(filtered) is len(p.spinner)
-        filtered = p._filter(p.ssd, 'data')
+        filtered = p._filter(p.ssd, "data")
         assert len(filtered) is 0
 
-        p = proposal.Proposal(output_helper.cephdisks_output, ratio=3,
-                              data='500-800')
-        filtered = p._filter(p.spinner, 'data')
+        p = proposal.Proposal(output_helper.cephdisks_output, ratio=3, data="500-800")
+        filtered = p._filter(p.spinner, "data")
         assert len(filtered) is 0
-        filtered = p._filter(p.ssd, 'data')
+        filtered = p._filter(p.ssd, "data")
         assert len(filtered) is 0
-        filtered = p._filter(p.nvme, 'data')
+        filtered = p._filter(p.nvme, "data")
         assert len(filtered) is len(p.nvme)
 
-        p = proposal.Proposal(output_helper.cephdisks_output, ratio=3,
-                              journal='500-800')
-        filtered = p._filter(p.ssd, 'journal')
+        p = proposal.Proposal(
+            output_helper.cephdisks_output, ratio=3, journal="500-800"
+        )
+        filtered = p._filter(p.ssd, "journal")
         assert len(filtered) is 0
-        filtered = p._filter(p.nvme, 'journal')
+        filtered = p._filter(p.nvme, "journal")
         assert len(filtered) is len(p.nvme)
 
     def test_create(self, output_helper):
         p = proposal.Proposal(output_helper.cephdisks_output)
         prop = p.create()
-        assert len(prop['standalone']) is (len(p.ssd) + len(p.spinner) +
-                                           len(p.nvme))
-        assert len(prop['ssd-spinner']) is p.DEFAULT_DATA_R * 2
-        assert len(prop['nvme-ssd-spinner']) is 0
-        assert len(prop['nvme-ssd']) is p.DEFAULT_DATA_R
-        assert len(prop['nvme-spinner']) is p.DEFAULT_DATA_R
+        assert len(prop["standalone"]) is (len(p.ssd) + len(p.spinner) + len(p.nvme))
+        assert len(prop["ssd-spinner"]) is p.DEFAULT_DATA_R * 2
+        assert len(prop["nvme-ssd-spinner"]) is 0
+        assert len(prop["nvme-ssd"]) is p.DEFAULT_DATA_R
+        assert len(prop["nvme-spinner"]) is p.DEFAULT_DATA_R
 
-
-    def replace_disk(self, type='hdd', ratio=2):
+    def replace_disk(self, type="hdd", ratio=2):
         # idx 0-11 -> HDD
         # idx 12-17 -> SSD
         # idx 18 -> NVME
-        wal_db_replaced = None
+        wal_db_replaced = dict()
         hwinfo_out = OutputHelper().cephdisks_output
         p = proposal.Proposal(OutputHelper().cephdisks_output, ratio=ratio)
         old_prop = p.create()
@@ -170,42 +163,45 @@ class TestProposal(object):
         new_p = proposal.Proposal(hwinfo_out_new)
         new_prop = new_p.create()
 
-        for prop_name, prop in  old_prop.items():
+        for prop_name, prop in old_prop.items():
             for disk_set in old_prop[prop_name]:
                 # ensure that its a proposal with dedicated wal/db
-                if disk_set.keys()[0] in replaced_hdd['Device Files']:
-                    if prop_name in ['ssd-spinner', 'nvme-ssd-spinner', 'nvme-ssd', 'nvme-spinner']:
-                        wal_db_replaced = disk_set.values()[0]
-                        break
+                if disk_set.keys()[0] in replaced_hdd["Device Files"]:
+                    if prop_name in [
+                        "ssd-spinner",
+                        "nvme-ssd-spinner",
+                        "nvme-ssd",
+                        "nvme-spinner",
+                    ]:
+                        wal_db_replaced[prop_name] = disk_set.values()[0]
 
         return old_prop, new_prop, replaced_hdd, wal_db_replaced
 
     def is_deterministic(self, replaced_disk):
         old_prop = replaced_disk[0]
         new_prop = replaced_disk[1]
-        replaced_hdd = replaced_disk[2]
         wal_db_replaced = replaced_disk[3]
 
+        results = list()
         for prop_name, prop in new_prop.items():
-            for disk_set in old_prop[prop_name]:
-                matching_disk_from_old_prop = [x for x in prop if disk_set == x]
-                osd_disk = disk_set.keys()[0]
-                wal_db = disk_set.values()[0]
-                # iterate over old proposal
-                # find disk in new proposal
-                # compare wal-db mapping
+            for new_disk_set in prop:
+                matching_old_disk_set = [
+                    x for x in old_prop[prop_name] if x == new_disk_set
+                ]
+                osd_disk = new_disk_set.keys()[0]
+                wal_db = new_disk_set.values()[0]
+                if matching_old_disk_set:
+                    assert osd_disk == matching_old_disk_set[0].keys()[0]
+                    assert wal_db == matching_old_disk_set[0].values()[0]
+                if "GENERATED" in osd_disk:
+                    if prop_name != "standalone":
+                        assert wal_db == wal_db_replaced[prop_name]
 
-                if not matching_disk_from_old_prop and osd_disk not in replaced_hdd['Device Files']:
-                    if 'GENERATED' in osd_disk:
-                        if wal_db != wal_db_replaced:
-                            return False, matching_disk_from_old_prop, osd_disk, wal_db, wal_db_replaced
+        for res in results:
+            assert res is True
+        return True, [], osd_disk, wal_db, wal_db_replaced
 
-                if matching_disk_from_old_prop:
-                    assert osd_disk == matching_disk_from_old_prop[0].keys()[0]
-                    assert wal_db == matching_disk_from_old_prop[0].values()[0]
-                return True, [], osd_disk, wal_db, wal_db_replaced
-
-    @pytest.mark.parametrize('execution_number', range(1, 1000))
+    @pytest.mark.parametrize("execution_number", range(1, 1000))
     def test_determ_hdd(self, execution_number, replaced_disk_hdd):
         """
         This test tries to confirm determinism in profile.generate
@@ -247,10 +243,12 @@ class TestProposal(object):
         :param replaced_disk_hdd:
         :return:
         """
-        ret, found, osd_disk, wal_db, wal_db_replaced = self.is_deterministic(replaced_disk_hdd)
+        ret, found, osd_disk, wal_db, wal_db_replaced = self.is_deterministic(
+            replaced_disk_hdd
+        )
         assert ret is True
 
-    @pytest.mark.parametrize('execution_number', range(1, 1000))
+    @pytest.mark.parametrize("execution_number", range(1, 1000))
     def test_determ_ssd(self, execution_number, replaced_disk_ssd):
         """
         See docstring of test_determ_hdd.
@@ -259,10 +257,12 @@ class TestProposal(object):
         :param replaced_disk_ssd:
         :return:
         """
-        ret, found, osd_disk, wal_db, wal_db_replaced = self.is_deterministic(replaced_disk_ssd)
+        ret, found, osd_disk, wal_db, wal_db_replaced = self.is_deterministic(
+            replaced_disk_ssd
+        )
         assert ret is True
 
-    @pytest.mark.parametrize('execution_number', range(1, 1000))
+    @pytest.mark.parametrize("execution_number", range(1, 1000))
     def test_determ_hdd_ratio_4(self, execution_number, replaced_disk_hdd_ratio_4):
         """
         See docstring of test_determ_hdd.
@@ -271,10 +271,12 @@ class TestProposal(object):
         :param replaced_disk_ssd:
         :return:
         """
-        ret, found, osd_disk, wal_db, wal_db_replaced = self.is_deterministic(replaced_disk_hdd_ratio_4)
+        ret, found, osd_disk, wal_db, wal_db_replaced = self.is_deterministic(
+            replaced_disk_hdd_ratio_4
+        )
         assert ret is True
 
-    @pytest.mark.parametrize('execution_number', range(1, 1000))
+    @pytest.mark.parametrize("execution_number", range(1, 1000))
     def test_determ_nvme(self, execution_number, replaced_disk_nvme):
         """
         See docstring of test_determ_hdd.
@@ -283,5 +285,7 @@ class TestProposal(object):
         :param replaced_disk_nvme:
         :return:
         """
-        ret, found, osd_disk, wal_db, wal_db_replaced = self.is_deterministic(replaced_disk_nvme)
+        ret, found, osd_disk, wal_db, wal_db_replaced = self.is_deterministic(
+            replaced_disk_nvme
+        )
         assert ret is True

--- a/tests/unit/helper/output.py
+++ b/tests/unit/helper/output.py
@@ -1,3 +1,6 @@
+from random import choice, randint
+import string
+
 class OutputHelper(object):
     def __init__(self, **kwargs):
         self.lsscsi_with_raid_fail = \
@@ -759,3 +762,70 @@ class OutputHelper(object):
         self.salt_versions = {'data4.ceph': '2016.11.4', 'data3.ceph': '2016.11.4', 'admin.ceph': '2016.11.4', 'mon2.ceph': '2016.11.4', 'mon3.ceph': '2016.11.4', 'mon1.ceph': '2016.11.4', 'data5.ceph': '2016.11.4', 'data1.ceph': '2016.11.4', 'data2.ceph': '2016.11.4'}
 
         self.os_codenames = {'data4.ceph': 'SUSE Linux Enterprise Server 12 SP3', 'data3.ceph': 'SUSE Linux Enterprise Server 12 SP3', 'admin.ceph': 'SUSE Linux Enterprise Server 12 SP3', 'mon2.ceph': 'SUSE Linux Enterprise Server 12 SP3', 'mon3.ceph': 'SUSE Linux Enterprise Server 12 SP3', 'data2.ceph': 'SUSE Linux Enterprise Server 12 SP3', 'data5.ceph': 'SUSE Linux Enterprise Server 12 SP3', 'data1.ceph': 'SUSE Linux Enterprise Server 12 SP3', 'mon1.ceph': 'SUSE Linux Enterprise Server 12 SP3'}
+
+
+class GenHwinfo(object):
+
+    def __init__(self, **kwargs):
+        """
+        Generating a object that represents a return
+        from 'hwinfo'
+
+        :param kwargs:
+        """
+        self._type = kwargs.get('type', 'hdd')
+        self.attached_to_nr = str(kwargs.get('attached_to', randint(1, 100)))
+        self.capacity = kwargs.get('capacity', 745)
+        self.bytes = kwargs.get('bytes', '800166076416')
+        if kwargs.get('random_type', False):
+            self.random_type()
+
+    def generate(self):
+        self.set_attr()
+        return {'Attached to': self._attached_to_str,
+                'Bytes': self.bytes,
+                'Capacity': '{} GB'.format(self.capacity),
+                'Device File': self._device_file,
+                'Device Files': '{}, {}'.format(self._device_file, self._dev_by_id),
+                'Device Number': 'block {}:1'.format(self._device_number),
+                'Driver': self._driver,
+                'Driver Modules': self._driver,
+                'Model': 'Intel DC P{} {}'.format(self._model_ident, self._type.upper()),
+                'device': self._device,
+                'rotational': self._rotational}
+
+
+    def set_attr(self):
+        self.disk_ident = choice(string.ascii_letters)
+        self.nvme_ident = randint(1, 50)
+        self._device_file = '/dev/sd{}'.format(self.disk_ident.lower())
+        self._device = '/dev/sd{}'.format(self.disk_ident.lower())
+        self._device_number = randint(200, 300)
+        alphanum_rand = ''.join(choice('0123456789abcdef') for i in range(32))
+        self._model_ident = randint(600, 800)
+        self._dev_by_id = '/dev/disk/by-id/scsi-SDELL_PERC_H{}_{}_GENERATED'.format(self._model_ident, alphanum_rand)
+        self._driver = 'ahci'
+
+        if self._type == 'nvme':
+            self._device_file = '/dev/nvme{}n1'.format(self.nvme_ident)
+            self._device = 'nvme{}n1'.format(self.nvme_ident)
+            self._rotational = '0'
+            self._attached_to_str = '#{} (Non-Volatile memory controller)'.format(self.attached_to_nr)
+            self._driver = 'nvme'
+
+        if self._type == 'hdd':
+            self._rotational = '1'
+            self._attached_to_str = '#{} (SATA controller)'.format(self.attached_to_nr)
+
+        if self._type == 'hddraid':
+            self._rotational = '1'
+            self._attached_to_str = '#{} (RAID Bus controller)'.format(self.attached_to_nr)
+
+        if self._type == 'ssd':
+            self._rotational = '0'
+            self._attached_to_str = '#{} (SATA controller)'.format(self.attached_to_nr)
+
+    def random_type(self):
+        types = ['hdd', 'nvme', 'hddraid', 'ssd']
+        self._type = choice(types)
+


### PR DESCRIPTION
Signed-off-by: Joshua Schmid <jschmid@suse.de>

Addresses #1215 ( Adding verify tests for this )

Description:

I'm not sure if that actually proves it. Please review thoroughly!

```
        Theory:
        The fear is that in a 'replace-disk' operation we _may_ end up with
        different osd - wal/db mappings than before. This would mean that
        a user will have to edit the profiles manually or face a migration.
        We never introduced pre-sorting of disk information that we get from
        hwinfo, which means that we can't guarantee a consistently sorted
        input.

        In order to test this, I try to do the following:

        1) Generate a profile
        2) 'replace' a disk ( replaced.disk() )
        2.1) Generate a 'new' disk ( suffixed with '_GENERATED' )
        2.2) Inject it a at a random index in the output from hwinfo
        2.3) Find the old, replaced disk to compare the wal/db pointer
        3) Compare the new and the old proposal for a match of
           old wal/db pointer and the new wal/db pointer

        To eliminate the factor of 'luck', repeat if 1000 times.

        Caveat:
          * Currently we are only testing if the newly replaced disk
            is matching it's old entry.
            Maybe we should test it for _every_ disk.
EDIT:    ->> I do. <<-
          * The number of repetitions could me reduced by adding more disks
            and therefore an increase in probability of a 'missplacement'
          * We have 3k tests more :/
```



-----------------

[Please find more information on how to run integration tests here](https://github.com/SUSE/DeepSea/wiki/Integration-tests)
