### PR TITLE
qa: always run Stage 3 with tuned disabled

### DIFF
--- a/qa/common/common.sh
+++ b/qa/common/common.sh
@@ -68,9 +68,20 @@ function run_stage_2 {
     test "$STAGE_SUCCEEDED"
 }
 
+function _disable_tuned {
+    local prefix=/srv/salt/ceph/tuned
+    mv $prefix/mgr/default.sls $prefix/mgr/default.sls-MOVED
+    mv $prefix/mon/default.sls $prefix/mon/default.sls-MOVED
+    mv $prefix/osd/default.sls $prefix/osd/default.sls-MOVED
+    mv $prefix/mgr/default-off.sls $prefix/mgr/default.sls
+    mv $prefix/mon/default-off.sls $prefix/mon/default.sls
+    mv $prefix/osd/default-off.sls $prefix/osd/default.sls
+}
+
 function run_stage_3 {
     cat_global_conf
     lsblk_on_storage_node
+    _disable_tuned
     _run_stage 3 "$@"
     ceph_disk_list_on_storage_node
     ceph osd tree


### PR DESCRIPTION
Two reasons for this:

1. this might fix a transient Stage 3 hang/timeout
2. tuned is not needed for integration testing

Signed-off-by: Nathan Cutler <ncutler@suse.com>

-----------------

**Checklist:**
~~- [ ] Added unittests and or functional tests~~
~~- [ ] Adapted documentation~~
~~- [ ] Referenced issues or internal bugtracker~~
- [ ] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
