### PR TITLE
Move from tgt_type to expr_form in .py files

### DIFF
--- a/srv/modules/runners/advise.py
+++ b/srv/modules/runners/advise.py
@@ -110,7 +110,7 @@ def osds():
     """
     local = salt.client.LocalClient()
     report = local.cmd('I@roles:storage', 'osd.report',
-                       ['human=False'], tgt_type="compound")
+                       ['human=False'], expr_form="compound")
 
     bold = '\033[1m'
     endc = '\033[0m'

--- a/srv/modules/runners/cephprocesses.py
+++ b/srv/modules/runners/cephprocesses.py
@@ -115,7 +115,7 @@ def need_restart_config_change(role=None, cluster='ceph'):
     restart = local.cmd(role_search,
                         'cephprocesses.need_restart_config_change',
                         ["role={}".format(role)],
-                        tgt_type="compound")
+                        expr_form="compound")
 
     sys.stdout = _stdout
     for minion, need_rs in six.iteritems(restart):
@@ -138,7 +138,7 @@ def need_restart(role=None, cluster='ceph'):
     restart = local.cmd(role_search,
                         'cephprocesses.need_restart',
                         ["role={}".format(role)],
-                        tgt_type="compound")
+                        expr_form="compound")
 
     sys.stdout = _stdout
     for minion, need_rs in six.iteritems(restart):

--- a/srv/modules/runners/remove.py
+++ b/srv/modules/runners/remove.py
@@ -44,7 +44,7 @@ def osd(*args, **kwargs):
 
         print("Removing osd {} from Ceph".format(osd_id))
         for cmd in cmds:
-            local.cmd(master_minion, 'cmd.run', [cmd], tgt_type='compound')
+            local.cmd(master_minion, 'cmd.run', [cmd], expr_form='compound')
 
     return ""
 


### PR DESCRIPTION
Signed-off-by: Joshua Schmid <jschmid@suse.de>

```
xxxxxxxx:/deepsea/deepsea # salt-run disengage.safety; salt-run remove.osd 0 5
Removing osds 0, 5 from minions
Press Ctrl-C to abort
Exception occurred in runner remove.osd: Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/salt/client/mixins.py", line 395, in _low
    data['return'] = self.functions[fun](*args, **kwargs)
  File "/srv/modules/runners/remove.py", line 29, in osd
    result = __salt__['replace.osd'](*args, called=True, **kwargs)
  File "/srv/modules/runners/replace.py", line 65, in osd
    grains = local.cmd(host, 'grains.get', ['ceph'], tgt_type='compound')
  File "/usr/lib/python2.7/site-packages/salt/client/__init__.py", line 667, in cmd
    **kwargs):
TypeError: get_cli_event_returns() got multiple values for keyword argument 'tgt_type'
```

Those things happen when using tgt_type in with salt2016


Note: we have a lot more tgt_type entries.. not sure yet how they behave. Maybe we need to revert those too.

-----------------

**Checklist:**
- [ ] Added unittests and or functional tests
- [ ] Adapted documentation
- [ ] Referenced issues or internal bugtracker
- [ ] Ran integration tests successfully ( trigger with @susebot run teuthology )
