### PR TITLE
[backport][ses5] Install smartmontools while stage.0

### DIFF
--- a/srv/salt/ceph/packages/common/default.sls
+++ b/srv/salt/ceph/packages/common/default.sls
@@ -15,6 +15,7 @@ stage prep dependencies suse:
   pkg.installed:
     - pkgs:
       - lsscsi
+      - smartmontools
       - pciutils
       - gptfdisk
       - python-boto
@@ -34,6 +35,7 @@ stage prep dependencies ubuntu:
   pkg.installed:
     - pkgs:
       - lsscsi
+      - smartmontools
       - pciutils
       - gdisk
       - python-boto


### PR DESCRIPTION
Signed-off-by: Joshua Schmid <jschmid@suse.de>
(cherry picked from commit a43a314b74387df9cb833f6460d857731f93feea)

backport of #1268 


-----------------

**Checklist:**
- [ ] Added unittests and or functional tests
- [ ] Adapted documentation
- [ ] Referenced issues or internal bugtracker
- [ ] Ran integration tests successfully ( trigger with @susebot run teuthology )
