### PR TITLE
[backport][SES5] Restart is separate state now

### DIFF
--- a/srv/modules/runners/ui_iscsi.py
+++ b/srv/modules/runners/ui_iscsi.py
@@ -358,7 +358,7 @@ def _deploy_in_minions(minions):
         target = 'L@{}'.format(','.join(minions))
     else:
         target = 'I@roles:igw'
-    state_res = local.cmd(target, 'state.apply', ['ceph.igw'], expr_form="compound")
+    state_res = local.cmd(target, 'state.apply', ['ceph.igw.restart'], expr_form="compound")
     for minion, states in state_res.items():
         result['minions'][minion] = _check_state_result(states)
         if not result['minions'][minion]:


### PR DESCRIPTION
Signed-off-by: Eric Jackson <ejackson@suse.com>
(cherry picked from commit 259124d382bc51e23f79e7bfefd94504d089f6d9)

backport of #1319 

-----------------

**Checklist:**

- [x] Referenced issues or internal bugtracker
- [ ] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
