### PR TITLE
monitoring: add missing ':' to alerts.yml

### DIFF
--- a/srv/salt/ceph/monitoring/prometheus/files/alerts.yml.j2
+++ b/srv/salt/ceph/monitoring/prometheus/files/alerts.yml.j2
@@ -4,13 +4,13 @@ groups:
       - alert: health error
         expr: ceph_health_status == 2
         for: 5m
-        annotations
+        annotations:
           description: Ceph in error for > 5m
-          severity: ciritical
+          severity: critical
       - alert: unhealthy
         expr: ceph_health_status != 0
         for: 15m
-        annotations
+        annotations:
           description: Ceph not healthy for > 5m
           severity: warning
   - name: mon


### PR DESCRIPTION
Signed-off-by: Tim Serong <tserong@suse.com>

Without this, prometheus won't start, which breaks all the monitoring. Tested by copying file to running system, ran `salt admin.ceph state.apply ceph.monitoring`, checked grafana and openATTIC display.