### PR TITLE
cli: support list of sls ids in salt.state orch function

### DIFF
--- a/cli/deepsea.py
+++ b/cli/deepsea.py
@@ -140,7 +140,7 @@ def _print_deps(step, indent, step_order_map):
 
 def _print_stage_step(step, indent, step_order_map):
     if isinstance(step, SaltState):
-        PP.print(PP.orange(step.sls))
+        PP.print(PP.orange(step.sls_str))
         PP.print(PP.dark_green(" ({})".format(step.desc)))
         PP.println(PP.orange(" on"))
         _print_deps(step, indent, step_order_map)

--- a/cli/monitor.py
+++ b/cli/monitor.py
@@ -41,7 +41,10 @@ class Stage(object):
                 step (stage_parse.SaltStep): the parsed step
             """
             self.step = step
-            self.name = name
+            if isinstance(name, list):
+                self.name = ",".join(name)
+            else:
+                self.name = name
             self.order = order
             self.jid = None
             self.finished = False
@@ -134,7 +137,7 @@ class Stage(object):
             if isinstance(step, SaltRunner):
                 wrapper = Stage.Step(step, step.function, len(self._steps)+1)
             elif isinstance(step, SaltState):
-                wrapper = Stage.TargetedStep(step, step.sls, len(self._steps)+1)
+                wrapper = Stage.TargetedStep(step, step.sls_str, len(self._steps)+1)
                 for s_steps in step.steps.values():
                     for s_step in s_steps:
                         wrapper.sub_steps.append(


### PR DESCRIPTION
This PR adds the support for orchestration salt.state functions with a list of sls identifiers. This fixes a problem in the CLI implementation that generated the following stacktrace:

```
Traceback (most recent call last):
  File "/usr/bin/deepsea", line 9, in <module>
    load_entry_point('deepsea==0.0.0', 'console_scripts', 'deepsea')()
  File "/usr/lib/python2.7/site-packages/deepsea/deepsea.py", line 371, in main
    cli(prog_name='deepsea')
  File "/usr/lib/python2.7/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/usr/lib/python2.7/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/usr/lib/python2.7/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/lib/python2.7/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/lib/python2.7/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/lib/python2.7/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/usr/lib/python2.7/site-packages/deepsea/common.py", line 66, in func_wraper
    return func(*args, **kwargs)
  File "/usr/lib/python2.7/site-packages/deepsea/deepsea.py", line 356, in state_orch
    ret = run_stage(stage_name, hide_state_steps, hide_dynamic_steps, simple_output)
  File "/usr/lib/python2.7/site-packages/deepsea/stage_executor.py", line 79, in run_stage
    mon.parse_stage(stage_name)
  File "/usr/lib/python2.7/site-packages/deepsea/monitor.py", line 533, in parse_stage
    self._monitor_listeners)
  File "/usr/lib/python2.7/site-packages/deepsea/stage_parser.py", line 294, in parse_stage
    states_to_render[step.target[0]].add(step.sls)
TypeError: unhashable type: 'list'
```

This commit should be forward port to master.

Signed-off-by: Ricardo Dias <rdias@suse.com>
