### PR TITLE
rescind: prevent empty rendering of ceph.rescind.tuned state file

### DIFF
--- a/srv/salt/ceph/rescind/tuned/default.sls
+++ b/srv/salt/ceph/rescind/tuned/default.sls
@@ -1,3 +1,7 @@
+prevent empty rendering:
+  test.nop:
+    - name: skip
+
 {% set roles = salt['pillar.get']('roles') %}
 
 {% if 'storage' not in roles and 'mon' not in roles and


### PR DESCRIPTION
Signed-off-by: Nathan Cutler <ncutler@suse.com>
(cherry picked from commit 4789754a253e1700406ad19c0b2376e47fffd7ca)
