### PR TITLE
[backport][SES5] Only restart with a running cluster and  functests: fix problems that occur when process unexpectedly not running

### DIFF
--- a/srv/salt/ceph/restart/default.sls
+++ b/srv/salt/ceph/restart/default.sls
@@ -1,3 +1,4 @@
+{% if salt['saltutil.runner']('cephprocesses.mon') == True %}
 include:
   - .mon
   - .mgr
@@ -8,3 +9,9 @@ include:
   - .ganesha
 # disabled due to https://github.com/SUSE/DeepSea/issues/816
 #  - .openattic 
+{% else %}
+
+No Ceph cluster:
+  test.nop
+{% endif %}
+

--- a/srv/salt/ceph/tests/restart/changed_pid.sls
+++ b/srv/salt/ceph/tests/restart/changed_pid.sls
@@ -1,9 +1,9 @@
 
-Changed pid:
+Changed pid of ceph-{{ service }}:
   cmd.run:
-    - name: "[ `pgrep ceph-{{ service }}` !=  `cat /tmp/restart.pid` ]"
-    - shell: /bin/bash
+    - name: "test \"$(pgrep ceph-{{ service }})\" != \"$(cat /tmp/restart.pid)\""
     - failhard: True
+    - shell: /bin/bash
 
 /tmp/restart.pid:
   file.absent

--- a/srv/salt/ceph/tests/restart/rgw/changed_pid.sls
+++ b/srv/salt/ceph/tests/restart/rgw/changed_pid.sls
@@ -1,9 +1,9 @@
 
-Changed pid:
+Changed pid of radosgw:
   cmd.run:
-    - name: "[ `pgrep radosgw` !=  `cat /tmp/restart.pid` ]"
-    - shell: /bin/bash
+    - name: "test \"$(pgrep radosgw)\" != \"$(cat /tmp/restart.pid)\""
     - failhard: True
+    - shell: /bin/bash
 
 /tmp/restart.pid:
   file.absent

--- a/srv/salt/ceph/tests/restart/rgw/same_pid.sls
+++ b/srv/salt/ceph/tests/restart/rgw/same_pid.sls
@@ -1,7 +1,7 @@
 
-Check pid:
+Check pid radosgw:
   cmd.run:
-    - name: "[ `pgrep radosgw` ==  `cat /tmp/restart.pid` ]"
+    - name: "test \"$(pgrep radosgw)\" = \"$(cat /tmp/restart.pid)\""
     - failhard: True
 
 /tmp/restart.pid:

--- a/srv/salt/ceph/tests/restart/rgw/save_pid.sls
+++ b/srv/salt/ceph/tests/restart/rgw/save_pid.sls
@@ -1,7 +1,12 @@
 
-Save pid:
+Save pid of radosgw:
   cmd.run:
     - name: "pgrep radosgw > /tmp/restart.pid"
+    - failhard: True
     - shell: /bin/bash
 
+Assert pid of radosgw really was determined:
+  cmd.run:
+    - name: "test -s /tmp/restart.pid"
+    - failhard: True
 

--- a/srv/salt/ceph/tests/restart/same_pid.sls
+++ b/srv/salt/ceph/tests/restart/same_pid.sls
@@ -1,7 +1,7 @@
 
-Check pid:
+Check pid {{ service }}:
   cmd.run:
-    - name: "[ `pgrep ceph-{{ service }}` ==  `cat /tmp/restart.pid` ]"
+    - name: "test \"$(pgrep ceph-{{ service }})\" = \"$(cat /tmp/restart.pid)\""
     - failhard: True
 
 /tmp/restart.pid:

--- a/srv/salt/ceph/tests/restart/save_pid.sls
+++ b/srv/salt/ceph/tests/restart/save_pid.sls
@@ -1,6 +1,12 @@
 
-Save pid:
+Save pid of ceph-{{ service }}:
   cmd.run:
     - name: "pgrep ceph-{{ service }} > /tmp/restart.pid"
+    - failhard: True
     - shell: /bin/bash
+
+Assert pid of ceph-{{ service }} really was determined:
+  cmd.run:
+    - name: "test -s /tmp/restart.pid"
+    - failhard: True
 


### PR DESCRIPTION
Backports:

* #1210 
* #1381 (WARNING: NOT MERGED YET)

---

- [x] Referenced issues or internal bugtracker
- [x] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
