### PR TITLE
[backport][SES5] fixed problem in stage.0 with error message no  minion found in metap…

### DIFF
--- a/srv/salt/ceph/stage/prep/minion/default-no-update-no-reboot.sls
+++ b/srv/salt/ceph/stage/prep/minion/default-no-update-no-reboot.sls
@@ -7,6 +7,7 @@ repo:
 metapackage minions:
   salt.state:
     - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
+    - tgt_type: compound
     - sls: ceph.metapackage
 
 common packages:

--- a/srv/salt/ceph/stage/prep/minion/default-no-update-reboot.sls
+++ b/srv/salt/ceph/stage/prep/minion/default-no-update-reboot.sls
@@ -7,6 +7,7 @@ repo:
 metapackage minions:
   salt.state:
     - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
+    - tgt_type: compound
     - sls: ceph.metapackage
 
 common packages:

--- a/srv/salt/ceph/stage/prep/minion/default-update-reboot.sls
+++ b/srv/salt/ceph/stage/prep/minion/default-update-reboot.sls
@@ -7,6 +7,7 @@ repo:
 metapackage minions:
   salt.state:
     - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
+    - tgt_type: compound
     - sls: ceph.metapackage
 
 common packages:

--- a/srv/salt/ceph/stage/prep/minion/default.sls
+++ b/srv/salt/ceph/stage/prep/minion/default.sls
@@ -7,6 +7,7 @@ repo:
 metapackage minions:
   salt.state:
     - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
+    - tgt_type: compound
     - sls: ceph.metapackage
 
 common packages:


### PR DESCRIPTION
Signed-off-by: root <joachim.kraftmayer@sap.com>
(cherry picked from commit 81245b4fa7a14637c9298f8e1a72e2bbd578f5c9)

backport of #1362 


-----------------

**Checklist:**
- [x] Referenced issues or internal bugtracker
- [ ] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
