### PR TITLE
[backport][ses5] Use fqdn for default minion name in template

### DIFF
--- a/srv/salt/ceph/igw/files/lrbd.conf.j2
+++ b/srv/salt/ceph/igw/files/lrbd.conf.j2
@@ -9,7 +9,7 @@
     "targets": [
         {
             "hosts": [
-{% for minion in salt.saltutil.runner('select.minions', cluster='ceph', roles='igw', host=True) %}
+{% for minion in salt.saltutil.runner('select.minions', cluster='ceph', roles='igw') %}
                 {
                     "host": "{{ minion }}",
                     "portal": "portal-{{ minion }}"
@@ -25,7 +25,7 @@
         }
     ],
     "portals": [
-{% for minion, address in salt.saltutil.runner('select.public_addresses', cluster='ceph', roles='igw', tuples=True, host=True) %}
+{% for minion, address in salt.saltutil.runner('select.public_addresses', cluster='ceph', roles='igw', tuples=True) %}
         {
             "name": "portal-{{ minion }}",
             "addresses": [


### PR DESCRIPTION
Signed-off-by: Eric Jackson <ejackson@suse.com>
(cherry picked from commit 496ff30a67b193e9f77e3c5e63c6c7cc470e94c6)

backport of #1281 

-----------------

**Checklist:**
- [ ] Added unittests and or functional tests
- [ ] Adapted documentation
- [ ] Referenced issues or internal bugtracker
- [ ] Ran integration tests successfully ( trigger with @susebot run teuthology )
