### PR TITLE
[backport][SES5] monitoring: fix fs fillup time query

### DIFF
--- a/srv/salt/ceph/monitoring/grafana/files/node.json
+++ b/srv/salt/ceph/monitoring/grafana/files/node.json
@@ -528,6 +528,7 @@
                 "value": "current"
               }
             ],
+            "datasource": "Prometheus",
             "editable": false,
             "error": false,
             "filterNull": false,
@@ -545,32 +546,44 @@
             "span": 4,
             "styles": [
               {
-                "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                "pattern": "Time",
-                "type": "date"
-              },
-              {
                 "colorMode": null,
                 "colors": [
                   "rgba(245, 54, 54, 0.9)",
                   "rgba(237, 129, 40, 0.89)",
                   "rgba(50, 172, 45, 0.97)"
                 ],
-                "decimals": 0,
-                "pattern": "/.*/",
+                "decimals": 1,
+                "pattern": "Current",
                 "thresholds": [],
                 "type": "number",
-                "unit": "s"
+                "unit": "s",
+                "alias": "Full in"
+              },
+              {
+                "unit": "short",
+                "type": "string",
+                "alias": "Mount point",
+                "decimals": 2,
+                "colors": [
+                  "rgba(245, 54, 54, 0.9)",
+                  "rgba(237, 129, 40, 0.89)",
+                  "rgba(50, 172, 45, 0.97)"
+                ],
+                "colorMode": null,
+                "pattern": "Metric",
+                "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                "thresholds": []
               }
             ],
             "targets": [
               {
-                "expr": "(node_filesystem_size{job='node-exporter',instance='$instance'} - node_filesystem_free{job='node-exporter',instance='$instance'}) / deriv(node_filesystem_free{job='node-exporter',instance='$instance',fstype!='rootfs',mountpoint!~'/(run|var).*',mountpoint!=''}[3d]) > 0",
+                "expr": "(node_filesystem_free{job='node-exporter',instance='$instance'} - node_filesystem_size{job='node-exporter',instance='$instance'}) / deriv(node_filesystem_free{job='node-exporter',instance='$instance',fstype!='rootfs',mountpoint!~'/(run|var).*',mountpoint!=''}[2d]) > 0",
+                "format": "time_series",
                 "interval": "",
                 "intervalFactor": 2,
                 "legendFormat": "{{mountpoint}}",
                 "refId": "A",
-                "step": 10
+                "step": 20
               }
             ],
             "timeFrom": "1h",


### PR DESCRIPTION
Thx to @evnu for the math assist.

Signed-off-by: Jan Fajerski <jfajerski@suse.com>
(cherry picked from commit 1b2a2679d5b305c630dfa0d797b2b65c9f9f43d4)

Supersedes: #1341

Backport of #1344 

-----------------

**Checklist:**
~- [ ] Added unittests and or functional tests~
~- [ ] Adapted documentation~
~- [ ] Referenced issues or internal bugtracker~
- [ ] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
