### PR TITLE
[backport][SES5] Invoke `find` to fix salt job cache permissions

### DIFF
--- a/srv/salt/ceph/configuration/create/default.sls
+++ b/srv/salt/ceph/configuration/create/default.sls
@@ -13,6 +13,7 @@ removing minion cache:
     - makedirs: True
     - fire_event: True
 
-
-
+fix salt job cache permissions:
+  cmd.run:
+  - name: "find /var/cache/salt/master/jobs -user root -exec chown {{ salt['deepsea.user']() }}:{{ salt['deepsea.group']() }} {} ';'"
 

--- a/srv/salt/ceph/ganesha/auth/default.sls
+++ b/srv/salt/ceph/ganesha/auth/default.sls
@@ -15,4 +15,7 @@ auth {{ keyring_file }}:
 {% endfor %}
 {% endfor %}
 
+fix salt job cache permissions:
+  cmd.run:
+  - name: "find /var/cache/salt/master/jobs -user root -exec chown {{ salt['deepsea.user']() }}:{{ salt['deepsea.group']() }} {} ';'"
 

--- a/srv/salt/ceph/ganesha/config/default.sls
+++ b/srv/salt/ceph/ganesha/config/default.sls
@@ -37,3 +37,8 @@ check {{ role }}:
 
 {% endfor %}
 {% endfor %}
+
+fix salt job cache permissions:
+  cmd.run:
+  - name: "find /var/cache/salt/master/jobs -user root -exec chown {{ salt['deepsea.user']() }}:{{ salt['deepsea.group']() }} {} ';'"
+

--- a/srv/salt/ceph/ganesha/key/default.sls
+++ b/srv/salt/ceph/ganesha/key/default.sls
@@ -31,4 +31,7 @@ check {{ role }}:
 {% endfor %}
 {% endfor %}
 
+fix salt job cache permissions:
+  cmd.run:
+  - name: "find /var/cache/salt/master/jobs -user root -exec chown {{ salt['deepsea.user']() }}:{{ salt['deepsea.group']() }} {} ';'"
 

--- a/srv/salt/ceph/igw/auth/default.sls
+++ b/srv/salt/ceph/igw/auth/default.sls
@@ -12,3 +12,8 @@ auth {{ keyring_file }}:
     - name: "ceph auth add {{ client }} -i {{ keyring_file }}"
 
 {% endfor %}
+
+fix salt job cache permissions:
+  cmd.run:
+  - name: "find /var/cache/salt/master/jobs -user root -exec chown {{ salt['deepsea.user']() }}:{{ salt['deepsea.group']() }} {} ';'"
+

--- a/srv/salt/ceph/igw/config/default.sls
+++ b/srv/salt/ceph/igw/config/default.sls
@@ -39,4 +39,7 @@ clear master file cache:
 
 {% endif %}
 
+fix salt job cache permissions:
+  cmd.run:
+  - name: "find /var/cache/salt/master/jobs -user root -exec chown {{ salt['deepsea.user']() }}:{{ salt['deepsea.group']() }} {} ';'"
 

--- a/srv/salt/ceph/igw/key/default.sls
+++ b/srv/salt/ceph/igw/key/default.sls
@@ -20,3 +20,8 @@ prevent empty rendering:
       secret: {{ salt['keyring.secret'](keyring_file) }}
 
 {% endfor %}
+
+fix salt job cache permissions:
+  cmd.run:
+  - name: "find /var/cache/salt/master/jobs -user root -exec chown {{ salt['deepsea.user']() }}:{{ salt['deepsea.group']() }} {} ';'"
+

--- a/srv/salt/ceph/mds/auth/default.sls
+++ b/srv/salt/ceph/mds/auth/default.sls
@@ -13,4 +13,7 @@ auth {{ keyring_file }}:
 
 {% endfor %}
 
+fix salt job cache permissions:
+  cmd.run:
+  - name: "find /var/cache/salt/master/jobs -user root -exec chown {{ salt['deepsea.user']() }}:{{ salt['deepsea.group']() }} {} ';'"
 

--- a/srv/salt/ceph/mds/key/default.sls
+++ b/srv/salt/ceph/mds/key/default.sls
@@ -22,4 +22,7 @@ prevent empty rendering:
 
 {% endfor %}
 
