### PR TITLE
[DNM] github: remove trigger phrase from PR description

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,4 +10,4 @@ Description:
 - [ ] Added unittests and or functional tests
 - [ ] Adapted documentation
 - [ ] Referenced issues or internal bugtracker
-- [ ] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
+- [ ] Ran integration tests successfully (see [this link](https://github.com/SUSE/DeepSea/wiki/Testing#how-to-trigger) for instructions)


### PR DESCRIPTION
Apparently, the Jenkins github plugin gets confused when we put the trigger
phrase in the PR description. Replace it with a link to:

https://github.com/SUSE/DeepSea/wiki/Testing#how-to-trigger

Signed-off-by: Nathan Cutler <ncutler@suse.com>

Fixes #


Description:


-----------------

**Checklist:**
- [ ] Added unittests and or functional tests
- [ ] Adapted documentation
- [ ] Referenced issues or internal bugtracker
- [ ] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
