### PR TITLE
OSD Migration for changed disk slots

### DIFF
--- a/srv/modules/runners/proposal.py
+++ b/srv/modules/runners/proposal.py
@@ -6,19 +6,24 @@ Generates the hardware profiles for a minion
 from __future__ import absolute_import
 from __future__ import print_function
 import pprint
-from os.path import isdir, isfile
+from os.path import isdir, isfile, join
 import os
+import re
+
 # pylint: disable=redefined-builtin
 from sys import exit
 import logging
+from collections import namedtuple
+
 # pylint: disable=import-error,3rd-party-module-not-gated,redefined-builtin
 import salt.client
 import yaml
+
 # pylint: disable=import-error
 
 log = logging.getLogger(__name__)
 
-USAGE = '''
+USAGE = """
 The proposal runner compiles and either shows or writes storage profile
 proposals. It offers two methods: 'peek' and 'populate'.
 The 'peek' method simply collects the proposals from the minions and displays
@@ -86,7 +91,7 @@ List of recognized parameters and their defaults:
                     number with a unit suffix. Unit suffix' as accepted by
                     sgdisk can be used, i.e. kibibytes (K), mebibytes (M),
                     gibibytes (G), tebibytes (T), or pebibytes (P).
-'''
+"""
 
 
 # pylint: disable=too-few-public-methods
@@ -94,44 +99,48 @@ class Target(object):
     """
     Wrapperclass around __utils__ to avoid early access to dunders
     """
+
     @staticmethod
     def show():
         """
         Wraps deepsea_minions.show
         """
-        return __utils__['deepsea_minions.show']()
+        return __utils__["deepsea_minions.show"]()
 
 
 class StdArgs(object):
     """
     Wrapper around STD_ARGS to avoid early expanding of Target().show()
     """
+
     @staticmethod
     def write_out():
         """
         Return STD_ARGS
         """
         return {
-         'leftovers': False,
-         'standalone': False,
-         'nvme-ssd-spinner': False,
-         'nvme-ssd': False,
-         'nvme-spinner': False,
-         'ssd-spinner': False,
-         'ratio': 5,
-         'db-ratio': 5,
-         'target': Target().show(),
-         'data': 0,
-         'journal': 0,
-         'wal': 0,
-         'name': 'default',
-         'format': 'bluestore',
-         'encryption': '',
-         'journal-size': '5g',
-         'db-size': '500m',
-         'wal-size': '500m'}
+            "leftovers": False,
+            "standalone": False,
+            "nvme-ssd-spinner": False,
+            "nvme-ssd": False,
+            "nvme-spinner": False,
+            "ssd-spinner": False,
+            "ratio": 5,
+            "db-ratio": 5,
+            "target": Target().show(),
+            "data": 0,
+            "journal": 0,
+            "wal": 0,
+            "name": "default",
+            "format": "bluestore",
+            "encryption": "",
+            "journal-size": "5g",
+            "db-size": "500m",
+            "wal-size": "500m",
+        }
 
-BASE_DIR = '/srv/pillar/ceph/proposals'
+
+BASE_DIR = "/srv/pillar/ceph/proposals"
 
 
 def _parse_args(kwargs):
@@ -140,18 +149,28 @@ def _parse_args(kwargs):
     """
     args = StdArgs().write_out().copy()
     args.update(kwargs)
-    if 'kwargs' in kwargs:
-        args.update(kwargs['kwargs'])
-        args.pop('kwargs')
+    if "kwargs" in kwargs:
+        args.update(kwargs["kwargs"])
+        args.pop("kwargs")
     log.info("args: {}".format(args))
 
-    if args.get('name') == 'import':
-        print(('ERROR: profile name import is a reserved name. Please use'
-              ' another name'))
+    if args.get("name") == "import":
+        print(
+            (
+                "ERROR: profile name import is a reserved name. Please use"
+                " another name"
+            )
+        )
         exit(-1)
-    if args.get('encryption') != '' and args.get('encryption') != 'dmcrypt':
-        print((('ERROR: encryption{} is not supported. Currently only '
-               '"dmcrypt" is supported.').format(args.get('encryption'))))
+    if args.get("encryption") != "" and args.get("encryption") != "dmcrypt":
+        print(
+            (
+                (
+                    "ERROR: encryption{} is not supported. Currently only "
+                    '"dmcrypt" is supported.'
+                ).format(args.get("encryption"))
+            )
+        )
         exit(-1)
 
     return args
@@ -165,27 +184,27 @@ def _propose(node, proposal, args):
     for device in proposal:
         key, value = list(device.items())[0]
         dev_par = {}
-        format_ = args.get('format')
+        format_ = args.get("format")
         if isinstance(value, dict):
-            assert format_ == 'bluestore'
+            assert format_ == "bluestore"
             # pylint: disable=invalid-name
             db, wal = list(value.items())[0]
