### PR TITLE
Makefile: rpmbuild will use /usr/src/packages when run as root

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -958,9 +958,9 @@ tarball:
 	sed "s/DEVVERSION/"$(VERSION)"/" $(TEMPDIR)/deepsea-$(VERSION)/setup.py.in > $(TEMPDIR)/deepsea-$(VERSION)/setup.py
 	sed "s/DEVVERSION/"$(VERSION)"/" $(TEMPDIR)/deepsea-$(VERSION)/deepsea.spec.in > $(TEMPDIR)/deepsea-$(VERSION)/deepsea.spec
 	sed -i "s/DEVVERSION/"$(VERSION)"/" $(TEMPDIR)/deepsea-$(VERSION)/srv/modules/runners/deepsea.py
-	mkdir -p ~/rpmbuild/SOURCES
+	mkdir -p /usr/src/packages/SOURCES
 	cp $(TEMPDIR)/deepsea-$(VERSION)/setup.py .
-	tar -cjf ~/rpmbuild/SOURCES/deepsea-$(VERSION).tar.bz2 -C $(TEMPDIR) .
+	tar -cjf /usr/src/packages/SOURCES/deepsea-$(VERSION).tar.bz2 -C $(TEMPDIR) .
 	rm -r $(TEMPDIR)
 
 test: setup.py


### PR DESCRIPTION
"make run" needs to be run as root, and when rpmbuild is run as root,
it wants to put stuff under /usr/src/packages.

Signed-off-by: Nathan Cutler <ncutler@suse.com>