### PR TITLE
Use fqdn for default minion name in template

### DIFF
--- a/srv/salt/ceph/igw/files/lrbd.conf.j2
+++ b/srv/salt/ceph/igw/files/lrbd.conf.j2
@@ -9,7 +9,7 @@
     "targets": [
         {
             "hosts": [
-{% for minion in salt.saltutil.runner('select.minions', cluster='ceph', roles='igw', host=True) %}
+{% for minion in salt.saltutil.runner('select.minions', cluster='ceph', roles='igw') %}
                 {
                     "host": "{{ minion }}",
                     "portal": "portal-{{ minion }}"
@@ -25,7 +25,7 @@
         }
     ],
     "portals": [
-{% for minion, address in salt.saltutil.runner('select.public_addresses', cluster='ceph', roles='igw', tuples=True, host=True) %}
+{% for minion, address in salt.saltutil.runner('select.public_addresses', cluster='ceph', roles='igw', tuples=True) %}
         {
             "name": "portal-{{ minion }}",
             "addresses": [


### PR DESCRIPTION
lrbd matches on either short name or fqdn, so the template matches the original behavior and is no longer necesary.

Signed-off-by: Eric Jackson <ejackson@suse.com>
bnc#1102455
-----------------

**Checklist:**
- [ ] Added unittests and or functional tests
- [ ] Adapted documentation
- [ ] Referenced issues or internal bugtracker
- [ ] Ran integration tests successfully ( trigger with @susebot run teuthology )
