### PR TITLE
[backport][SES5] NFS-Ganesha + Cephfs: Add cache config options

### DIFF
--- a/srv/salt/ceph/ganesha/files/ganesha.conf.j2
+++ b/srv/salt/ceph/ganesha/files/ganesha.conf.j2
@@ -22,6 +22,19 @@ EXPORT
 
 }
 
+# The libcephfs client will aggressively cache information while it
+# can, so there is little benefit to ganesha actively caching the same
+# objects. Doing so can also hurt cache coherency. Here, we disable
+# as much attribute and directory caching as we can.
+CACHEINODE {
+    # Size the dirent cache down as small as possible.
+    Dir_Chunk = 0;
+
+    # size the inode cache as small as possible
+    NParts = 1;
+    Cache_Size = 1;
+}
+
 {% endif %}
 
 {% if salt.saltutil.runner('select.minions', cluster='ceph', roles=role) != [] %}


### PR DESCRIPTION
Signed-off-by: Supriti Singh <supriti.singh@suse.com>

Fixes #
This patch can avoid the internal cache pressure warning as seen in bug#1103418
Backport of https://github.com/SUSE/DeepSea/pull/1326 

**Checklist:**
- [ ] Added unittests and or functional tests
- [ ] Adapted documentation
- [x] Referenced issues or internal bugtracker
- [x] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)