### PR TITLE
[backport][ses5] Add unittests for wait.just

### DIFF
--- a/srv/salt/_modules/wait.py
+++ b/srv/salt/_modules/wait.py
@@ -1,10 +1,15 @@
 # -*- coding: utf-8 -*-
 
-import rados
 import json
 import time
 import logging
+# pylint: disable=import-error,3rd-party-module-not-gated
+try:
+    import rados
+except ImportError:
+    logging.info("Could not import rados")
 
+# pylint: disable=incompatible-py3-code
 log = logging.getLogger(__name__)
 
 

--- a/tests/unit/_modules/test_wait.py
+++ b/tests/unit/_modules/test_wait.py
@@ -1,0 +1,28 @@
+import pytest
+import sys
+sys.path.insert(0, 'srv/salt/_modules')
+from srv.salt._modules import wait
+from mock import MagicMock, mock
+
+DEFAULT_MODULE = wait
+
+
+class TestHealthStatusCheck(object):
+
+    """ Unittests for HealthStatusCheck """
+    @pytest.fixture()
+    def wait(self):
+        wait.rados = MagicMock()
+        yield wait
+
+    @mock.patch('srv.salt._modules.wait.time')
+    def test_just(self, time_mock, wait):
+        kwargs = {'status': "HEALTH_OK"}
+        wait.just(**kwargs)
+        time_mock.sleep.assert_called_with(6)
+
+    @mock.patch('srv.salt._modules.wait.time')
+    def test_just_custom_delay(self, time_mock, wait):
+        kwargs = {'status': "HEALTH_OK", 'delay': 7}
+        wait.just(**kwargs)
+        time_mock.sleep.assert_called_with(7)


### PR DESCRIPTION
Signed-off-by: Joshua Schmid <jschmid@suse.de>
(cherry picked from commit 3626d246766851ea673877981e32964c29cee965)

backport of #1298 

-----------------

**Checklist:**
- [x] Added unittests and or functional tests
~- [ ] Adapted documentation~
- [x] Referenced issues or internal bugtracker
- [ ] Ran integration tests successfully ( trigger with @susebot run teuthology )