-            dev_par['wal'] = wal
-            dev_par['db'] = db
-            dev_par['wal_size'] = args.get('wal-size')
-            dev_par['db_size'] = args.get('db-size')
-        elif isinstance(value, str) and value != '':
-            if format_ == 'bluestore':
-                dev_par['wal'] = value
-                dev_par['db'] = value
-                dev_par['wal_size'] = args.get('wal-size')
-                dev_par['db_size'] = args.get('db-size')
+            dev_par["wal"] = wal
+            dev_par["db"] = db
+            dev_par["wal_size"] = args.get("wal-size")
+            dev_par["db_size"] = args.get("db-size")
+        elif isinstance(value, str) and value != "":
+            if format_ == "bluestore":
+                dev_par["wal"] = value
+                dev_par["db"] = value
+                dev_par["wal_size"] = args.get("wal-size")
+                dev_par["db_size"] = args.get("db-size")
             else:
-                dev_par['journal'] = value
-                dev_par['journal_size'] = args.get('journal-size')
-        dev_par['format'] = format_
-        if args.get('encryption') != '':
-            dev_par['encryption'] = args.get('encryption')
+                dev_par["journal"] = value
+                dev_par["journal_size"] = args.get("journal-size")
+        dev_par["format"] = format_
+        if args.get("encryption") != "":
+            dev_par["encryption"] = args.get("encryption")
         profile[key] = dev_par
 
     return {node: profile}
@@ -195,7 +214,13 @@ def _choose_proposal(node, proposal, args):
     """
     Select proposal or default to hardware present
     """
-    confs = ['nvme-ssd-spinner', 'nvme-ssd', 'nvme-spinner', 'ssd-spinner', 'standalone']
+    confs = [
+        "nvme-ssd-spinner",
+        "nvme-ssd",
+        "nvme-spinner",
+        "ssd-spinner",
+        "standalone",
+    ]
     # propose according to flags if present
     for conf in confs:
         if args[conf]:
@@ -225,8 +250,9 @@ def test(**kwargs):
 
     local_client = salt.client.LocalClient()
 
-    proposals = local_client.cmd(args['target'], 'proposal.test',
-                                 tgt_type='compound', kwarg=args)
+    proposals = local_client.cmd(
+        args["target"], "proposal.test", tgt_type="compound", kwarg=args
+    )
 
     # determine which proposal to choose
     for node, proposal in proposals.items():
@@ -243,8 +269,9 @@ def peek(**kwargs):
 
     local_client = salt.client.LocalClient()
 
-    proposals = local_client.cmd(args['target'], 'proposal.generate',
-                                 tgt_type='compound', kwarg=args)
+    proposals = local_client.cmd(
+        args["target"], "proposal.generate", tgt_type="compound", kwarg=args
+    )
 
     # determine which proposal to choose
     for node, proposal in proposals.items():
@@ -260,23 +287,22 @@ def _write_proposal(prop, profile_dir):
     node, proposal = list(prop.items())[0]
 
     # write out roles
-    role_file = '{}/cluster/{}.sls'.format(profile_dir, node)
+    role_file = "{}/cluster/{}.sls".format(profile_dir, node)
 
-    with open(role_file, 'w') as outfile:
-        content = {'roles': ['storage']}
+    with open(role_file, "w") as outfile:
+        content = {"roles": ["storage"]}
         # implement merge of existing data
         yaml.dump(content, outfile, default_flow_style=False)
 
     # TODO do not hardcode cluster name ceph here
-    profile_file = '{}/stack/default/ceph/minions/{}.yml'.format(profile_dir,
-                                                                 node)
+    profile_file = "{}/stack/default/ceph/minions/{}.yml".format(profile_dir, node)
     if isfile(profile_file):
-        log.warning('not overwriting existing proposal {}'.format(node))
+        log.warning("not overwriting existing proposal {}".format(node))
         return
 
     # write storage profile
-    with open(profile_file, 'w') as outfile:
-        content = {'ceph': {'storage': {'osds': proposal}}}
+    with open(profile_file, "w") as outfile:
+        content = {"ceph": {"storage": {"osds": proposal}}}
         # implement merge of existing data
         yaml.dump(content, outfile, default_flow_style=False)
 
@@ -285,11 +311,11 @@ def _record_filter(args, base_dir):
     """
     Save the filter provided
     """
-    filter_file = '{}/.filter'.format(base_dir)
+    filter_file = "{}/.filter".format(base_dir)
 
     if not isfile(filter_file):
         # do a touch filter_file
-        open(filter_file, 'a').close()
+        open(filter_file, "a").close()
 
     current_filter = {}
     with open(filter_file) as filehandle:
@@ -300,12 +326,230 @@ def _record_filter(args, base_dir):
     pprint.pprint(current_filter)
 
     # filter a bunch of salt content and the target key before writing
-    rec_args = {k: v for k, v in args.items() if k != 'target' and not
-                k.startswith('__')}
-    current_filter[args['target']] = rec_args
+    rec_args = {
+        k: v for k, v in args.items() if k != "target" and not k.startswith("__")
+    }
+    current_filter[args["target"]] = rec_args
 
-    with open(filter_file, 'w') as filehandle:
+    with open(filter_file, "w") as filehandle:
         yaml.dump(current_filter, filehandle, default_flow_style=False)