+fix salt job cache permissions:
+  cmd.run:
+  - name: "find /var/cache/salt/master/jobs -user root -exec chown {{ salt['deepsea.user']() }}:{{ salt['deepsea.group']() }} {} ';'"
 

--- a/srv/salt/ceph/mds/pools/default.sls
+++ b/srv/salt/ceph/mds/pools/default.sls
@@ -36,3 +36,7 @@ cephfs:
 
 {% endif %}
 
+fix salt job cache permissions:
+  cmd.run:
+  - name: "find /var/cache/salt/master/jobs -user root -exec chown {{ salt['deepsea.user']() }}:{{ salt['deepsea.group']() }} {} ';'"
+

--- a/srv/salt/ceph/mgr/auth/default.sls
+++ b/srv/salt/ceph/mgr/auth/default.sls
@@ -13,4 +13,7 @@ auth {{ keyring_file }}:
 
 {% endfor %}
 
+fix salt job cache permissions:
+  cmd.run:
+  - name: "find /var/cache/salt/master/jobs -user root -exec chown {{ salt['deepsea.user']() }}:{{ salt['deepsea.group']() }} {} ';'"
 

--- a/srv/salt/ceph/mgr/key/default.sls
+++ b/srv/salt/ceph/mgr/key/default.sls
@@ -22,4 +22,7 @@ prevent empty rendering:
 
 {% endfor %}
 
+fix salt job cache permissions:
+  cmd.run:
+  - name: "find /var/cache/salt/master/jobs -user root -exec chown {{ salt['deepsea.user']() }}:{{ salt['deepsea.group']() }} {} ';'"
 

--- a/srv/salt/ceph/monitoring/default.sls
+++ b/srv/salt/ceph/monitoring/default.sls
@@ -3,3 +3,8 @@ include:
   - .prometheus.update_service_discovery
   - .prometheus.alertmanager
   - .grafana
+
+fix salt job cache permissions:
+  cmd.run:
+  - name: "find /var/cache/salt/master/jobs -user root -exec chown {{ salt['deepsea.user']() }}:{{ salt['deepsea.group']() }} {} ';'"
+

--- a/srv/salt/ceph/remove/ganesha/default.sls
+++ b/srv/salt/ceph/remove/ganesha/default.sls
@@ -14,3 +14,8 @@ auth {{ keyring }}:
 {% endfor %}
 {% endfor %}
 {% endif %}
+
+fix salt job cache permissions:
+  cmd.run:
+  - name: "find /var/cache/salt/master/jobs -user root -exec chown {{ salt['deepsea.user']() }}:{{ salt['deepsea.group']() }} {} ';'"
+

--- a/srv/salt/ceph/remove/mds/default.sls
+++ b/srv/salt/ceph/remove/mds/default.sls
@@ -22,3 +22,7 @@ remove data:
 
 {% endif %}
 
+fix salt job cache permissions:
+  cmd.run:
+  - name: "find /var/cache/salt/master/jobs -user root -exec chown {{ salt['deepsea.user']() }}:{{ salt['deepsea.group']() }} {} ';'"
+

--- a/srv/salt/ceph/remove/mgr/default.sls
+++ b/srv/salt/ceph/remove/mgr/default.sls
@@ -10,3 +10,8 @@ remove mgr auth:
 
 
 {% endif %}
+
+fix salt job cache permissions:
+  cmd.run:
+  - name: "find /var/cache/salt/master/jobs -user root -exec chown {{ salt['deepsea.user']() }}:{{ salt['deepsea.group']() }} {} ';'"
+

--- a/srv/salt/ceph/remove/migrated/default.sls
+++ b/srv/salt/ceph/remove/migrated/default.sls
@@ -18,3 +18,7 @@ remove id {{ id }}:
 
 {% endfor %}
 
+fix salt job cache permissions:
+  cmd.run:
+  - name: "find /var/cache/salt/master/jobs -user root -exec chown {{ salt['deepsea.user']() }}:{{ salt['deepsea.group']() }} {} ';'"
+

--- a/srv/salt/ceph/remove/mon/default.sls
+++ b/srv/salt/ceph/remove/mon/default.sls
@@ -10,3 +10,7 @@ remove mon.{{ minion }}:
 {% endif %}
 {% endfor %}
 
