### PR TITLE
Add an option to disable write cache of the rotational disks

### DIFF
--- a/srv/salt/_modules/cephdisks.py
+++ b/srv/salt/_modules/cephdisks.py
@@ -512,6 +512,31 @@ def list_(**kwargs):
     return hwd.assemble_device_list()
 
 
+def disable_write_cache(disk=None, persistent=False, **kwargs):
+    """
+    Disable write cache (WCE) on rotational disks
+    """
+    hwd = HardwareDetections(**kwargs)
+    sdparm_path = hwd._which('sdparm')
+    base_disk_path = "/sys/block/{}".format(disk)
+    disk_path = "/dev/{}".format(disk)
+
+    if persistent:
+        cmd = "{} --clear=WCE --save {}".format(sdparm_path, disk_path)
+    else:
+        cmd = "{} --clear=WCE {}".format(sdparm_path, disk_path)
+
+    if hwd._is_rotational(base_disk_path):
+        proc = Popen(cmd, stdout=PIPE, stderr=PIPE, shell=True)
+        stdout, stderr = proc.communicate()
+        if stderr:
+            log.warning("Could not change write cache settings for {}".format(disk))
+            return False
+    else:
+        log.warning("Disk {} is not rotational".format(disk))
+        return False
+    return True
+
 def version():
     """
     Displays version


### PR DESCRIPTION
Fixes #1238 

When ever we have spinning disks that do not have battery backed write cache - we have to disable the write cache to ensure data-consistency also in case of power outages.

Description:

This sdparm command does not always work with the --save parameter, hense the persistent=False default argument. Apparently the special manufacturer specific utility is needed for disabling WCE.
But with some manufacturers sdparm is enough.


-----------------

[Please find more information on how to run integration tests here](https://github.com/SUSE/DeepSea/wiki/Integration-tests)
