### PR TITLE
Restart is separate state now

### DIFF
--- a/srv/modules/runners/ui_iscsi.py
+++ b/srv/modules/runners/ui_iscsi.py
@@ -372,7 +372,7 @@ def _deploy_in_minions(minions):
         target = 'L@{}'.format(','.join(minions))
     else:
         target = 'I@roles:igw'
-    state_res = local.cmd(target, 'state.apply', ['ceph.igw'], tgt_type="compound")
+    state_res = local.cmd(target, 'state.apply', ['ceph.igw.restart'], tgt_type="compound")
     for minion, states in state_res.items():
         result['minions'][minion] = _check_state_result(states)
         if not result['minions'][minion]:


### PR DESCRIPTION
Signed-off-by: Eric Jackson <ejackson@suse.com>

bnc#1105733

Description:
The intent of the code to restart the iSCSI gateway has been relying on the side effect of the igw/default.sls state.  The restart is a separate state.


-----------------

**Checklist:**
- [ ] Added unittests and or functional tests
- [ ] Adapted documentation
- [ ] Referenced issues or internal bugtracker
- [ ] Ran integration tests successfully ( trigger with @susebot run teuthology )