+
+
+def _find_minions_to_replace(profile_dir):
+    """
+    Search through a given profile directory for files that end with '-replace'.
+
+    :param profile_dir: Profile directory, e.g. "/srv/pillar/ceph/proposals/profile-default"
+    """
+    to_replace = namedtuple("to_replace", ["fullpath", "filename"])
+    dir_ = "{}/stack/default/ceph/minions".format(profile_dir)
+    files = [
+        f for f in os.listdir(dir_) if isfile(join(dir_, f)) and f.endswith("-replace")
+    ]
+
+    return [to_replace(join(dir_, f), f) for f in files]
+
+
+# pylint: disable=too-many-instance-attributes
+class ReplaceDiskOn(object):
+    """
+    Handle replacement of disks on OSD minions.
+
+    This class encapsulates everything that is needed to parse an old
+    proposal, compare it to the new/unused disks on the given minion and adapt
+    the old proposal if necessary.
+    When the same physical slots for are used, the only change of the proposal
+    is that the "replace: true" attribute gets stripped out of the proposal.
+    Otherwise the disks identifiers in the proposal are replaced by new ones.
+
+    Public method: replace() - trigger replacement of all flagged disks
+
+    :param minion: namedtuple with 'filename' and 'fullpath' as fields
+
+    """
+
+    def __init__(self, minion):
+        self.minion = minion
+        self.proposal_basename = self._proposal_basename()
+        self.proposal_basepath = self._proposal_basepath()
+        self.name = self._minion_name_from_file()
+        self.proposal = self._load_proposal()
+        self.disks = self._query_node_disks()
+        self.unused_disks = self._prepare_device_files()
+        self.flagged_replace = self._flagged_replace()
+
+    def _proposal_basename(self):
+        """ Get proposal basename from the provided filename """
+        pattern = re.compile(r"[^/]*\w\.yml", re.IGNORECASE)
+        return pattern.findall(self.minion.filename)[0]
+
+    def _proposal_basepath(self):
+        """ Get proposal basepath from the provided filename """
+        pattern = re.compile(r".+\.yml", re.IGNORECASE)
+        return pattern.findall(self.minion.fullpath)[0]
+
+    def _minion_name_from_file(self):
+        """ Get minion name from the proposal basename """
+        return self.proposal_basename.replace(".yml", "")
+
+    def _load_proposal(self):
+        """ Load proposal YAML file """
+        with open(self.minion.fullpath, "rb") as filename:
+            return yaml.safe_load(filename)
+
+    def _query_node_disks(self):
+        """ Return a list of currently present disks on the minion """
+        local_client = salt.client.LocalClient()
+        # ensure fresh data in case cephdisks.list was run shortly before with
+        # old disks present
+        local_client.cmd(self.name, "mine.flush", tgt_type="compound")
+        local_client.cmd(self.name, "mine.update", tgt_type="compound")
+        # the return of this call is a dictionary with the targets as keys
+        # even if there is only a single target
+        return local_client.cmd(self.name, "cephdisks.list", tgt_type="compound")[
+            self.name
+        ]
+
+    def _prepare_device_files(self):
+        """
+        Check which of the device file style is used and build a list of device files
+        """
+
+        local_client = salt.client.LocalClient()
+        new_disk_device_files = []
+        for old_disk_key, old_disk_val in self.proposal["ceph"]["storage"][
+            "osds"
+        ].items():
+            for new_disk in self.disks:
+                for dev_file in new_disk["Device Files"].split(","):
+                    # remove osd disks from self.disks unless they are marked for replacement
+                    if old_disk_key == dev_file.strip() and (
+                        "replace" not in old_disk_val
+                        or old_disk_val["replace"] is False
+                    ):
+
+                        self.disks.remove(new_disk)
+                    else:
+                        # remove wal db and journal disks from self.disks
+                        self._check_nested_for_disk(old_disk_val, dev_file, new_disk)
+
+        for disk in self.disks:
+            new_disk_device_files.append(
+                local_client.cmd(
+                    self.name,
+                    "cephdisks.device",
+                    [disk["Device File"]],
+                    tgt_type="compound",
+                )[self.name]
+            )
+        return sorted(new_disk_device_files)
+
+    def _check_nested_for_disk(self, old_disk_val, dev_file, new_disk):
+        """ Check nested proposal entries for occurances of the new disk """
+
+        for val in old_disk_val.values():
+            if val == dev_file.strip():
+                # if more than one disk points to e.g. one journal, the journal disk is already
+                # removed and another removal fails.
+                try:
+                    self.disks.remove(new_disk)
+                except ValueError:
+                    pass
+
+    def _flagged_replace(self):
+        """ Return a list of all disks in the old proposal that will be replaced """
+        return [
+            x
+            for x in self.proposal["ceph"]["storage"]["osds"]
+            if "replace" in self.proposal["ceph"]["storage"]["osds"][x]
+        ]
+
+    def _swap_disks_in_proposal(self):
+        """
+        Iterate over the old proposal and call _change_disk_path for all disks that need
+        replacement
+        """
+        for disk in self.flagged_replace:
+            if self.proposal["ceph"]["storage"]["osds"][disk]["replace"] is True:
+                self._change_disk_path(disk)
+
+    def _change_disk_path(self, old_disk):
+        """ Exchange the old disk for the new disk for one disk replacement """
+        unused_disk = self.unused_disks.pop(0)
+        temp = self.proposal["ceph"]["storage"]["osds"][old_disk]
+        del self.proposal["ceph"]["storage"]["osds"][old_disk]
+        self.proposal["ceph"]["storage"]["osds"][unused_disk] = temp
+
+    def _strip_replace_flags(self):
+        """ Remove all 'replace' flags from the proposal """
+        for disk in self.proposal["ceph"]["storage"]["osds"]:
+            if "replace" in self.proposal["ceph"]["storage"]["osds"][disk]:
+                del self.proposal["ceph"]["storage"]["osds"][disk]["replace"]
+
+    def _write_new_proposal(self):
+        """ Write the changed proposal to the original (pre 'replace' suffix) location """
+        with open(self.proposal_basepath, "w") as filename:
+            yaml.dump(self.proposal, filename, default_flow_style=False)
+
+    def _delete_old_proposal(self):
+        """ Remove file with 'replace' suffix """
+        os.remove(self.minion.fullpath)
+
+    def replace(self):
+        """
+        Adapt the proposal for replaced disks.
+
+        Following steps take place:
+        (0.) Use a new disk (by-path) for the proposal if the physical location
+            has changed.
+        1. Remove all "replace: " attributes from the proposal
+        2. Write proposal to the "normal" proposal file
+        3. Remove proposal file with "-replace" in its name
+        """
+
+        num_unused = len(self.unused_disks)
+        num_replace = len(
+            [
+                x
+                for x in self.flagged_replace
+                if self.proposal["ceph"]["storage"]["osds"][x]["replace"] is True
+            ]
+        )
+        if num_unused < 1:
+            log.error("At least one unused disk is needed.")
+            return False
+        elif num_unused > num_replace:
+            log.error(
+                "There are more ({}) unsused disks than disks to replace ({})".format(
+                    num_unused, num_replace
+                )
+            )
+            return False
+        elif num_unused < num_replace:
+            log.error(
+                "There are fewer ({}) unsused disks than disks to replace ({})".format(
+                    num_unused, num_replace
+                )
+            )
+            return False
+
+        log.debug(
+            "Correct amount of unused disks ({}). Swapping disks in proposal.".format(
+                num_unused
+            )
+        )
+        self._swap_disks_in_proposal()
+        self._strip_replace_flags()
+
+        try:
+            self._write_new_proposal()
+            log.info("New proposal was written to {}".format(self.proposal_basepath))
+            self._delete_old_proposal()
+        # pylint: disable=bare-except
+        except:
+            log.error("Writing new proposal failed.")
+
+        return None
 
 
 def populate(**kwargs):
