### PR TITLE
qa/deploy: use jq instead of python in salt_api_test

### DIFF
--- a/qa/common/common.sh
+++ b/qa/common/common.sh
@@ -264,13 +264,6 @@ function ceph_health_test {
     ! grep -q 'Timeout expired' $LOGFILE
 }
 
-function salt_api_test {
-    echo "Salt API test: BEGIN"
-    systemctl --no-pager --full status salt-api.service
-    curl http://$(hostname):8000/ | python3 -m json.tool
-    echo "Salt API test: END"
-}
-
 function rados_write_test {
     #
     # NOTE: function assumes the pool "write_test" already exists. Pool can be

--- a/qa/common/deploy.sh
+++ b/qa/common/deploy.sh
@@ -137,9 +137,14 @@ function initialization_sequence {
 }
 
 function salt_api_test {
+    local tmpfile=$(mktemp)
     echo "Salt API test: BEGIN"
     systemctl --no-pager --full status salt-api.service
-    curl http://$(hostname):8000/ | python3 -m json.tool
+    curl http://$(hostname):8000/ | tee $tmpfile # show curl output in log
+    test -s $tmpfile
+    jq . $tmpfile >/dev/null
+    echo -en "\n" # this is just for log readability
+    rm $tmpfile
     echo "Salt API test: END"
 }
 

--- a/qa/common/deploy.sh
+++ b/qa/common/deploy.sh
@@ -136,6 +136,13 @@ function initialization_sequence {
     set -x
 }
 
+function salt_api_test {
+    echo "Salt API test: BEGIN"
+    systemctl --no-pager --full status salt-api.service
+    curl http://$(hostname):8000/ | python3 -m json.tool
+    echo "Salt API test: END"
+}
+
 function deploy_ceph {
     initialization_sequence
     if _ceph_cluster_running ; then


### PR DESCRIPTION
- [x] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
