### PR TITLE
[forwardport][master] cli: fix parsing of salt.runner when used inside state files

### DIFF
--- a/cli/stage_parser.py
+++ b/cli/stage_parser.py
@@ -253,7 +253,10 @@ class SLSParser(object):
         if step_dict['state'] == 'salt' and step_dict['fun'] == 'state':
             return SaltState(step_dict)
         if step_dict['state'] == 'salt' and step_dict['fun'] == 'runner':
-            return SaltRunner(step_dict)
+            if target:
+                return SaltStateFunction(step_dict, target)
+            else:
+                return SaltRunner(step_dict)
         if step_dict['state'] == 'salt' and step_dict['fun'] == 'function':
             return SaltExecutionFunction(step_dict, step_dict['tgt'])
         if step_dict['state'] == 'module' and step_dict['fun'] == 'run':


### PR DESCRIPTION
Fixes: #1364

Signed-off-by: Ricardo Dias <rdias@suse.com>
(cherry picked from commit 8ca9753da0b01fee28fa407f24ff9bd8f5e43caf)

forwardport of #1366 

```
xxxxxx :: projects/deepsea/cli ‹forwardport-1366*› » ./run-unit-tests.sh
...snip..
15 passed in 114.88 seconds 
```

- [x] Referenced issues or internal bugtracker
- [ ] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)