@@ -317,18 +561,38 @@ def populate(**kwargs):
 
     local_client = salt.client.LocalClient()
 
-    proposals = local_client.cmd(args['target'], 'proposal.generate',
-                                 tgt_type='compound', kwarg=args)
+    minions_to_replace = []
+    profile_dir = "{}/profile-{}".format(BASE_DIR, args["name"])
+    if isdir(profile_dir):
+        minions_to_replace = _find_minions_to_replace(profile_dir)
+
+    non_targets = []
+    if minions_to_replace:
+        for minion in minions_to_replace:
+            replace_operation = ReplaceDiskOn(minion)
+            replace_operation.replace()
+            non_targets.append(replace_operation.name)
+
+        # generate proposals for all nodes but the ones with a replace operation
+        proposals = local_client.cmd(
+            "{} and not {}".format(args["target"], " and not ".join(non_targets)),
+            "proposal.generate",
+            tgt_type="compound",
+            kwarg=args,
+        )
+    else:
+        proposals = local_client.cmd(
+            args["target"], "proposal.generate", tgt_type="compound", kwarg=args
+        )
 
     # check if profile of 'name' exists
-    profile_dir = '{}/profile-{}'.format(BASE_DIR, args['name'])
     if not isdir(profile_dir):
         os.makedirs(profile_dir, 0o755)
     # TODO do not hardcode cluster name ceph here
-    if not isdir('{}/stack/default/ceph/minions'.format(profile_dir)):
-        os.makedirs('{}/stack/default/ceph/minions'.format(profile_dir), 0o755)
-    if not isdir('{}/cluster'.format(profile_dir)):
-        os.makedirs('{}/cluster'.format(profile_dir), 0o755)
+    if not isdir("{}/stack/default/ceph/minions".format(profile_dir)):
+        os.makedirs("{}/stack/default/ceph/minions".format(profile_dir), 0o755)
+    if not isdir("{}/cluster".format(profile_dir)):
+        os.makedirs("{}/cluster".format(profile_dir), 0o755)
 
     # determine which proposal to choose
     for node, proposal in proposals.items():
