### PR TITLE
qa:  common/helper: storage-only node might be master node 

### DIFF
--- a/qa/common/helper.sh
+++ b/qa/common/helper.sh
@@ -135,7 +135,6 @@ mds
 rgw
 igw
 ganesha
-master
 "
     local ROLE=
     for ROLE in $NOT_ROLES ; do

--- a/qa/common/helper.sh
+++ b/qa/common/helper.sh
@@ -140,7 +140,8 @@ ganesha
     for ROLE in $NOT_ROLES ; do
         COMPOUND_TARGET="$COMPOUND_TARGET and not I@roles:$ROLE"
     done
-    salt --static --out json -C "$COMPOUND_TARGET" test.ping 2>/dev/null | jq -r 'keys[0]'
+    local MAYBEJSON=$(salt --static --out json -C "$COMPOUND_TARGET" test.ping 2>/dev/null)
+    echo $MAYBEJSON | jq --raw-output 'keys[0]'
 }
 
 function _run_test_script_on_node {


### PR DESCRIPTION
Fixes #1282


Description:

Fixes a case where CI tests fail bogusly.

-----------------

**Checklist:**
~~- [ ] Added unittests and or functional tests~~
~~- [ ] Adapted documentation~~
- [x] Referenced issues or internal bugtracker
- [ ] Ran integration tests successfully ( trigger with @susebot run teuthology )
