### PR TITLE
[backport] [SES5] build/ops: make "make rpm" work without special environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -855,7 +855,7 @@ install: copy-files setup.py
 	zypper -n install python-setuptools python-click
 	python setup.py install --root=$(DESTDIR)/
 
-rpm: pyc tarball test
+rpm: pyc tarball
 	sed '/^Version:/s/[^ ]*$$/'$(VERSION)'/' deepsea.spec.in > deepsea.spec
 	rpmbuild -bb deepsea.spec
 


### PR DESCRIPTION
Running unit tests in "make rpm" is probably a bad idea in SES5 as well.

Running of unit tests could be added to `%check` section of deepsea.spec.in, then they would be run in OBS/IBS builds. But we don't need them for "make rpm" builds, since they require special setup.