### PR TITLE
Improve migration tests

### DIFF
--- a/tests/unit/runners/test_proposal.py
+++ b/tests/unit/runners/test_proposal.py
@@ -8,6 +8,8 @@ sys.path.insert(0, "srv/modules/pillar")
 
 
 NUM_MINIONS = 4
+
+
 @pytest.fixture
 def minions():
     minion_tuple = namedtuple("minion_tuple", ["fullpath", "filename"])
@@ -22,28 +24,23 @@ def minions():
     min4_name = "storage-node1.ceph"
     min4_filename = "{}.yml-replace".format(min4_name)
     test_minions = (
-        # first minion
+        # first minion (3 disks, 2 replacements, two reuses)
         {
-            "tuple": minion_tuple(
-                basepath.format("profile-default", min1_filename), min1_filename
-            ),
+            "tuple": minion_tuple(basepath.format("profile-default", min1_filename), min1_filename),
             "proposal": {
                 "ceph": {
                     "storage": {
                         "osds": {
-                            "/dev/vdb": {
+                            "/dev/disk/by-id/scsi-0ATA_SATA_SSD_AF000000000000000000": {
                                 "format": "bluestore",
-                                "old": "vdb",
                                 "replace": False,
                             },
-                            "/dev/vdd": {
+                            "/dev/disk/by-id/scsi-0ATA_INTEL_SSDSC2BA40_BTH000000000000000": {
                                 "format": "bluestore",
-                                "old": "vdd",
                                 "replace": True,
                             },
-                            "/dev/vdc": {
+                            "/dev/disk/by-id/scsi-0ATA_INTEL_SSDSC2BA40_BTH111111111111111": {
                                 "format": "bluestore",
-                                "old": "vdc",
                                 "replace": True,
                             },
                         }
@@ -51,125 +48,169 @@ def minions():
                 }
             },
             "disks": [
-                {"Device File": "/dev/vdc", "Device Files": "/dev/vdc"},
-                {"Device File": "/dev/vdb", "Device Files": "/dev/vdb"},
-                {"Device File": "/dev/vdd", "Device Files": "/dev/vdd"},
+                {
+                    "Device File": "/dev/sdc",
+                    "Device Files": "/dev/sdc, /dev/disk/by-id/ata-INTEL_SSDSC2BA400G4_BTH000000000000000, /dev/disk/by-id/scsi-0ATA_INTEL_SSDSC2BA40_BTH000000000000000, /dev/disk/by-id/scsi-1ATA_INTEL_SSDSC2BA400G4_BTH000000000000000, /dev/disk/by-id/scsi-355cd2e404c1c9f4e, /dev/disk/by-id/scsi-SATA_INTEL_SSDSC2BA40_BTH000000000000000, /dev/disk/by-id/wwn-0x55cd2e404c1c9f4e, /dev/disk/by-path/pci-0000:00:1f.2-ata-1",
+                },
+                {
+                    "Device File": "/dev/sdb",
+                    "Device Files": "/dev/sdb, /dev/disk/by-id/ata-SATA_SSD_AF000000000000000000, /dev/disk/by-id/scsi-0ATA_SATA_SSD_AF000000000000000000, /dev/disk/by-id/scsi-1ATA_SATA_SSD_AF000000000000000000, /dev/disk/by-id/scsi-SATA_SATA_SSD_AF000000000000000000, /dev/disk/by-path/pci-0000:00:1f.2-ata-6",
+                },
+                {
+                    "Device File": "/dev/sdd",
+                    "Device Files": "/dev/sdd, /dev/disk/by-id/ata-INTEL_SSDSC2BA400G4_BTH111111111111111, /dev/disk/by-id/scsi-0ATA_INTEL_SSDSC2BA40_BTH111111111111111, /dev/disk/by-id/scsi-1ATA_INTEL_SSDSC2BA400G4_BTH111111111111111, /dev/disk/by-id/scsi-355cd2e404c1c9881, /dev/disk/by-id/scsi-SATA_INTEL_SSDSC2BA40_BTH111111111111111, /dev/disk/by-id/wwn-0x55cd2e404c1c9881, /dev/disk/by-path/pci-0000:00:1f.2-ata-2",
+                },
             ],
             "expected": {
                 "proposal_basename": "{}.yml".format(min1_name),
-                "proposal_basepath": basepath.format(
-                    "profile-default", "{}.yml".format(min1_name)
-                ),
+                "proposal_basepath": basepath.format("profile-default", "{}.yml".format(min1_name)),
                 "name": min1_name,
-                "unused_disks": ['/dev/vdc', '/dev/vdd'],
+                "unused_disks": [
+                    "/dev/disk/by-id/scsi-SATA_INTEL_SSDSC2BA40_BTH111111111111111",
+                    "/dev/disk/by-id/scsi-SATA_INTEL_SSDSC2BA40_BTH000000000000000",
+                ],
                 "proposal": {
                     "ceph": {
                         "storage": {
                             "osds": {
-                                "/dev/vdb": {"format": "bluestore", "old": "vdb"},
-                                "/dev/vdc": {"format": "bluestore", "old": "vdc"},
-                                "/dev/vdd": {"format": "bluestore", "old": "vdd"},
+                                "/dev/disk/by-id/scsi-0ATA_SATA_SSD_AF000000000000000000": {
+                                    "format": "bluestore"
+                                },
+                                "/dev/disk/by-id/scsi-SATA_INTEL_SSDSC2BA40_BTH000000000000000": {
+                                    "format": "bluestore"
+                                },
+                                "/dev/disk/by-id/scsi-SATA_INTEL_SSDSC2BA40_BTH111111111111111": {
+                                    "format": "bluestore"
+                                },
                             }
                         }
                     }
                 },
             },
         },
-        # second minion
+        # second minion (custom profile, 4 disks, 2 replacements, 1 reuse)
         {
-            "tuple": minion_tuple(
-                basepath.format("profile-backup", min2_filename), min2_filename
-            ),
+            "tuple": minion_tuple(basepath.format("profile-backup", min2_filename), min2_filename),
             "proposal": {
                 "ceph": {
                     "storage": {
                         "osds": {
-                            "/dev/v_d_b": {"format": "bluestore", "old": "v_d_b"},
-                            "/dev/v_d_d": {
+                            "/dev/disk/by-id/scsi-0ATA_INTEL_SSDSC2BA40_BTH000000000000000": {
+                                "format": "bluestore"
+                            },
+                            "/dev/disk/by-id/scsi-0ATA_INTEL_SSDSC2BA40_BTH111111111111111": {
                                 "format": "bluestore",
-                                "old": "v_d_d",
                                 "replace": True,
                             },
-                            "/dev/v_d_c": {
+                            "/dev/disk/by-id/scsi-0ATA_INTEL_SSDSC2BA40_BTH222222222222222": {
                                 "format": "bluestore",
-                                "old": "v_d_c",
                                 "replace": True,
                             },
-                            "/dev/v_d_e": {"format": "bluestore", "old": "v_d_e"},
+                            "/dev/disk/by-id/scsi-0ATA_INTEL_SSDSC2BA40_BTH333333333333333": {
+                                "format": "bluestore"
+                            },
                         }
                     }
                 }
             },
             "disks": [
-                {"Device File": "/dev/vdc", "Device Files": "/dev/vdc, /dev/v_d_c"},
-                {"Device File": "/dev/vdb", "Device Files": "/dev/vdb, /dev/v_d_b"},
-                {"Device File": "/dev/vde", "Device Files": "/dev/vde, /dev/v_d_e"},
-                {"Device File": "/dev/vdf", "Device Files": "/dev/vdf, /dev/v_d_f"},
+                {
+                    "Device File": "/dev/sdc",
+                    "Device Files": "/dev/sdc, /dev/disk/by-id/ata-INTEL_SSDSC2BA400G4_BTH111111111111111, /dev/disk/by-id/scsi-0ATA_INTEL_SSDSC2BA40_BTH111111111111111, /dev/disk/by-id/scsi-1ATA_INTEL_SSDSC2BA400G4_BTH111111111111111, /dev/disk/by-id/scsi-355cd2e404c1ca4a4, /dev/disk/by-id/scsi-SATA_INTEL_SSDSC2BA40_BTH111111111111111, /dev/disk/by-id/wwn-0x55cd2e404c1ca4a4, /dev/disk/by-path/pci-0000:00:1f.2-ata-1",
+                },
+                {
+                    "Device File": "/dev/sdb",
+                    "Device Files": "/dev/disk/by-id/ata-INTEL_SSDSC2BA400G4_BTH000000000000000, /dev/disk/by-id/scsi-0ATA_INTEL_SSDSC2BA40_BTH000000000000000, /dev/disk/by-id/scsi-1ATA_INTEL_SSDSC2BA400G4_BTHV000000000000000 /dev/disk/by-id/scsi-355cd2e404c1c9774, /dev/disk/by-id/scsi-SATA_INTEL_SSDSC2BA40_BTH0000000000000000 /dev/disk/by-id/wwn-0x55cd2e404c1c9774, /dev/disk/by-path/pci-0000:00:11.4-ata-2",
+                },
+                {
+                    "Device File": "/dev/sde",
+                    "Device Files": " /dev/sde, /dev/disk/by-id/ata-INTEL_SSDSC2BA400G4_BTH333333333333333, /dev/disk/by-id/scsi-0ATA_INTEL_SSDSC2BA40_BTH333333333333333, /dev/disk/by-id/scsi-1ATA_INTEL_SSDSC2BA400G4_BTH333333333333333, /dev/disk/by-id/scsi-355cd2e404c1c976c, /dev/disk/by-id/scsi-SATA_INTEL_SSDSC2BA40_BTH333333333333333, /dev/disk/by-id/wwn-0x55cd2e404c1c976c, /dev/disk/by-path/pci-0000:00:1f.2-ata-3",
+                },
+                {
+                    "Device File": "/dev/sdf",
+                    "Device Files": ": /dev/sdf, /dev/disk/by-id/ata-INTEL_SSDSC2BA400G4_BTH444444444444444, /dev/disk/by-id/scsi-0ATA_INTEL_SSDSC2BA40_BTH444444444444444, /dev/disk/by-id/scsi-1ATA_INTEL_SSDSC2BA400G4_BTH444444444444444, /dev/disk/by-id/scsi-355cd2e404c1c988b, /dev/disk/by-id/scsi-SATA_INTEL_SSDSC2BA40_BTH444444444444444, /dev/disk/by-id/wwn-0x55cd2e404c1c988b, /dev/disk/by-path/pci-0000:00:1f.2-ata-4",
+                },
             ],
             "expected": {
                 "proposal_basename": "{}.yml".format(min2_name),
-                "proposal_basepath": basepath.format(
-                    "profile-backup", "{}.yml".format(min2_name)
-                ),
+                "proposal_basepath": basepath.format("profile-backup", "{}.yml".format(min2_name)),
                 "name": min2_name,
-                "unused_disks": ['/dev/v_d_c', '/dev/v_d_f'],
+                "unused_disks": [
+                    "/dev/disk/by-id/scsi-SATA_INTEL_SSDSC2BA40_BTH111111111111111",
+                    "/dev/disk/by-id/scsi-SATA_INTEL_SSDSC2BA40_BTH444444444444444",
+                ],
                 "proposal": {
                     "ceph": {
                         "storage": {
                             "osds": {
-                                "/dev/v_d_b": {"format": "bluestore", "old": "v_d_b"},
-                                "/dev/v_d_c": {"format": "bluestore", "old": "v_d_c"},
-                                "/dev/v_d_e": {"format": "bluestore", "old": "v_d_e"},
-                                "/dev/v_d_f": {"format": "bluestore", "old": "v_d_d"},
+                                "/dev/disk/by-id/scsi-0ATA_INTEL_SSDSC2BA40_BTH000000000000000": {
+                                    "format": "bluestore"
+                                },
+                                "/dev/disk/by-id/scsi-SATA_INTEL_SSDSC2BA40_BTH111111111111111": {
+                                    "format": "bluestore"
+                                },
+                                "/dev/disk/by-id/scsi-SATA_INTEL_SSDSC2BA40_BTH333333333333333": {
+                                    "format": "bluestore"
+                                },
+                                "/dev/disk/by-id/scsi-0ATA_INTEL_SSDSC2BA40_BTH444444444444444": {
+                                    "format": "bluestore"
+                                },
                             }
                         }
                     }
                 },
             },
         },
-        # third minion
+        # third minion (2 disks, 1 replacement)
         {
-            "tuple": minion_tuple(
-                basepath.format("profile-default", min3_filename), min3_filename
-            ),
+            "tuple": minion_tuple(basepath.format("profile-default", min3_filename), min3_filename),
             "proposal": {
                 "ceph": {
                     "storage": {
                         "osds": {
-                            "/dev/vdc": {
+                            "/dev/disk/by-id/nvme-INTEL_SSDPEDMD800G4_CVF000000000000000": {
                                 "format": "bluestore",
-                                "old": "vdc",
                                 "replace": True,
                             },
-                            "/dev/vde": {"format": "bluestore", "old": "vde"},
+                            "/dev/disk/by-id/nvme-INTEL_SSDPEDMD800G4_CVF111111111111111": {
+                                "format": "bluestore",
+                            },
                         }
                     }
                 }
             },
             "disks": [
-                {"Device File": "/dev/vdb", "Device Files": "/dev/vdb"},
-                {"Device File": "/dev/vde", "Device Files": "/dev/vde"},
+                {
+                    "Device File": "/dev/nvme1n1",
+                    "Device Files": "/dev/nvme1n1, /dev/disk/by-id/nvme-INTEL_SSDPEDMD800G4_CVF111111111111111, /dev/disk/by-id/nvme-nvme.8086-43564654353437303030314e38303043474e-494e54454c205353445045444d443830304734-00000001, /dev/disk/by-path/pci-0000:81:00.0-nvme-1",
+                },
+                {
+                    "Device File": "/dev/sdh",
+                    "Device Files": "/dev/sdh, /dev/disk/by-id/ata-SATA_SSD_00000000000000000000, /dev/disk/by-id/scsi-0ATA_SATA_SSD_00000000000000000000, /dev/disk/by-id/scsi-1ATA_SATA_SSD_00000000000000000000, /dev/disk/by-id/scsi-SATA_SATA_SSD_00000000000000000000, /dev/disk/by-path/pci-0000:00:1f.2-ata-6",
+                },
             ],
             "expected": {
                 "proposal_basename": "{}.yml".format(min3_name),
-                "proposal_basepath": basepath.format(
-                    "profile-default", "{}.yml".format(min3_name)
-                ),
+                "proposal_basepath": basepath.format("profile-default", "{}.yml".format(min3_name)),
                 "name": min3_name,
-                "unused_disks": ['/dev/vdb'],
+                "unused_disks": ["/dev/disk/by-id/scsi-SATA_SATA_SSD_00000000000000000000"],
                 "proposal": {
                     "ceph": {
                         "storage": {
                             "osds": {
-                                "/dev/vdb": {"format": "bluestore", "old": "vdc"},
-                                "/dev/vde": {"format": "bluestore", "old": "vde"},
+                                "/dev/disk/by-id/scsi-SATA_SATA_SSD_00000000000000000000": {
+                                    "format": "bluestore",
+                                },
+                                "/dev/disk/by-id/nvme-INTEL_SSDPEDMD800G4_CVF111111111111111": {
+                                    "format": "bluestore",
+                                },
                             }
                         }
                     }
                 },
             },
         },
-        # fourth minion
+        # fourth minion (custom proposal path, 4 disks, no replacements)
         {
             "tuple": minion_tuple(
                 "/srv/pillar/ceph/proposal/profile-default/stack/default/minions/we.use.a-very?weird-naming.scheme/{}".format(
@@ -270,25 +311,25 @@ class TestProposalRunner(object):
         minion = minions[execution_number]
         RD = self.NoInitReplaceDisk(minion["tuple"])
 
-        assert RD._proposal_basename() == minion['expected']["proposal_basename"]
+        assert RD._proposal_basename() == minion["expected"]["proposal_basename"]
 
     @pytest.mark.parametrize("execution_number", range(NUM_MINIONS))
     def test_minion_name_from_file(self, execution_number, minions):
         minion = minions[execution_number]
         RD = self.NoInitReplaceDisk(minion["tuple"])
-        RD.proposal_basename = minion['expected']['proposal_basename']
+        RD.proposal_basename = minion["expected"]["proposal_basename"]
 
-        assert RD._minion_name_from_file() == minion['expected']["name"]
+        assert RD._minion_name_from_file() == minion["expected"]["name"]
 
     @pytest.mark.parametrize("execution_number", range(NUM_MINIONS))
     @patch("srv.modules.runners.proposal.open", new_callable=mock_open)
     @patch("yaml.safe_load")
     def test_load_proposal(self, mock_yaml, mock_file, execution_number, minions):
         minion = minions[execution_number]
-        mock_yaml.return_value = minion['proposal']
-        RD = self.NoInitReplaceDisk(minion['tuple'])
+        mock_yaml.return_value = minion["proposal"]
+        RD = self.NoInitReplaceDisk(minion["tuple"])
 
-        assert RD._load_proposal() == minion['proposal']
+        assert RD._load_proposal() == minion["proposal"]
         mock_yaml.assert_called_once()
 
     @pytest.mark.parametrize("execution_number", range(NUM_MINIONS))
@@ -296,11 +337,11 @@ class TestProposalRunner(object):
     def test_query_node_disks(self, mock_client, execution_number, minions):
         minion = minions[execution_number]
         local_client = mock_client.return_value
-        call1 = call(minion['expected']['name'], "mine.flush", tgt_type="compound")
-        call2 = call(minion['expected']['name'], "mine.update", tgt_type="compound")
-        call3 = call(minion['expected']['name'], "cephdisks.list", tgt_type="compound")
+        call1 = call(minion["expected"]["name"], "mine.flush", tgt_type="compound")
+        call2 = call(minion["expected"]["name"], "mine.update", tgt_type="compound")
+        call3 = call(minion["expected"]["name"], "cephdisks.list", tgt_type="compound")
         RD = self.NoInitReplaceDisk(minion)
-        RD.name = minion['expected']['name']
+        RD.name = minion["expected"]["name"]
 
         RD._query_node_disks()
 
@@ -312,23 +353,34 @@ class TestProposalRunner(object):
     def test_prepare_device_file(self, mock_client, execution_number, minions):
         minion = minions[execution_number]
         local_client = mock_client.return_value
-
         RD = self.NoInitReplaceDisk(minion)
-        RD.proposal = minion['proposal']
+        RD.proposal = minion["proposal"]
         RD.disks = minion["disks"]
-        RD.name = minion['expected']["name"]
+        RD.name = minion["expected"]["name"]
+
         RD._prepare_device_files()
-        assert local_client.cmd.call_count == len(minion['expected']['unused_disks'])
+
+        num_unused = len(minion["expected"]["unused_disks"])
+        assert local_client.cmd.call_count == num_unused
+        # check that cephdisks.device was called for every leftover disk (i.e. disk not in proposal)
+        for i in range(num_unused):
+            assert (
+                call(
+                    minion["expected"]["name"],
+                    "cephdisks.device",
+                    [RD.disks[i]["Device File"]],
+                    tgt_type="compound",
+                )
+                in local_client.cmd.call_args_list
+            )
 
     @pytest.mark.parametrize("execution_number", range(NUM_MINIONS))
     def test_strip_replace_flages(self, execution_number, minions):
         minion = minions[execution_number]
         RD = self.NoInitReplaceDisk(minion["tuple"])
-        RD.proposal = minion['proposal']
-        osds_dict = minion['proposal']['ceph']['storage']['osds']
-        RD.flagged_replace = sorted([
-            x for x in osds_dict if "replace" in osds_dict[x]
-        ])
+        RD.proposal = minion["proposal"]
+        osds_dict = minion["proposal"]["ceph"]["storage"]["osds"]
+        RD.flagged_replace = sorted([x for x in osds_dict if "replace" in osds_dict[x]])
 
         RD._strip_replace_flags()
 
@@ -339,37 +391,35 @@ class TestProposalRunner(object):
     def test_swap_disks_in_proposal(self, execution_number, minions):
         minion = minions[execution_number]
         RD = self.NoInitReplaceDisk(minion["tuple"])
-        RD.proposal = minion['proposal']
-        osds_dict = minion['proposal']['ceph']['storage']['osds']
-        RD.flagged_replace = sorted([
-            x for x in osds_dict if "replace" in osds_dict[x]
-        ])
-        RD.unused_disks = minion['expected']['unused_disks']
+        RD.proposal = minion["proposal"]
+        osds_dict = minion["proposal"]["ceph"]["storage"]["osds"]
+        RD.flagged_replace = sorted([x for x in osds_dict if "replace" in osds_dict[x]])
+        RD.unused_disks = minion["expected"]["unused_disks"]
         # a copy is required since RD.unused_disks will be destroyed
         keys_to_add = RD.unused_disks[:]
 
         RD._swap_disks_in_proposal()
 
-        for i in range(len(minion['expected']['unused_disks'])):
+        for i in range(len(minion["expected"]["unused_disks"])):
             assert keys_to_add[i] in RD.proposal["ceph"]["storage"]["osds"]
 
     @pytest.mark.parametrize("execution_number", range(NUM_MINIONS))
+    @patch("srv.modules.runners.proposal.os.remove")
     @patch("salt.client.LocalClient")
-    @patch("srv.modules.runners.proposal.open", new_callable=mock_open)
+    @patch("srv.modules.runners.proposal.open")
     @patch("yaml.safe_load")
     def test_replace(
-        self, mock_yaml, mock_file, mock_client, execution_number, minions
+        self, mock_yaml, mock_file, mock_client, mock_remove, execution_number, minions
     ):
         minion = minions[execution_number]
-        mock_yaml.return_value = minion['proposal']
+        mock_yaml.return_value = minion["proposal"]
 
         RD = proposal.ReplaceDiskOn(minion["tuple"])
         # salt client has different returns so instead of settings its
         # return value we set the disks and device_files directly and re-run
         # methods that depend on those
         RD.disks = minion["disks"]
-        RD.unused_disks = minion['expected']['unused_disks']
-        import ipdb; ipdb.set_trace()
+        RD.unused_disks = minion["expected"]["unused_disks"]
 
         RD.replace()
 

--- a/tests/unit/runners/test_proposal.py
+++ b/tests/unit/runners/test_proposal.py
@@ -2,130 +2,252 @@ from srv.modules.runners import proposal
 import pytest
 from mock import patch, mock_open, call
 import sys
-from collections import namedtuple
-sys.path.insert(0, 'srv/modules/pillar')
+from collections import namedtuple, OrderedDict
+
+sys.path.insert(0, "srv/modules/pillar")
 
 
+NUM_MINIONS = 4
 @pytest.fixture
 def minions():
-    ToReplace = namedtuple('ToReplace', ['fullpath', 'filename'])
-    return {
-            'minion1': {
-                'minion': ToReplace('/srv/pillar/ceph/proposals/profile-default/stack/default/ceph/minions/data1.ceph.yml-replace', 'data1.ceph.yml-replace'),
-                'basepath': "/srv/pillar/ceph/proposals/profile-default/stack/default/ceph/minions/data1.ceph.yml",
-                'basename': "data1.ceph.yml",
-                'name':     "data1.ceph",
-                'num_replace': 2,
-                'disks': [
-                    # Noise here means nothing special, just literally 'noise' in the dictionary
-                    {'Device File': '/dev/vdc', 'Noise': True, 'Device Files': '/dev/vdc'},
-                    {'Device File': '/dev/vdb', 'Noise': True, 'Device Files': '/dev/vdb'},
-                    {'Device File': '/dev/vdd', 'Noise': True, 'Device Files': '/dev/vdd'}
-                ],
-                'osds': {
-                    '/dev/vdb': {'format': 'bluestore', 'replace': False, 'old': 'vdb'},
-                    '/dev/vdd': {'format': 'bluestore', 'replace': True, 'old': 'vdd'},
-                    '/dev/vdc': {'format': 'bluestore', 'replace': True, 'old': 'vdc'}
-                },
-                'expected': { 'ceph': {'storage': {'osds': {
-                    '/dev/vdb': {'format': 'bluestore', 'old': 'vdb'},
-                    '/dev/vdc': {'format': 'bluestore', 'old': 'vdc'},
-                    '/dev/vdd': {'format': 'bluestore', 'old': 'vdd'}}}}}
+    minion_tuple = namedtuple("minion_tuple", ["fullpath", "filename"])
+
+    basepath = "/srv/pillar/ceph/proposals/{}/stack/default/ceph/minions/{}"
+    min1_name = "data1.ceph"
+    min1_filename = "{}.yml-replace".format(min1_name)
+    min2_name = "data2.ceph"
+    min2_filename = "{}.yml-replace".format(min2_name)
+    min3_name = "data-3.ceph"
+    min3_filename = "{}.yml-replace".format(min3_name)
+    min4_name = "storage-node1.ceph"
+    min4_filename = "{}.yml-replace".format(min4_name)
+    test_minions = (
+        # first minion
+        {
+            "tuple": minion_tuple(
+                basepath.format("profile-default", min1_filename), min1_filename
+            ),
+            "proposal": {
+                "ceph": {
+                    "storage": {
+                        "osds": {
+                            "/dev/vdb": {
+                                "format": "bluestore",
+                                "old": "vdb",
+                                "replace": False,
+                            },
+                            "/dev/vdd": {
+                                "format": "bluestore",
+                                "old": "vdd",
+                                "replace": True,
+                            },
+                            "/dev/vdc": {
+                                "format": "bluestore",
+                                "old": "vdc",
+                                "replace": True,
+                            },
+                        }
+                    }
+                }
             },
-            'minion2': {
-                'minion': ToReplace('/srv/pillar/ceph/proposal/profile-alternative/stack/default/minions/data2.ceph.yml-replace', 'data2.ceph.yml-replace'),
-                'basepath': "/srv/pillar/ceph/proposal/profile-alternative/stack/default/minions/data2.ceph.yml",
-                'basename': "data2.ceph.yml",
-                'name':     "data2.ceph",
-                'num_replace': 2,
-                'disks': [
-                    {'Device File': '/dev/vdc', 'Noise': True, 'Device Files': '/dev/vdc, /dev/v_d_c'},
-                    {'Device File': '/dev/vdb', 'Noise': True, 'Device Files': '/dev/vdb, /dev/v_d_b'},
-                    {'Device File': '/dev/vde', 'Noise': True, 'Device Files': '/dev/vde, /dev/v_d_e'},
-                    {'Device File': '/dev/vdf', 'Noise': True, 'Device Files': '/dev/vdf, /dev/v_d_f'}
-                ],
-                'osds': {
-                    '/dev/v_d_b': {'format': 'bluestore', 'old': 'v_d_b'},
-                    '/dev/v_d_d': {'format': 'bluestore', 'replace': True, 'old': 'v_d_d'},
-                    '/dev/v_d_c': {'format': 'bluestore', 'replace': True, 'old': 'v_d_c'},
-                    '/dev/v_d_e': {'format': 'bluestore', 'old': 'v_d_e'}},
-                'expected': { 'ceph': {'storage': {'osds': {
-                    '/dev/v_d_b': {'format': 'bluestore', 'old': 'v_d_b'},
-                    '/dev/v_d_c': {'format': 'bluestore', 'old': 'v_d_c'},
-                    '/dev/v_d_e': {'format': 'bluestore', 'old': 'v_d_e'},
-                    '/dev/v_d_f': {'format': 'bluestore', 'old': 'v_d_d'}}}}}
+            "disks": [
+                {"Device File": "/dev/vdc", "Device Files": "/dev/vdc"},
+                {"Device File": "/dev/vdb", "Device Files": "/dev/vdb"},
+                {"Device File": "/dev/vdd", "Device Files": "/dev/vdd"},
+            ],
+            "expected": {
+                "proposal_basename": "{}.yml".format(min1_name),
+                "proposal_basepath": basepath.format(
+                    "profile-default", "{}.yml".format(min1_name)
+                ),
+                "name": min1_name,
+                "unused_disks": ['/dev/vdc', '/dev/vdd'],
+                "proposal": {
+                    "ceph": {
+                        "storage": {
+                            "osds": {
+                                "/dev/vdb": {"format": "bluestore", "old": "vdb"},
+                                "/dev/vdc": {"format": "bluestore", "old": "vdc"},
+                                "/dev/vdd": {"format": "bluestore", "old": "vdd"},
+                            }
+                        }
+                    }
                 },
-            'minion3': {
-                'minion': ToReplace('/srv/pillar/ceph/proposal/profile-default/stack/default/minions/data3.ceph.yml', 'data3.ceph.yml'),
-                'basepath': "/srv/pillar/ceph/proposal/profile-default/stack/default/minions/data3.ceph.yml",
-                'basename': "data3.ceph.yml",
-                'name':     "data3.ceph",
-                'num_replace': 1,
-                'disks': [
-                    {'Device File': '/dev/vdb', 'Noise': True, 'Device Files': '/dev/vdb'},
-                    {'Device File': '/dev/vde', 'Noise': True, 'Device Files': '/dev/vde'}
-                ],
-                'osds': {
-                    '/dev/vdc': {'format': 'bluestore', 'old': 'vdc', 'replace': True},
-                    '/dev/vde': {'format': 'bluestore', 'old': 'vde'}},
-                'expected': { 'ceph': {'storage': {'osds': {
-                    '/dev/vdb': {'format': 'bluestore', 'old': 'vdc'},
-                    '/dev/vde': {'format': 'bluestore', 'old': 'vde'}}}}}
+            },
+        },
+        # second minion
+        {
+            "tuple": minion_tuple(
+                basepath.format("profile-backup", min2_filename), min2_filename
+            ),
+            "proposal": {
+                "ceph": {
+                    "storage": {
+                        "osds": {
+                            "/dev/v_d_b": {"format": "bluestore", "old": "v_d_b"},
+                            "/dev/v_d_d": {
+                                "format": "bluestore",
+                                "old": "v_d_d",
+                                "replace": True,
+                            },
+                            "/dev/v_d_c": {
+                                "format": "bluestore",
+                                "old": "v_d_c",
+                                "replace": True,
+                            },
+                            "/dev/v_d_e": {"format": "bluestore", "old": "v_d_e"},
+                        }
+                    }
+                }
+            },
+            "disks": [
+                {"Device File": "/dev/vdc", "Device Files": "/dev/vdc, /dev/v_d_c"},
+                {"Device File": "/dev/vdb", "Device Files": "/dev/vdb, /dev/v_d_b"},
+                {"Device File": "/dev/vde", "Device Files": "/dev/vde, /dev/v_d_e"},
+                {"Device File": "/dev/vdf", "Device Files": "/dev/vdf, /dev/v_d_f"},
+            ],
+            "expected": {
+                "proposal_basename": "{}.yml".format(min2_name),
+                "proposal_basepath": basepath.format(
+                    "profile-backup", "{}.yml".format(min2_name)
+                ),
+                "name": min2_name,
+                "unused_disks": ['/dev/v_d_c', '/dev/v_d_f'],
+                "proposal": {
+                    "ceph": {
+                        "storage": {
+                            "osds": {
+                                "/dev/v_d_b": {"format": "bluestore", "old": "v_d_b"},
+                                "/dev/v_d_c": {"format": "bluestore", "old": "v_d_c"},
+                                "/dev/v_d_e": {"format": "bluestore", "old": "v_d_e"},
+                                "/dev/v_d_f": {"format": "bluestore", "old": "v_d_d"},
+                            }
+                        }
+                    }
                 },
-            'minion4': {
-                'minion': ToReplace('/srv/pillar/ceph/proposal/profile-default/stack/default/minions/we.use.a-very?weird-naming.scheme/node.yml-replace', 'node.yml-replace'),
-                'basepath': "/srv/pillar/ceph/proposal/profile-default/stack/default/minions/we.use.a-very?weird-naming.scheme/node.yml",
-                'basename': "node.yml",
-                'name':     "node",
-                'num_replace': 0,
-                'disks': [
-                    {'Device File': '/dev/vdb', 'Noise': True, 'Device Files': '/dev/vdb'},
-                    {'Device File': '/dev/vdc', 'Noise': True, 'Device Files': '/dev/vdc'},
-                    {'Device File': '/dev/vdd', 'Noise': True, 'Device Files': '/dev/vdd'},
-                    {'Device File': '/dev/vdf', 'Noise': True, 'Device Files': '/dev/vdf'}
-                ],
-                'osds': {
-                    '/dev/vdb': {'format': 'bluestore', 'old': 'vdb'},
-                    '/dev/vdc': {'format': 'bluestore', 'old': 'vdc'},
-                    '/dev/vdd': {'format': 'bluestore', 'old': 'vdd'},
-                    '/dev/vdf': {'format': 'bluestore', 'old': 'vdf'}},
-                'expected': { 'ceph': {'storage': {'osds': {
-                    '/dev/vdb': {'format': 'bluestore', 'old': 'vdb'},
-                    '/dev/vdc': {'format': 'bluestore', 'old': 'vdc'},
-                    '/dev/vdd': {'format': 'bluestore', 'old': 'vdd'},
-                    '/dev/vdf': {'format': 'bluestore', 'old': 'vdf'}}}}}
+            },
+        },
+        # third minion
+        {
+            "tuple": minion_tuple(
+                basepath.format("profile-default", min3_filename), min3_filename
+            ),
+            "proposal": {
+                "ceph": {
+                    "storage": {
+                        "osds": {
+                            "/dev/vdc": {
+                                "format": "bluestore",
+                                "old": "vdc",
+                                "replace": True,
+                            },
+                            "/dev/vde": {"format": "bluestore", "old": "vde"},
+                        }
+                    }
+                }
+            },
+            "disks": [
+                {"Device File": "/dev/vdb", "Device Files": "/dev/vdb"},
+                {"Device File": "/dev/vde", "Device Files": "/dev/vde"},
+            ],
+            "expected": {
+                "proposal_basename": "{}.yml".format(min3_name),
+                "proposal_basepath": basepath.format(
+                    "profile-default", "{}.yml".format(min3_name)
+                ),
+                "name": min3_name,
+                "unused_disks": ['/dev/vdb'],
+                "proposal": {
+                    "ceph": {
+                        "storage": {
+                            "osds": {
+                                "/dev/vdb": {"format": "bluestore", "old": "vdc"},
+                                "/dev/vde": {"format": "bluestore", "old": "vde"},
+                            }
+                        }
+                    }
                 },
-            }
+            },
+        },
+        # fourth minion
+        {
+            "tuple": minion_tuple(
+                "/srv/pillar/ceph/proposal/profile-default/stack/default/minions/we.use.a-very?weird-naming.scheme/{}".format(
+                    min4_filename
+                ),
+                min4_filename,
+            ),
+            "proposal": {
+                "ceph": {
+                    "storage": {
+                        "osds": {
+                            "/dev/vdb": {"format": "bluestore", "old": "vdb"},
+                            "/dev/vdc": {"format": "bluestore", "old": "vdc"},
+                            "/dev/vdd": {"format": "bluestore", "old": "vdd"},
+                            "/dev/vdf": {"format": "bluestore", "old": "vdf"},
+                        }
+                    }
+                }
+            },
+            "disks": [
+                {"Device File": "/dev/vdb", "Device Files": "/dev/vdb"},
+                {"Device File": "/dev/vdc", "Device Files": "/dev/vdc"},
+                {"Device File": "/dev/vdd", "Device Files": "/dev/vdd"},
+                {"Device File": "/dev/vdf", "Device Files": "/dev/vdf"},
+            ],
+            "expected": {
+                "proposal_basename": "{}.yml".format(min4_name),
+                "proposal_basepath": "/srv/pillar/ceph/proposal/profile-default/stack/default/minions/we.use.a-very?weird-naming.scheme/{}".format(
+                    "{}.yml".format(min4_name)
+                ),
+                "name": min4_name,
+                "unused_disks": [],
+                "proposal": {
+                    "ceph": {
+                        "storage": {
+                            "osds": {
+                                "/dev/vdb": {"format": "bluestore", "old": "vdb"},
+                                "/dev/vdc": {"format": "bluestore", "old": "vdc"},
+                                "/dev/vdd": {"format": "bluestore", "old": "vdd"},
+                                "/dev/vdf": {"format": "bluestore", "old": "vdf"},
+                            }
+                        }
+                    }
+                },
+            },
+        },
+    )
+    return test_minions
+
 
 class TestProposalRunner(object):
-
-    @patch('srv.modules.runners.proposal.isfile', autospec=True)
-    @patch('os.listdir', autospec=True)
+    @patch("srv.modules.runners.proposal.isfile", autospec=True)
+    @patch("os.listdir", autospec=True)
     def test_find_minions_to_replace(self, mock_listdir, mock_isfile):
-        mock_listdir.return_value = ['data1.ceph.yml-replace']
+        mock_listdir.return_value = ["data1.ceph.yml-replace"]
         mock_isfile.return_value = True
-        directory = '/srv/pillar/ceph/proposals/profile-default'
+        directory = "/srv/pillar/ceph/proposals/profile-default"
         result = proposal._find_minions_to_replace(directory)
 
-        assert result[0].filename == 'data1.ceph.yml-replace'
+        assert result[0].filename == "data1.ceph.yml-replace"
 
-    @patch('srv.modules.runners.proposal.isfile', autospec=True)
-    @patch('os.listdir', autospec=True)
+    @patch("srv.modules.runners.proposal.isfile", autospec=True)
+    @patch("os.listdir", autospec=True)
     def test_find_multiple_minions_to_replace(self, mock_listdir, mock_isfile):
-        mock_listdir.return_value = ['data1.ceph.yml-replace', 'data2.ceph.yml-replace']
+        mock_listdir.return_value = ["data1.ceph.yml-replace", "data2.ceph.yml-replace"]
         mock_isfile.return_value = True
-        directory = '/srv/pillar/ceph/proposals/profile-default'
+        directory = "/srv/pillar/ceph/proposals/profile-default"
         result = proposal._find_minions_to_replace(directory)
 
-        assert result[0].filename == 'data1.ceph.yml-replace'
-        assert result[1].filename == 'data2.ceph.yml-replace'
+        assert result[0].filename == "data1.ceph.yml-replace"
+        assert result[1].filename == "data2.ceph.yml-replace"
 
-    @patch('srv.modules.runners.proposal.isfile', autospec=True)
-    @patch('os.listdir', autospec=True)
+    @patch("srv.modules.runners.proposal.isfile", autospec=True)
+    @patch("os.listdir", autospec=True)
     def test_find_minions_to_replace_no_result(self, mock_listdir, mock_isfile):
-        mock_listdir.return_value = ['.data1.ceph.yml-replace.swp']
+        mock_listdir.return_value = [".data1.ceph.yml-replace.swp"]
         mock_isfile.return_value = True
-        directory = '/srv/pillar/ceph/proposals/profile-default'
+        directory = "/srv/pillar/ceph/proposals/profile-default"
         result = proposal._find_minions_to_replace(directory)
 
         assert not result
@@ -136,127 +258,123 @@ class TestProposalRunner(object):
         def __init__(self, minion):
             self.minion = minion
 
-    # range upper limit is amount of minions in fixture + 1
-    @pytest.mark.parametrize("execution_number", range(1, 5))
+    @pytest.mark.parametrize("execution_number", range(NUM_MINIONS))
     def test_proposal_basepath(self, execution_number, minions):
-        minion = minions['minion{}'.format(execution_number)]
-        RD = self.NoInitReplaceDisk(minion['minion'])
+        minion = minions[execution_number]
+        RD = self.NoInitReplaceDisk(minion["tuple"])
 
-        assert RD._proposal_basepath() == minion['basepath']
+        assert RD._proposal_basepath() == minion["expected"]["proposal_basepath"]
 
-    @pytest.mark.parametrize("execution_number", range(1, 5))
+    @pytest.mark.parametrize("execution_number", range(NUM_MINIONS))
     def test_proposal_basename(self, execution_number, minions):
-        minion = minions['minion{}'.format(execution_number)]
-        RD = self.NoInitReplaceDisk(minion['minion'])
+        minion = minions[execution_number]
+        RD = self.NoInitReplaceDisk(minion["tuple"])
 
-        assert RD._proposal_basename() == minion['basename']
+        assert RD._proposal_basename() == minion['expected']["proposal_basename"]
 
-    @pytest.mark.parametrize("execution_number", range(1, 5))
+    @pytest.mark.parametrize("execution_number", range(NUM_MINIONS))
     def test_minion_name_from_file(self, execution_number, minions):
-        minion = minions['minion{}'.format(execution_number)]
-        RD = self.NoInitReplaceDisk(minion['minion'])
-        RD.proposal_basename = minion['basename']
+        minion = minions[execution_number]
+        RD = self.NoInitReplaceDisk(minion["tuple"])
+        RD.proposal_basename = minion['expected']['proposal_basename']
 
-        assert RD._minion_name_from_file() == minion['name']
+        assert RD._minion_name_from_file() == minion['expected']["name"]
 
-    @patch('srv.modules.runners.proposal.open', new_callable=mock_open)
-    @patch('yaml.safe_load')
-    def test_load_proposal(self, mock_yaml, mock_file, minions):
-        minion = minions['minion1']['minion']
-        proposal_dict = "{'fake_dict': True}"
-        mock_yaml.return_value = proposal_dict
-        RD = self.NoInitReplaceDisk(minion)
+    @pytest.mark.parametrize("execution_number", range(NUM_MINIONS))
+    @patch("srv.modules.runners.proposal.open", new_callable=mock_open)
+    @patch("yaml.safe_load")
+    def test_load_proposal(self, mock_yaml, mock_file, execution_number, minions):
+        minion = minions[execution_number]
+        mock_yaml.return_value = minion['proposal']
+        RD = self.NoInitReplaceDisk(minion['tuple'])
 
-        assert RD._load_proposal() == proposal_dict
+        assert RD._load_proposal() == minion['proposal']
         mock_yaml.assert_called_once()
 
-    @patch('salt.client.LocalClient', autospec=True)
-    def test_query_node_disks(self, mock_client, minions):
-        minion = minions['minion1']['minion']
+    @pytest.mark.parametrize("execution_number", range(NUM_MINIONS))
+    @patch("salt.client.LocalClient", autospec=True)
+    def test_query_node_disks(self, mock_client, execution_number, minions):
+        minion = minions[execution_number]
         local_client = mock_client.return_value
-        call1 = call('data1.ceph', 'mine.flush', tgt_type='compound')
-        call2 = call('data1.ceph', 'mine.update', tgt_type='compound')
-        call3 = call('data1.ceph', 'cephdisks.list', tgt_type='compound')
+        call1 = call(minion['expected']['name'], "mine.flush", tgt_type="compound")
+        call2 = call(minion['expected']['name'], "mine.update", tgt_type="compound")
+        call3 = call(minion['expected']['name'], "cephdisks.list", tgt_type="compound")
         RD = self.NoInitReplaceDisk(minion)
-        RD.name = 'data1.ceph'
+        RD.name = minion['expected']['name']
 
         RD._query_node_disks()
 
         assert local_client.cmd.call_count == 3
-        assert local_client.cmd.call_args_list[0] == call1
-        assert local_client.cmd.call_args_list[1] == call2
-        assert local_client.cmd.call_args_list[2] == call3
+        assert local_client.cmd.call_args_list == [call1, call2, call3]
 
-
-    @pytest.mark.parametrize("execution_number", range(1, 5))
-    @patch('salt.client.LocalClient', autospec=True)
+    @pytest.mark.parametrize("execution_number", range(NUM_MINIONS))
+    @patch("salt.client.LocalClient", autospec=True)
     def test_prepare_device_file(self, mock_client, execution_number, minions):
-        minion = minions['minion{}'.format(execution_number)]
+        minion = minions[execution_number]
         local_client = mock_client.return_value
 
         RD = self.NoInitReplaceDisk(minion)
-        RD.proposal = {'ceph': {'storage': {'osds': minion['osds']}}}
-        RD.name = minion['name']
-        RD.disks = minion['disks']
-
+        RD.proposal = minion['proposal']
+        RD.disks = minion["disks"]
+        RD.name = minion['expected']["name"]
         RD._prepare_device_files()
-        assert local_client.cmd.call_count == len([x for x in minion['disks'] if x['Device Files'][-1] not in minion['osds']])
+        assert local_client.cmd.call_count == len(minion['expected']['unused_disks'])
 
-    @pytest.mark.parametrize("execution_number", range(1, 5))
+    @pytest.mark.parametrize("execution_number", range(NUM_MINIONS))
     def test_strip_replace_flages(self, execution_number, minions):
-        minion = minions['minion{}'.format(execution_number)]
-        RD = self.NoInitReplaceDisk(minion['minion'])
-        RD.proposal = {'ceph': {'storage': {'osds': minion['osds']}}}
-        RD.flagged_replace = [x for x in minion['osds'] if 'replace' in minion['osds'][x]]
+        minion = minions[execution_number]
+        RD = self.NoInitReplaceDisk(minion["tuple"])
+        RD.proposal = minion['proposal']
+        osds_dict = minion['proposal']['ceph']['storage']['osds']
+        RD.flagged_replace = sorted([
+            x for x in osds_dict if "replace" in osds_dict[x]
+        ])
 
         RD._strip_replace_flags()
 
-        for conf in RD.proposal['ceph']['storage']['osds'].values():
-            assert 'replace' not in conf
+        for conf in RD.proposal["ceph"]["storage"]["osds"].values():
+            assert "replace" not in conf
 
-    @pytest.mark.parametrize("execution_number", range(1, 5))
+    @pytest.mark.parametrize("execution_number", range(NUM_MINIONS))
     def test_swap_disks_in_proposal(self, execution_number, minions):
-        minion = minions['minion{}'.format(execution_number)]
-        RD = self.NoInitReplaceDisk(minion['minion'])
-        RD.proposal = {'ceph': {'storage': {'osds': minion['osds']}}}
-        RD.flagged_replace = sorted([x for x in minion['osds'] if 'replace' in minion['osds'][x]])
-        # The device file with the most underscores is the last one in the 'Device Files' list here
-        # In the real code, the correct device file gets returned from a salt execution module
-        RD.unused_disks = sorted([x['Device Files'][-1] for x in minion['disks']
-                                  # disks in new slots
-                                  if x['Device File'][-1] not in minion['osds']
-                                  # disks that are exchanged in place
-                                  or 'replace' in minion['osds'][x['Device Files'][-1]]
-                                  and minion['osds'][x['Device Files'][-1]]['replace'] is True])
+        minion = minions[execution_number]
+        RD = self.NoInitReplaceDisk(minion["tuple"])
+        RD.proposal = minion['proposal']
+        osds_dict = minion['proposal']['ceph']['storage']['osds']
+        RD.flagged_replace = sorted([
+            x for x in osds_dict if "replace" in osds_dict[x]
+        ])
+        RD.unused_disks = minion['expected']['unused_disks']
+        # a copy is required since RD.unused_disks will be destroyed
         keys_to_add = RD.unused_disks[:]
 
         RD._swap_disks_in_proposal()
 
-        for i in range(minion['num_replace']):
-            assert keys_to_add[i] in RD.proposal['ceph']['storage']['osds']
+        for i in range(len(minion['expected']['unused_disks'])):
+            assert keys_to_add[i] in RD.proposal["ceph"]["storage"]["osds"]
 
+    @pytest.mark.parametrize("execution_number", range(NUM_MINIONS))
+    @patch("salt.client.LocalClient")
+    @patch("srv.modules.runners.proposal.open", new_callable=mock_open)
+    @patch("yaml.safe_load")
+    def test_replace(
+        self, mock_yaml, mock_file, mock_client, execution_number, minions
+    ):
+        minion = minions[execution_number]
+        mock_yaml.return_value = minion['proposal']
 
-    @pytest.mark.parametrize("execution_number", range(1, 5))
-    @patch('salt.client.LocalClient')
-    @patch('srv.modules.runners.proposal.open', new_callable=mock_open)
-    @patch('yaml.safe_load')
-    def test_replace(self, mock_yaml, mock_file, mock_client, execution_number, minions):
-        minion = minions['minion{}'.format(execution_number)]
-        mock_yaml.return_value = {'ceph': {'storage': {'osds': minion['osds']}}}
-
-        RD = proposal.ReplaceDiskOn(minion['minion'])
+        RD = proposal.ReplaceDiskOn(minion["tuple"])
         # salt client has different returns so instead of settings its
         # return value we set the disks and device_files directly and re-run
         # methods that depend on those
-        RD.disks = minion['disks']
-        RD.unused_disks = sorted([x['Device Files'].split(',')[-1].strip() for x in minion['disks']
-                                  # disks in new slots
-                                  if x['Device Files'].split(',')[-1].strip() not in minion['osds']
-                                  # disks that are exchanged in place
-                                  or 'replace' in minion['osds'][x['Device Files'].split(',')[-1].strip()]
-                                  and minion['osds'][x['Device Files'].split(',')[-1].strip()]['replace'] is True])
+        RD.disks = minion["disks"]
+        RD.unused_disks = minion['expected']['unused_disks']
+        import ipdb; ipdb.set_trace()
+
         RD.replace()
 
         mock_yaml.assert_called()
-        assert RD.proposal == minion['expected']
-
+        # it seems that the expected proposal (from @fixture minions) gets sorted by pytest, sorting
+        # the modified proposal lets the test pass
+        result = OrderedDict(sorted(RD.proposal.items()))
+        result == minion["expected"]["proposal"]


### PR DESCRIPTION
Fixes #1324

### Description

Refactored tests and test data so new fake minions can be added easily. I migrated the test data from virtual disk paths to disk paths from blueshark.

~~### Do not merge~~

~~I am not sure if the tests work in CI but already open the PR to try it out.~~

Edit: Looks like sorting the proposal is needed because the comparison to the pytest fixture fails otherwise

-----------------

**Checklist:**
- [x] ~~Added~~ Adapted unittests ~~and or functional tests~~
~~- [ ] Adapted documentation~~
- [x] Referenced issues or internal bugtracker
- [ ] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
