### PR TITLE
qa: use "systemctl --no-pager --full status" and restart rsyslog service after installing curl RPM

### DIFF
--- a/qa/common/common.sh
+++ b/qa/common/common.sh
@@ -260,7 +260,7 @@ function ceph_health_test {
 
 function salt_api_test {
     echo "Salt API test: BEGIN"
-    systemctl status salt-api.service
+    systemctl --no-pager --full status salt-api.service
     curl http://$(hostname):8000/ | python3 -m json.tool
     echo "Salt API test: END"
 }
@@ -345,7 +345,7 @@ sed -i -e 's/\("host": "target[[:digit:]]\+\)"/\1.teuthology"/' /tmp/lrbd.conf
 cat /tmp/lrbd.conf
 source /etc/sysconfig/lrbd; lrbd -v $LRBD_OPTIONS -f /tmp/lrbd.conf
 systemctl restart lrbd.service
-systemctl status -l lrbd.service
+systemctl --no-pager --full status lrbd.service
 echo "Result: OK"
 EOF
     _run_test_script_on_node $TESTSCRIPT $IGWNODE
@@ -390,12 +390,12 @@ set -x
 zypper --non-interactive install --no-recommends open-iscsi multipath-tools
 systemctl start iscsid.service
 sleep 5
-systemctl status -l iscsid.service
+systemctl --no-pager --full status iscsid.service
 iscsiadm -m discovery -t st -p $IGWNODE
 iscsiadm -m node -L all
 systemctl start multipathd.service
 sleep 5
-systemctl status -l multipathd.service
+systemctl --no-pager --full status multipathd.service
 ls -lR /dev/mapper
 ls -l /dev/disk/by-path
 ls -l /dev/disk/by-*id

--- a/qa/common/rgw.sh
+++ b/qa/common/rgw.sh
@@ -68,8 +68,9 @@ function rgw_curl_test {
     done
     set -x
     zypper --non-interactive install --no-recommends curl libxml2-tools
-    # installing curl RPM causes ceph-radosgw service to need restart
+    # installing curl RPM causes ceph-radosgw and rsyslog services to need restart
     salt-run state.orch ceph.restart.rgw 2>/dev/null
+    systemctl restart rsyslog.service
     _zypper_ps
     RGWNODE=$(salt --no-color -C "I@roles:rgw" test.ping | grep -o -P '^\S+(?=:)' | head -1)
     RGWXMLOUT=/tmp/rgw_test.xml


### PR DESCRIPTION
When running integration test scripts from an interactive shell,
bare "systemctl status" will trigger a pager, requiring manual
intervention to continue.

Fix by always passing --no-pager to systemctl status.

Signed-off-by: Nathan Cutler <ncutler@suse.com>