@@ -340,6 +604,5 @@ def populate(**kwargs):
 
     return True
 
-__func_alias__ = {
-                 'help_': 'help',
-                 }
+
+__func_alias__ = {"help_": "help"}

--- a/srv/salt/_modules/cephdisks.py
+++ b/srv/salt/_modules/cephdisks.py
@@ -517,7 +517,7 @@ def device_(devicename, pathname=None, match=None):
         _devices = _stdout.split()
         index = _prefer_underscores(_devices)
         return _devices[index]
-    return ""
+    return devicename
 
 
 def _match_setting(match):

--- a/srv/salt/_modules/osd.py
+++ b/srv/salt/_modules/osd.py
@@ -1816,18 +1816,18 @@ class OSDDevices(object):
             log.error("file {} is missing".format(filename))
             return None
 
-    # pylint: disable=no-self-use
-    def _uuid_device(self, device, pathname="/dev/disk/by-id"):
+    # pylint: disable=no-self-use, no-else-return
+    def _uuid_device(self, device):
         """
         Return the uuid device, prefer the most descriptive
         """
         if os.path.exists(device):
-            if os.path.exists(pathname):
-                devicename = __salt__['cephdisks.device'](device)
-                if devicename:
-                    return devicename
+            devicename = __salt__['cephdisks.device'](device)
+            # if the devicename and device are the same, cephdisks.device did not find any symlinks
+            if devicename != device:
+                return devicename
+            else:
                 return readlink(device)
-            return readlink(device)
         return None
 
 

--- a/srv/salt/_modules/proposal.py
+++ b/srv/salt/_modules/proposal.py
@@ -236,10 +236,7 @@ def _device(drive):
     """
     Default to Device File value.  Prefer most descriptive.
     """
-    devicename = __salt__['cephdisks.device'](drive['Device File'])
-    if devicename:
-        return devicename
-    return drive['Device File']
+    return __salt__['cephdisks.device'](drive['Device File'])
 
 
 def generate(**kwargs):

--- a/tests/unit/_modules/test_cephdisks.py
+++ b/tests/unit/_modules/test_cephdisks.py
@@ -420,14 +420,14 @@ class TestCephDiskDevice():
         pu.return_value = -1
         cephdisks.__salt__ = {}
         cephdisks.__salt__['helper.run'] = mock.Mock()
-        cephdisks.__salt__['helper.run'].return_value = (0, '/dev/sda', "")
+        cephdisks.__salt__['helper.run'].return_value = (0, '/dev/disk/by-id/sda', "")
         ret = cephdisks.device_('/dev/sda')
-        assert ret == '/dev/sda'
+        assert ret == '/dev/disk/by-id/sda'
 
     @mock.patch('srv.salt._modules.cephdisks._pathname_setting')
     @mock.patch('srv.salt._modules.cephdisks._match_setting')
     @mock.patch('srv.salt._modules.cephdisks._prefer_underscores')
-    def test_device_no_match(self, pu, ms, ps):
+    def test_device_returns_input_if_no_match(self, pu, ms, ps):
         ps.return_value = '/dev/disk/by-id'
         ms.return_value = '-name ata* -o -name scsi* -o -name nvme*'
         pu.return_value = -1
@@ -435,7 +435,7 @@ class TestCephDiskDevice():
         cephdisks.__salt__['helper.run'] = mock.Mock()
         cephdisks.__salt__['helper.run'].return_value = (0, "", "")
         ret = cephdisks.device_('/dev/sda')
-        assert ret == ""
+        assert ret == "/dev/sda"
 
     def test_match_setting_arg(self):
         ret = cephdisks._match_setting('custom')

