### PR TITLE
Prevent rgw-ssl name collision

### DIFF
--- a/srv/modules/runners/validate.py
+++ b/srv/modules/runners/validate.py
@@ -434,6 +434,21 @@ class Validate(Preparation):
             return True
         return False
 
+    def rgw(self):
+        """
+        Prevent a name collision when the admin wishes to push certificates
+        using default-ssl.sls and custom configurations.
+        """
+        for _, data in self.data.items():
+            if 'roles' in data:
+                if ('rgw_configurations' in data and
+                    "rgw-ssl" in data['rgw_configurations']):
+                    if "rgw_init" in data and data['rgw_init'] == "default-ssl":
+                        msg = "Please rename the custom rgw role from rgw-ssl to another name"
+                        self.errors['rgw'] = msg
+                        return
+        self.passed['rgw'] = "valid"
+
     def ganesha(self):
         """
         Nodes may only be assigned one ganesha role.  Ganesha depends on
@@ -1086,6 +1101,7 @@ def pillar(cluster=None, printer=None, **kwargs):
     valid.monitors()
     valid.mgrs()
     valid.storage()
+    valid.rgw()
     valid.ganesha()
     valid.master_role()
     valid.osd_creation()

--- a/tests/unit/runners/test_validate.py
+++ b/tests/unit/runners/test_validate.py
@@ -244,6 +244,30 @@ class TestValidation():
         assert 'ceph_version' not in validator.errors
 
     @patch('salt.client.LocalClient')
+    def test_rgw_succeeds(self, mock_localclient):
+        fake_data = {'node1': {'roles': 'rgw'}}
+
+        local = mock_localclient.return_value
+        local.cmd.return_value = fake_data
+        validator = validate.Validate("setup", search_pillar=True)
+
+        validator.rgw()
+        assert 'rgw' not in validator.errors
+
+    @patch('salt.client.LocalClient')
+    def test_rgw_fails(self, mock_localclient):
+        fake_data = {'node1': {'roles': 'rgw-ssl',
+                               'rgw_configurations': 'rgw-ssl',
+                               'rgw_init': 'default-ssl'}}
+
+        local = mock_localclient.return_value
+        local.cmd.return_value = fake_data
+        validator = validate.Validate("setup", search_pillar=True)
+
+        validator.rgw()
+        assert 'rgw' in validator.errors
+
+    @patch('salt.client.LocalClient')
     def test_check_installed_is_older(self, mock_localclient):
         fake_data = {'admin.ceph': {'ceph-common': {'version': '10.1.1'}},
                      'data.ceph': {'ceph-common': {'version': '13.0.1'}}}


### PR DESCRIPTION
When using custom rgw roles and pushing certificates, prevent name collision

Signed-off-by: Eric Jackson <ejackson@suse.com>

bnc#1105478

-----------------

**Checklist:**
- [x] Added unittests and or functional tests
- [ ] Adapted documentation
- [x] Referenced issues or internal bugtracker
- [ ] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
