### PR TITLE
qa: fail SES5 test if python2 not present

### DIFF
--- a/qa/common/deploy.sh
+++ b/qa/common/deploy.sh
@@ -123,9 +123,9 @@ function initialization_sequence {
     _determine_master_minion
     _os_specific_install_deps
     _os_specific_repos_and_packages_info
-    python --version || true
-    python2 --version || true
-    python3 --version
+    python --version
+    python2 --version
+    python3 --version || true
     deepsea --version || true
     _set_deepsea_minions
     _initialize_minion_array


### PR DESCRIPTION
Fixes: https://github.com/SUSE/DeepSea/issues/1332
Signed-off-by: Nathan Cutler <ncutler@suse.com>

-----------------

**Checklist:**
~~- [ ] Added unittests and or functional tests~~
~~- [ ] Adapted documentation~~
- [x] Referenced issues or internal bugtracker
- [ ] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