--- a/tests/unit/runners/test_proposal.py
+++ b/tests/unit/runners/test_proposal.py
@@ -1,0 +1,262 @@
+from srv.modules.runners import proposal
+import pytest
+from mock import patch, mock_open, call
+import sys
+from collections import namedtuple
+sys.path.insert(0, 'srv/modules/pillar')
+
+
+@pytest.fixture
+def minions():
+    ToReplace = namedtuple('ToReplace', ['fullpath', 'filename'])
+    return {
+            'minion1': {
+                'minion': ToReplace('/srv/pillar/ceph/proposals/profile-default/stack/default/ceph/minions/data1.ceph.yml-replace', 'data1.ceph.yml-replace'),
+                'basepath': "/srv/pillar/ceph/proposals/profile-default/stack/default/ceph/minions/data1.ceph.yml",
+                'basename': "data1.ceph.yml",
+                'name':     "data1.ceph",
+                'num_replace': 2,
+                'disks': [
+                    # Noise here means nothing special, just literally 'noise' in the dictionary
+                    {'Device File': '/dev/vdc', 'Noise': True, 'Device Files': '/dev/vdc'},
+                    {'Device File': '/dev/vdb', 'Noise': True, 'Device Files': '/dev/vdb'},
+                    {'Device File': '/dev/vdd', 'Noise': True, 'Device Files': '/dev/vdd'}
+                ],
+                'osds': {
+                    '/dev/vdb': {'format': 'bluestore', 'replace': False, 'old': 'vdb'},
+                    '/dev/vdd': {'format': 'bluestore', 'replace': True, 'old': 'vdd'},
+                    '/dev/vdc': {'format': 'bluestore', 'replace': True, 'old': 'vdc'}
+                },
+                'expected': { 'ceph': {'storage': {'osds': {
+                    '/dev/vdb': {'format': 'bluestore', 'old': 'vdb'},
+                    '/dev/vdc': {'format': 'bluestore', 'old': 'vdc'},
+                    '/dev/vdd': {'format': 'bluestore', 'old': 'vdd'}}}}}
+            },
+            'minion2': {
+                'minion': ToReplace('/srv/pillar/ceph/proposal/profile-alternative/stack/default/minions/data2.ceph.yml-replace', 'data2.ceph.yml-replace'),
+                'basepath': "/srv/pillar/ceph/proposal/profile-alternative/stack/default/minions/data2.ceph.yml",
+                'basename': "data2.ceph.yml",
+                'name':     "data2.ceph",
+                'num_replace': 2,
+                'disks': [
+                    {'Device File': '/dev/vdc', 'Noise': True, 'Device Files': '/dev/vdc, /dev/v_d_c'},
+                    {'Device File': '/dev/vdb', 'Noise': True, 'Device Files': '/dev/vdb, /dev/v_d_b'},
+                    {'Device File': '/dev/vde', 'Noise': True, 'Device Files': '/dev/vde, /dev/v_d_e'},
+                    {'Device File': '/dev/vdf', 'Noise': True, 'Device Files': '/dev/vdf, /dev/v_d_f'}
+                ],
+                'osds': {
+                    '/dev/v_d_b': {'format': 'bluestore', 'old': 'v_d_b'},
+                    '/dev/v_d_d': {'format': 'bluestore', 'replace': True, 'old': 'v_d_d'},
+                    '/dev/v_d_c': {'format': 'bluestore', 'replace': True, 'old': 'v_d_c'},
+                    '/dev/v_d_e': {'format': 'bluestore', 'old': 'v_d_e'}},
+                'expected': { 'ceph': {'storage': {'osds': {
+                    '/dev/v_d_b': {'format': 'bluestore', 'old': 'v_d_b'},
+                    '/dev/v_d_c': {'format': 'bluestore', 'old': 'v_d_c'},
+                    '/dev/v_d_e': {'format': 'bluestore', 'old': 'v_d_e'},
+                    '/dev/v_d_f': {'format': 'bluestore', 'old': 'v_d_d'}}}}}
+                },
+            'minion3': {
+                'minion': ToReplace('/srv/pillar/ceph/proposal/profile-default/stack/default/minions/data3.ceph.yml', 'data3.ceph.yml'),
+                'basepath': "/srv/pillar/ceph/proposal/profile-default/stack/default/minions/data3.ceph.yml",
+                'basename': "data3.ceph.yml",
+                'name':     "data3.ceph",
+                'num_replace': 1,
+                'disks': [
+                    {'Device File': '/dev/vdb', 'Noise': True, 'Device Files': '/dev/vdb'},
+                    {'Device File': '/dev/vde', 'Noise': True, 'Device Files': '/dev/vde'}
+                ],
+                'osds': {
+                    '/dev/vdc': {'format': 'bluestore', 'old': 'vdc', 'replace': True},
+                    '/dev/vde': {'format': 'bluestore', 'old': 'vde'}},
+                'expected': { 'ceph': {'storage': {'osds': {
+                    '/dev/vdb': {'format': 'bluestore', 'old': 'vdc'},
+                    '/dev/vde': {'format': 'bluestore', 'old': 'vde'}}}}}
+                },
+            'minion4': {
+                'minion': ToReplace('/srv/pillar/ceph/proposal/profile-default/stack/default/minions/we.use.a-very?weird-naming.scheme/node.yml-replace', 'node.yml-replace'),
+                'basepath': "/srv/pillar/ceph/proposal/profile-default/stack/default/minions/we.use.a-very?weird-naming.scheme/node.yml",
+                'basename': "node.yml",
+                'name':     "node",
+                'num_replace': 0,
+                'disks': [
+                    {'Device File': '/dev/vdb', 'Noise': True, 'Device Files': '/dev/vdb'},
+                    {'Device File': '/dev/vdc', 'Noise': True, 'Device Files': '/dev/vdc'},
+                    {'Device File': '/dev/vdd', 'Noise': True, 'Device Files': '/dev/vdd'},
+                    {'Device File': '/dev/vdf', 'Noise': True, 'Device Files': '/dev/vdf'}
+                ],
+                'osds': {
+                    '/dev/vdb': {'format': 'bluestore', 'old': 'vdb'},
+                    '/dev/vdc': {'format': 'bluestore', 'old': 'vdc'},
+                    '/dev/vdd': {'format': 'bluestore', 'old': 'vdd'},
+                    '/dev/vdf': {'format': 'bluestore', 'old': 'vdf'}},
+                'expected': { 'ceph': {'storage': {'osds': {
+                    '/dev/vdb': {'format': 'bluestore', 'old': 'vdb'},
+                    '/dev/vdc': {'format': 'bluestore', 'old': 'vdc'},
+                    '/dev/vdd': {'format': 'bluestore', 'old': 'vdd'},
+                    '/dev/vdf': {'format': 'bluestore', 'old': 'vdf'}}}}}
+                },
+            }
+
+class TestProposalRunner(object):
+
+    @patch('srv.modules.runners.proposal.isfile', autospec=True)
+    @patch('os.listdir', autospec=True)
+    def test_find_minions_to_replace(self, mock_listdir, mock_isfile):
+        mock_listdir.return_value = ['data1.ceph.yml-replace']
+        mock_isfile.return_value = True
+        directory = '/srv/pillar/ceph/proposals/profile-default'
+        result = proposal._find_minions_to_replace(directory)
+
+        assert result[0].filename == 'data1.ceph.yml-replace'
+
+    @patch('srv.modules.runners.proposal.isfile', autospec=True)
+    @patch('os.listdir', autospec=True)
+    def test_find_multiple_minions_to_replace(self, mock_listdir, mock_isfile):
+        mock_listdir.return_value = ['data1.ceph.yml-replace', 'data2.ceph.yml-replace']
+        mock_isfile.return_value = True
+        directory = '/srv/pillar/ceph/proposals/profile-default'
+        result = proposal._find_minions_to_replace(directory)
+
+        assert result[0].filename == 'data1.ceph.yml-replace'
+        assert result[1].filename == 'data2.ceph.yml-replace'
+
+    @patch('srv.modules.runners.proposal.isfile', autospec=True)
+    @patch('os.listdir', autospec=True)
+    def test_find_minions_to_replace_no_result(self, mock_listdir, mock_isfile):
+        mock_listdir.return_value = ['.data1.ceph.yml-replace.swp']
+        mock_isfile.return_value = True
+        directory = '/srv/pillar/ceph/proposals/profile-default'
+        result = proposal._find_minions_to_replace(directory)
+
+        assert not result
+
+    class NoInitReplaceDisk(proposal.ReplaceDiskOn):
+        """ Don't populate attributes via private methods automatically """
+
+        def __init__(self, minion):
+            self.minion = minion
+
+    # range upper limit is amount of minions in fixture + 1
+    @pytest.mark.parametrize("execution_number", range(1, 5))
+    def test_proposal_basepath(self, execution_number, minions):
+        minion = minions['minion{}'.format(execution_number)]
+        RD = self.NoInitReplaceDisk(minion['minion'])
+
+        assert RD._proposal_basepath() == minion['basepath']
+
+    @pytest.mark.parametrize("execution_number", range(1, 5))
+    def test_proposal_basename(self, execution_number, minions):
+        minion = minions['minion{}'.format(execution_number)]
+        RD = self.NoInitReplaceDisk(minion['minion'])
+
+        assert RD._proposal_basename() == minion['basename']
+
+    @pytest.mark.parametrize("execution_number", range(1, 5))
+    def test_minion_name_from_file(self, execution_number, minions):
+        minion = minions['minion{}'.format(execution_number)]
+        RD = self.NoInitReplaceDisk(minion['minion'])
+        RD.proposal_basename = minion['basename']
+
+        assert RD._minion_name_from_file() == minion['name']
+
+    @patch('srv.modules.runners.proposal.open', new_callable=mock_open)
+    @patch('yaml.safe_load')
+    def test_load_proposal(self, mock_yaml, mock_file, minions):
+        minion = minions['minion1']['minion']
+        proposal_dict = "{'fake_dict': True}"
+        mock_yaml.return_value = proposal_dict
+        RD = self.NoInitReplaceDisk(minion)
+
+        assert RD._load_proposal() == proposal_dict
+        mock_yaml.assert_called_once()
+
+    @patch('salt.client.LocalClient', autospec=True)
+    def test_query_node_disks(self, mock_client, minions):
+        minion = minions['minion1']['minion']
+        local_client = mock_client.return_value
+        call1 = call('data1.ceph', 'mine.flush', tgt_type='compound')
+        call2 = call('data1.ceph', 'mine.update', tgt_type='compound')
+        call3 = call('data1.ceph', 'cephdisks.list', tgt_type='compound')
+        RD = self.NoInitReplaceDisk(minion)
+        RD.name = 'data1.ceph'
+
+        RD._query_node_disks()
+
+        assert local_client.cmd.call_count == 3
+        assert local_client.cmd.call_args_list[0] == call1
+        assert local_client.cmd.call_args_list[1] == call2
+        assert local_client.cmd.call_args_list[2] == call3
+
+
+    @pytest.mark.parametrize("execution_number", range(1, 5))
+    @patch('salt.client.LocalClient', autospec=True)
+    def test_prepare_device_file(self, mock_client, execution_number, minions):
+        minion = minions['minion{}'.format(execution_number)]
+        local_client = mock_client.return_value
+
+        RD = self.NoInitReplaceDisk(minion)
+        RD.proposal = {'ceph': {'storage': {'osds': minion['osds']}}}
+        RD.name = minion['name']
+        RD.disks = minion['disks']
+
+        RD._prepare_device_files()
+        assert local_client.cmd.call_count == len([x for x in minion['disks'] if x['Device Files'][-1] not in minion['osds']])
+
+    @pytest.mark.parametrize("execution_number", range(1, 5))
+    def test_strip_replace_flages(self, execution_number, minions):
+        minion = minions['minion{}'.format(execution_number)]
+        RD = self.NoInitReplaceDisk(minion['minion'])
+        RD.proposal = {'ceph': {'storage': {'osds': minion['osds']}}}
+        RD.flagged_replace = [x for x in minion['osds'] if 'replace' in minion['osds'][x]]
+
+        RD._strip_replace_flags()
+
+        for conf in RD.proposal['ceph']['storage']['osds'].values():
+            assert 'replace' not in conf
+
+    @pytest.mark.parametrize("execution_number", range(1, 5))
+    def test_swap_disks_in_proposal(self, execution_number, minions):
+        minion = minions['minion{}'.format(execution_number)]
+        RD = self.NoInitReplaceDisk(minion['minion'])
+        RD.proposal = {'ceph': {'storage': {'osds': minion['osds']}}}
+        RD.flagged_replace = sorted([x for x in minion['osds'] if 'replace' in minion['osds'][x]])
+        # The device file with the most underscores is the last one in the 'Device Files' list here
+        # In the real code, the correct device file gets returned from a salt execution module
+        RD.unused_disks = sorted([x['Device Files'][-1] for x in minion['disks']
+                                  # disks in new slots
+                                  if x['Device File'][-1] not in minion['osds']
+                                  # disks that are exchanged in place
+                                  or 'replace' in minion['osds'][x['Device Files'][-1]]
+                                  and minion['osds'][x['Device Files'][-1]]['replace'] is True])
+        keys_to_add = RD.unused_disks[:]
+
+        RD._swap_disks_in_proposal()
+
+        for i in range(minion['num_replace']):
+            assert keys_to_add[i] in RD.proposal['ceph']['storage']['osds']
+
+
+    @pytest.mark.parametrize("execution_number", range(1, 5))
+    @patch('salt.client.LocalClient')
+    @patch('srv.modules.runners.proposal.open', new_callable=mock_open)
+    @patch('yaml.safe_load')
+    def test_replace(self, mock_yaml, mock_file, mock_client, execution_number, minions):
+        minion = minions['minion{}'.format(execution_number)]
+        mock_yaml.return_value = {'ceph': {'storage': {'osds': minion['osds']}}}
+
+        RD = proposal.ReplaceDiskOn(minion['minion'])
+        # salt client has different returns so instead of settings its
+        # return value we set the disks and device_files directly and re-run
+        # methods that depend on those
+        RD.disks = minion['disks']
+        RD.unused_disks = sorted([x['Device Files'].split(',')[-1].strip() for x in minion['disks']
+                                  # disks in new slots
+                                  if x['Device Files'].split(',')[-1].strip() not in minion['osds']
+                                  # disks that are exchanged in place
+                                  or 'replace' in minion['osds'][x['Device Files'].split(',')[-1].strip()]
+                                  and minion['osds'][x['Device Files'].split(',')[-1].strip()]['replace'] is True])
+        RD.replace()
+
+        mock_yaml.assert_called()
+        assert RD.proposal == minion['expected']
+


