### PR TITLE
cephinspector: use cephdisks.device in engulf (bsc#1082994)

### DIFF
--- a/srv/salt/_modules/cephinspector.py
+++ b/srv/salt/_modules/cephinspector.py
@@ -73,18 +73,14 @@ def _get_device_of_partition(partition):
 def _get_disk_id(partition):
     """
     Return the disk id of a partition/device, or the original partition/device if
-    the disk id is not available.
+    the disk id is not available.  This is essentially the same thing as _uuid_device()
+    in srv/salt/_modules/osd.py
     """
-    disk_id_cmd = Popen("find -L /dev/disk/by-id -samefile " + partition +
-                        r" \( -name ata* -o -name nvme* \)", stdout=PIPE,
-                        stderr=PIPE, shell=True)
-    # pylint: disable=unused-variable
-    out, err = disk_id_cmd.communicate()
+    if os.path.exists(partition) and os.path.exists("/dev/disk/by-id"):
+        devicename = __salt__['cephdisks.device'](partition)
+        if devicename:
+            return devicename
 
-    # We should only ever have one entry that we return.
-    if out:
-        out = __salt__['helper.convert_out'](out)
-        return out.split()[-1]
     return partition
 
 


### PR DESCRIPTION
This ensures the same code is used for determining /dev/disk/by-id paths
during engulf, as is used when invoking stage.1 to generate profiles.

Fixes: https://github.com/SUSE/DeepSea/issues/1264
Signed-off-by: Tim Serong <tserong@suse.com>

-----------------

**Checklist:**
- [ ] Added unittests and or functional tests
- [ ] Adapted documentation
- [x] Referenced issues or internal bugtracker
- [ ] Ran integration tests successfully ( trigger with @susebot run teuthology )
