### PR TITLE
fixed problem in stage.0 with error message no  minion found in metap…

### DIFF
--- a/srv/salt/ceph/stage/prep/minion/default-no-update-no-reboot.sls
+++ b/srv/salt/ceph/stage/prep/minion/default-no-update-no-reboot.sls
@@ -7,6 +7,7 @@ repo:
 metapackage minions:
   salt.state:
     - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
+    - tgt_type: compound
     - sls: ceph.metapackage
 
 common packages:

--- a/srv/salt/ceph/stage/prep/minion/default-no-update-reboot.sls
+++ b/srv/salt/ceph/stage/prep/minion/default-no-update-reboot.sls
@@ -10,6 +10,7 @@ repo:
 metapackage minions:
   salt.state:
     - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
+    - tgt_type: compound
     - sls: ceph.metapackage
 
 common packages:

--- a/srv/salt/ceph/stage/prep/minion/default-update-reboot.sls
+++ b/srv/salt/ceph/stage/prep/minion/default-update-reboot.sls
@@ -10,6 +10,7 @@ repo:
 metapackage minions:
   salt.state:
     - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
+    - tgt_type: compound
     - sls: ceph.metapackage
 
 common packages:

--- a/srv/salt/ceph/stage/prep/minion/default.sls
+++ b/srv/salt/ceph/stage/prep/minion/default.sls
@@ -10,6 +10,7 @@ repo:
 metapackage minions:
   salt.state:
     - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
+    - tgt_type: compound
     - sls: ceph.metapackage
 
 common packages:


### PR DESCRIPTION
…ackage

Signed-off-by: root <joachim.kraftmayer@clyso.com>

Fixes #

added the - tgt_type: compound to the metapackage

Description:

salt-run state.orch ceph.stage.0
.....
[WARNING ] All minions are ready
No minions matched the target. No command was sent, no jid was assigned.
[ERROR   ] No minions returned
....
----------
          ID: metapackage minions
    Function: salt.state
      Result: False
     Comment: No minions returned
     Started: 14:35:35.329779
    Duration: 1
...
Succeeded: 96 (changed=62)
Failed:     1





-----------------

**Checklist:**
- [ ] Added unittests and or functional tests
- [ ] Adapted documentation
- [ ] Referenced issues or internal bugtracker
- [x] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
