### PR TITLE
qa/deploy: handle possibility that deepsea-cli is not installed

### DIFF
--- a/qa/common/deploy.sh
+++ b/qa/common/deploy.sh
@@ -122,7 +122,7 @@ function initialization_sequence {
     python --version || true
     python2 --version || true
     python3 --version
-    deepsea --version
+    deepsea --version || true
     _set_deepsea_minions
     _initialize_minion_array
     _update_salt


### PR DESCRIPTION
When installing DeepSea from packages, the "deepsea-cli" package might
not get installed (it is not strictly required), and depending on which tests
are being run, the absence of the CLI might not be a problem.

In any case, there is no reason why failure of "deepsea --version" should
fail the entire test.

Signed-off-by: Nathan Cutler <ncutler@suse.com>

Fixes #


Description:


-----------------

**Checklist:**
- [ ] Added unittests and or functional tests
- [ ] Adapted documentation
- [ ] Referenced issues or internal bugtracker
- [ ] Ran integration tests successfully ( trigger with @susebot run teuthology )
