### PR TITLE
populate: don't create role-mon yml line during engulf (bsc#1104781)

### DIFF
--- a/srv/modules/runners/populate.py
+++ b/srv/modules/runners/populate.py
@@ -1144,7 +1144,6 @@ def engulf_existing_cluster(**kwargs):
         if "ceph-mon" in info["running_services"]:
             mon_minions.append(minion)
             policy_cfg.append("role-mon/cluster/" + minion + ".sls")
-            policy_cfg.append("role-mon/stack/default/ceph/minions/" + minion + ".yml")
             for minion, ipaddrs in local.cmd(minion,
                                              "cephinspector.get_minion_public_networks",
                                              [], tgt_type="compound").items():


### PR DESCRIPTION
Engulf shouldn't create policy.cfg lines referencing role-mon yml files,
as these are no longer created since the following commits:

- https://github.com/SUSE/DeepSea/commit/59123bbf (master)
- https://github.com/SUSE/DeepSea/commit/87ffece9 (SES5)

Signed-off-by: Tim Serong <tserong@suse.com>