### PR TITLE
man: add line break between separate commands.

### DIFF
--- a/man/deepsea-minions.7
+++ b/man/deepsea-minions.7
@@ -34,6 +34,8 @@ For example,
 .PP
 .RS 4
 salt -L node1.domain,node2.domain grains.append deepsea default
+.RS
+.RE
 salt -S 10.0.0.0/24 grains.append deepsea default
 .RE
 .PP


### PR DESCRIPTION
Signed-off-by: Jonathan Brielmaier <jbrielmaier@suse.de>

Fixes: wrong formatting in `deapsee-minions` man page.
