### PR TITLE
qa: reinstate rbd client test as part of tier2

### DIFF
--- a/qa/common/common.sh
+++ b/qa/common/common.sh
@@ -166,24 +166,6 @@ EOF
 
 
 #
-# functions that create pools
-#
-
-function pgs_per_pool {
-    local TOTALPOOLS=$1
-    test -n "$TOTALPOOLS"
-    local TOTALOSDS=$(json_total_osds)
-    test -n "$TOTALOSDS"
-    # given the total number of pools and OSDs,
-    # assume triple replication and equal number of PGs per pool
-    # and aim for 100 PGs per OSD
-    let "TOTALPGS = $TOTALOSDS * 100"
-    let "PGSPEROSD = $TOTALPGS / $TOTALPOOLS / 3"
-    echo $PGSPEROSD
-}
-
-
-#
 # functions that print status information
 #
 

--- a/qa/common/deploy.sh
+++ b/qa/common/deploy.sh
@@ -167,6 +167,7 @@ function deploy_ceph {
     ceph_conf_small_cluster
     ceph_conf_mon_allow_pool_delete
     ceph_conf_dashboard
+    test "$RBD" && ceph_conf_upstream_rbd_default_features
     run_stage_3 "$CLI"
     pre_create_pools
     ceph_cluster_status

--- a/qa/common/pool.sh
+++ b/qa/common/pool.sh
@@ -57,6 +57,7 @@ function pre_create_pools {
     POOLS="write_test"
     test "$MDS" && POOLS+=" cephfs_data cephfs_metadata"
     test "$OPENSTACK" && POOLS+=" smoketest-cloud-backups smoketest-cloud-volumes smoketest-cloud-images smoketest-cloud-vms cloud-backups cloud-volumes cloud-images cloud-vms"
+    test "$RBD" && POOLS+=" rbd"
     create_all_pools_at_once $POOLS
     ceph osd pool application enable write_test deepsea_qa
     sleep 10

--- a/qa/common/pool.sh
+++ b/qa/common/pool.sh
@@ -4,6 +4,20 @@
 # separate file to house the pool creation functions
 #
 
+
+function pgs_per_pool {
+    local TOTALPOOLS=$1
+    test -n "$TOTALPOOLS"
+    local TOTALOSDS=$(json_total_osds)
+    test -n "$TOTALOSDS"
+    # given the total number of pools and OSDs,
+    # assume triple replication and equal number of PGs per pool
+    # and aim for 100 PGs per OSD
+    let "TOTALPGS = $TOTALOSDS * 100"
+    let "PGSPEROSD = $TOTALPGS / $TOTALPOOLS / 3"
+    echo $PGSPEROSD
+}
+
 function create_pool_incrementally {
     # Special-purpose function for creating pools incrementally. For example,
     # if your test case needs 2 pools "foo" and "bar", but you cannot create

--- a/qa/suites/basic/health-ok.sh
+++ b/qa/suites/basic/health-ok.sh
@@ -36,7 +36,8 @@ function usage {
     echo "Usage:"
     echo "  $SCRIPTNAME [-h,--help] [--cli] [--client-nodes=X]"
     echo "  [--mds] [--min-nodes=X] [--nfs-ganesha] [--no-update]"
-    echo "  [--profile=X] [--rbd] [--rgw] [--ssl]"
+    echo "  [--openstack] [--profile=X] [--rbd] [--rgw] [--ssl]"
+    echo "  [--tuned=X]"
     echo
     echo "Options:"
     echo "    --cli           Use DeepSea CLI"

--- a/qa/suites/basic/health-ok.sh
+++ b/qa/suites/basic/health-ok.sh
@@ -36,7 +36,7 @@ function usage {
     echo "Usage:"
     echo "  $SCRIPTNAME [-h,--help] [--cli] [--client-nodes=X]"
     echo "  [--mds] [--min-nodes=X] [--nfs-ganesha] [--no-update]"
-    echo "  [--profile=X] [--rgw] [--ssl]"
+    echo "  [--profile=X] [--rbd] [--rgw] [--ssl]"
     echo
     echo "Options:"
     echo "    --cli           Use DeepSea CLI"
@@ -48,6 +48,7 @@ function usage {
     echo "    --no-update     Use no-update-no-reboot Stage 0 alt default"
     echo "    --openstack     Pre-create pools for OpenStack functests"
     echo "    --profile       Storage/OSD profile (see below)"
+    echo "    --rbd           Modify ceph.conf for rbd integration testing"
     echo "    --rgw           Deploy RGW"
     echo "    --ssl           Deploy RGW with SSL"
     echo "    --tuned=on/off  Deploy tuned in Stage 3 (default: off)"
@@ -65,7 +66,7 @@ function usage {
 assert_enhanced_getopt
 
 TEMP=$(getopt -o h \
---long "cli,client-nodes:,help,igw,mds,min-nodes:,nfs-ganesha,no-update,openstack,profile:,rgw,ssl,tuned:" \
+--long "cli,client-nodes:,help,igw,mds,min-nodes:,nfs-ganesha,no-update,openstack,profile:,rbd,rgw,ssl,tuned:" \
 -n 'health-ok.sh' -- "$@")
 
 if [ $? != 0 ] ; then echo "Terminating..." >&2 ; exit 1 ; fi
@@ -83,6 +84,7 @@ MIN_NODES=1
 OPENSTACK=""
 NFS_GANESHA=""
 NO_UPDATE=""
+RBD=""
 RGW=""
 SSL=""
 TUNED="off"
@@ -97,6 +99,7 @@ while true ; do
         --no-update) NO_UPDATE="$1" ; shift ;;
         --openstack) OPENSTACK="$1" ; shift ;;
         --profile) shift ; STORAGE_PROFILE=$1 ; shift ;;
+        --rbd) RBD="$1" ; shift ;;
         --rgw) RGW="$1" ; shift ;;
         --ssl) SSL="$1" ; shift ;;
         --tuned) shift ; TUNED=$1 ; shift ;;
@@ -125,6 +128,7 @@ test -n "$MDS" && echo "- MDS"
 test -n "$NFS_GANESHA" && echo "- NFS-Ganesha"
 test -n "$OPENSTACK" && echo "- OpenStack test pools will be pre-created"
 echo "- PROFILE ->$STORAGE_PROFILE<-"
+test -n "$RBD" && echo "- RBD"
 test -n "$RGW" && echo "- RGW"
 test -n "$SSL" && echo "- SSL"
 echo -n "- TUNED: "


### PR DESCRIPTION
We used to have an rbd client test (librbd and rbd CLI), but it got disabled as part of the big QA refactor. This PR, along with https://github.com/SUSE/ceph/pull/206, reinstate it as part of tier2.

-----------------

**Checklist:**
- [x] Added unittests and or functional tests
~~- [ ] Adapted documentation~~
~~- [ ] Referenced issues or internal bugtracker~~
- [x] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