### PR DESCRIPTION
Fixes #1215

Please have a look already, there are still a few things to do (I've noted them below) but the core business logic should stay more or less the same (unless you find some problems :wink:)

Description:
OSD Migration currently only works if the same slot is used. This works
because the generation of proposals is deterministic, so if all disks
are in the same position we end up with the same proposal.

This commit changes that behaviour: instead of creating a new proposal,
the old one is used and adapted. This happens in the following steps:

1) When `salt-run replace.osd X` is used and a proposal file (e.g.
    "data1.ceph.yml" in /srv/pillar/proposals/...) gets the "-replace"
    suffix, a new attribute is written for the disks that get replaced
2) When `salt-run proposals.populate` is used (e.g. in stage.1), all
    proposal files that have the "-replace" suffix get parsed and the
    disks in the proposal are compared to the currently installed disks
    on the node.
3) Disks in the old proposal that have the attribute inserted in 1) and
    are still present (i.e. replaced in place) plus new disks (disks
    that are not in the old proposal but present) are considered free.
4) The disks in the old proposal get interated over and if they are
    labeled for replacement they are swapped with one of the free disks.
5) This modified proposal gets saved in the place of the original one
    and can be used by later stages

Things that should still be done:
* Have a way to roll the "destroyed" mark in the CRUSH map back if renaming and inserting of "replace: true" in proposal file fails
* Clean up and add more unittests
* Add functional tests 

-----------------

**Checklist:**
- [x] Added unittests ~and or functional tests~
- [ ] Adapted documentation
- [x] Referenced issues or internal bugtracker
- [x] Ran integration tests successfully ( trigger with @susebot run teuthology )
