### PR TITLE
[backport][SES5] stage 0: update salt mines correctly without restarting minion

### DIFF
--- a/srv/salt/ceph/mines/default.sls
+++ b/srv/salt/ceph/mines/default.sls
@@ -1,15 +1,20 @@
 
 
-configure_mines:
+configure_mine_functions_conf:
   file.managed:
     - name: /etc/salt/minion.d/mine_functions.conf
     - source: salt://ceph/mines/files/mine_functions.conf
     - fire_event: True
 
+add_mine_cephdisks.list_to_minion:
+  module.run:
+    - name: mine.send
+    - func: cephdisks.list
+
 manage_salt_minion_for_mines:
-  service.running:
-    - name: salt-minion
+  module.run:
+    - name: mine.update
     - watch:
-      - file: configure_mines
+      - file: configure_mine_functions_conf
     - fire_event: True
 


### PR DESCRIPTION
Fixes: https://github.com/SUSE/DeepSea/issues/1367

backport of PR #727

-----------------

**Checklist:**
~~- [ ] Added unittests and or functional tests~~
~~- [ ] Adapted documentation~~
- [x] Referenced issues or internal bugtracker
- [ ] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
