### PR TITLE
[backport][ses5] monitoring: fix rbd_exporter pool parsing for ids > 9

### DIFF
--- a/srv/salt/ceph/monitoring/prometheus/exporters/files/rbd.sh
+++ b/srv/salt/ceph/monitoring/prometheus/exporters/files/rbd.sh
@@ -34,7 +34,7 @@ for conf in /etc/ceph/*.conf
 do
     filename=$(basename "$conf")
     cluster="${filename%.*}"
-    pools="$(ceph -c $conf osd lspools 2>/dev/null | sed 's/[[:digit:]] \([^,]*\),/\1 /g')"
+    pools="$(ceph -c $conf osd lspools 2>/dev/null | sed 's/[[:digit:]]\+ \([^,]*\),/\1 /g')"
     for pool in $pools
     do
         for img in `rbd -p $pool ls`; do


### PR DESCRIPTION
There was an issue with an sed regex that broke the exporter for pools
with IDs greater then 9.

Signed-off-by: Jan Fajerski <jfajerski@suse.com>

Fixes: bsc#1106872
Backport of #1338 


**Checklist:**
- [ ] Added unittests and or functional tests
- [ ] Adapted documentation
- [x] Referenced issues or internal bugtracker
- [ ] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