+fix salt job cache permissions:
+  cmd.run:
+  - name: "find /var/cache/salt/master/jobs -user root -exec chown {{ salt['deepsea.user']() }}:{{ salt['deepsea.group']() }} {} ';'"
+

--- a/srv/salt/ceph/remove/openattic/default.sls
+++ b/srv/salt/ceph/remove/openattic/default.sls
@@ -9,3 +9,8 @@ remove openattic auth:
     - name: "ceph auth del client.openattic"
 
 {% endif %}
+
+fix salt job cache permissions:
+  cmd.run:
+  - name: "find /var/cache/salt/master/jobs -user root -exec chown {{ salt['deepsea.user']() }}:{{ salt['deepsea.group']() }} {} ';'"
+

--- a/srv/salt/ceph/remove/rgw/default.sls
+++ b/srv/salt/ceph/remove/rgw/default.sls
@@ -34,3 +34,7 @@ remove rgw users.uid:
 
 {% endif %}
 
+fix salt job cache permissions:
+  cmd.run:
+  - name: "find /var/cache/salt/master/jobs -user root -exec chown {{ salt['deepsea.user']() }}:{{ salt['deepsea.group']() }} {} ';'"
+

--- a/srv/salt/ceph/remove/storage/default.sls
+++ b/srv/salt/ceph/remove/storage/default.sls
@@ -18,3 +18,7 @@ remove id {{ id }}:
 
 {% endfor %}
 
+fix salt job cache permissions:
+  cmd.run:
+  - name: "find /var/cache/salt/master/jobs -user root -exec chown {{ salt['deepsea.user']() }}:{{ salt['deepsea.group']() }} {} ';'"
+

--- a/srv/salt/ceph/rgw/auth/default.sls
+++ b/srv/salt/ceph/rgw/auth/default.sls
@@ -15,4 +15,7 @@ auth {{ keyring_file }}:
 {% endfor %}
 {% endfor %}
 
+fix salt job cache permissions:
+  cmd.run:
+  - name: "find /var/cache/salt/master/jobs -user root -exec chown {{ salt['deepsea.user']() }}:{{ salt['deepsea.group']() }} {} ';'"
 

--- a/srv/salt/ceph/rgw/key/default.sls
+++ b/srv/salt/ceph/rgw/key/default.sls
@@ -31,4 +31,7 @@ check {{ role }}:
 {% endfor %}
 {% endfor %}
 
+fix salt job cache permissions:
+  cmd.run:
+  - name: "find /var/cache/salt/master/jobs -user root -exec chown {{ salt['deepsea.user']() }}:{{ salt['deepsea.group']() }} {} ';'"
 


### PR DESCRIPTION
```
When there's a lot of files in the salt job cache, using salt's
builtin file.directory construct is remarkably slow.  Let's start
with about 10,000 files in the cache, all correctly owned:

  # find /var/cache/salt/master/jobs | wc -l
  9920
  # find /var/cache/salt/master/jobs -user root | wc -l
  0

Then, run ceph.stage.2:

  # salt-run state.orch ceph.stage.2
  [...]
  Summary for admin.ceph_master
  -------------
  Succeeded: 14 (changed=10)
  Failed:     0
  -------------
  Total states run:     14
  Total run time:  409.141 s

That's 409 seconds, or a bit under seven minutes.  Now, with this
change applied, which instead invokes `find ... -exec chown ...`,
it only takes a minute twenty, which is quite a bit better:

  # salt-run state.orch ceph.stage.2
  [...]
  Summary for admin.ceph_master
  -------------
  Succeeded: 14 (changed=10)
  Failed:     0
  -------------
  Total states run:     14
  Total run time:   82.443 s

Fixes: https://github.com/SUSE/DeepSea/issues/1131
Signed-off-by: Tim Serong <tserong@suse.com>
(cherry picked from commit 24b40ce35211b02b9b32f47d57c22c981e85cff8)

```

backport of #1175 

-----------------

**Checklist:**
- [x] Added unittests and or functional tests ( not needed )
- [x] Adapted documentation ( not needed )
- [x] Referenced issues or internal bugtracker
- [x] Ran integration tests successfully ( trigger with @susebot run teuthology )
