### PR TITLE
qa/health-ok: repeat Stage 0 only once

### DIFF
--- a/qa/suites/basic/health-ok.sh
+++ b/qa/suites/basic/health-ok.sh
@@ -148,6 +148,7 @@ test "$STORAGE_NODES" = "$(number_of_hosts_in_ceph_osd_tree)"
 salt -I roles:storage osd.report 2>/dev/null
 
 # test phase
+REPEAT_STAGE_0=""
 ceph_log_grep_enoent_eaccess
 test_systemd_ceph_osd_target_wants
 rados_write_test
@@ -184,9 +185,9 @@ if [ "$NFS_GANESHA" ] ; then
         nfs_ganesha_umount
         sleep 10
     done
-    # exercise ceph.restart orchestration
-    run_stage_0 "$CLI"
+    REPEAT_STAGE_0="yes, please"
 fi
+test "$REPEAT_STAGE_0" && run_stage_0 "$CLI" # exercise ceph.restart orchestration
 
 echo "YYYY"
 echo "health-ok test result: PASS"


### PR DESCRIPTION
In SES5 we have run_stage_0 in both the IGW and NFS_GANESHA conditionals, which
means Stage 0 gets run twice in the openattic test case.

This commit ensures we only ever re-run Stage 0 once, by putting it into its
own conditional.

-----------------

**Checklist:**
- [x] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
