### PR TITLE
[backport][SES5] qa/health-ok: repeat Stage 0 only once and dump lrbd.service status in certain failure cases

### DIFF
--- a/qa/common/helper.sh
+++ b/qa/common/helper.sh
@@ -20,12 +20,12 @@ function maybe_dump_lrbd_service_status {
 function _report_stage_failure {
     STAGE_SUCCEEDED=""
     local stage_num=$1
+    local stage_status=$2
 
     echo "********** Stage $stage_num failed **********"
-    maybe_dump_lrbd_service_status "$stage_num"
-    set -x
+    test "$stage_status" = "124" && echo "Stage $stage_num timed out after $STAGE_TIMEOUT_DURATION"
+    set -ex
     journalctl -r | head -n 2000
-    set +x
     echo "WWWW"
     echo "Finished dumping up to 2000 lines of journalctl"
 }
@@ -46,7 +46,6 @@ function _run_stage {
 function _run_stage_cli {
     local stage_num=$1
     local deepsea_cli_output_path="/tmp/deepsea.${stage_num}.log"
-    local deepsea_exit_status=""
 
     set +e
     set -x
@@ -59,24 +58,19 @@ function _run_stage_cli {
         ceph.stage.${stage_num} \
         --simple-output \
         2>&1 | tee $deepsea_cli_output_path
-    local exit_status="${PIPESTATUS[0]}"
+    local stage_status="${PIPESTATUS[0]}"
     set +x
-    echo "deepsea exit status: $exit_status"
+    echo "deepsea exit status: $stage_status"
     echo "WWWW"
-    if [ "$exit_status" = "124" ] ; then
-        echo "Stage $stage_num timed out after $STAGE_TIMEOUT_DURATION"
-        exit 1
-    fi
-    if [ "$exit_status" != "0" ] ; then
-        _report_stage_failure $stage_num
-        set -ex
+    if [ "$stage_status" != "0" ] ; then
+        _report_stage_failure $stage_num $stage_status
         return 0
     fi
     if grep -q -F "failed=0" $deepsea_cli_output_path ; then
         echo "********** Stage $stage_num completed successfully **********"
     else
         echo "ERROR: deepsea stage returned exit status 0, yet one or more steps failed. Bailing out!"
-        _report_stage_failure $stage_num
+        _report_stage_failure $stage_num $stage_status
     fi
     set -ex
 }
@@ -93,16 +87,11 @@ function _run_stage_non_cli {
         state.orch \
         ceph.stage.${stage_num} \
         2>/dev/null | tee $stage_log_path
-    local exit_status="${PIPESTATUS[0]}"
+    local stage_status="${PIPESTATUS[0]}"
     set +x
     echo "WWWW"
-    if [ "$exit_status" = "124" ] ; then
-        echo "Stage $stage_num timed out after $STAGE_TIMEOUT_DURATION"
-        exit 1
-    fi
-    if [ "$exit_status" != "0" ] ; then
-        _report_stage_failure $stage_num
-        set -ex
+    if [ "$stage_status" != "0" ] ; then
+        _report_stage_failure $stage_num $stage_status
         return 0
     fi
     STAGE_FINISHED=$(grep -F 'Total states run' $stage_log_path)
@@ -110,13 +99,13 @@ function _run_stage_non_cli {
         FAILED=$(grep -F 'Failed: ' $stage_log_path | sed 's/.*Failed:\s*//g' | head -1)
         if [ "$FAILED" -gt "0" ]; then
             echo "ERROR: salt-run returned exit status 0, yet one or more steps failed. Bailing out!"
-            _report_stage_failure $stage_num
+            _report_stage_failure $stage_num $stage_status
         else
             echo "********** Stage $stage_num completed successfully **********"
         fi
     else
         echo "ERROR: salt-run returned exit status 0, yet Stage did not complete. Bailing out!"
-        _report_stage_failure $stage_num
+        _report_stage_failure $stage_num $stage_status
     fi
     set -ex
 }
@@ -164,13 +153,13 @@ function _run_test_script_on_node {
     salt-cp $TESTNODE $TESTSCRIPT $TESTSCRIPT 2>/dev/null
     local LOGFILE=/tmp/test_script.log
     local STDERR_LOGFILE=/tmp/test_script_stderr.log
-    local exit_status=
+    local stage_status=
     if [ -z "$ASUSER" -o "x$ASUSER" = "xroot" ] ; then
       salt $TESTNODE cmd.run "sh $TESTSCRIPT" 2>$STDERR_LOGFILE | tee $LOGFILE
-      exit_status="${PIPESTATUS[0]}"
+      stage_status="${PIPESTATUS[0]}"
     else
       salt $TESTNODE cmd.run "sudo su $ASUSER -c \"bash $TESTSCRIPT\"" 2>$STDERR_LOGFILE | tee $LOGFILE
-      exit_status="${PIPESTATUS[0]}"
+      stage_status="${PIPESTATUS[0]}"
     fi
     local RESULT=$(grep -o -P '(?<=Result: )(OK)$' $LOGFILE) # since the script
                                   # is run by salt, the output appears indented

--- a/qa/common/helper.sh
+++ b/qa/common/helper.sh
@@ -6,17 +6,28 @@
 
 STAGE_TIMEOUT_DURATION="60m"
 
+function maybe_dump_lrbd_service_status {
+    local stage_num=$1
+    if [ "$stage_num" = "0" -a "$REPEAT_STAGE_0" ] || [ "$stage_num" = "4" ] ; then
+        if [ "$IGW" ] ; then
+            set -x
+            systemctl --no-pager --full status lrbd.service
+            set +x
+        fi
+    fi
+}
+
 function _report_stage_failure {
     STAGE_SUCCEEDED=""
     local stage_num=$1
-    #local stage_log_path=$2
 
     echo "********** Stage $stage_num failed **********"
-    echo "Here comes the systemd log:"
-    #cat $stage_log_path
-    journalctl -r | head -n 1000
+    maybe_dump_lrbd_service_status "$stage_num"
+    set -x
+    journalctl -r | head -n 2000
+    set +x
     echo "WWWW"
-    echo "There goes the systemd log"
+    echo "Finished dumping up to 2000 lines of journalctl"
 }
 
 function _run_stage {

--- a/qa/suites/basic/health-ok.sh
+++ b/qa/suites/basic/health-ok.sh
@@ -155,6 +155,7 @@ test "$STORAGE_NODES" = "$(number_of_hosts_in_ceph_osd_tree)"
 salt -I roles:storage osd.report 2>/dev/null
 
 # test phase
+REPEAT_STAGE_0=""
 ceph_log_grep_enoent_eaccess
 test_systemd_ceph_osd_target_wants
 rados_write_test
@@ -170,8 +171,7 @@ if [ -n "$IGW" -a "$CLIENT_NODES" -ge 1 ] ; then
     #iscsi_kludge # see bsc#1049669
     igw_info
     iscsi_mount_and_sanity_test
-    # exercise ceph.restart orchestration
-    run_stage_0 "$CLI"
+    REPEAT_STAGE_0="yes, please"
 fi
 if [ "$NFS_GANESHA" ] ; then
     for v in "" "3" "4" ; do
@@ -198,9 +198,9 @@ if [ "$NFS_GANESHA" ] ; then
         nfs_ganesha_umount
         sleep 10
     done
-    # exercise ceph.restart orchestration
-    run_stage_0 "$CLI"
+    REPEAT_STAGE_0="yes, please"
 fi
+test "$REPEAT_STAGE_0" && run_stage_0 "$CLI" # exercise ceph.restart orchestration
 
 echo "YYYY"
 echo "health-ok test result: PASS"


### PR DESCRIPTION
backport of https://github.com/SUSE/DeepSea/pull/1383

---

In SES5 we have run_stage_0 in both the IGW and NFS_GANESHA conditionals, which
means Stage 0 gets run twice in the openattic test case.

This commit ensures we only ever re-run Stage 0 once, by putting it into its
own conditional.

---

The igw role is associated with transient failures in Stages 0 and 4.

This commit attempts to get more debugging info into the log when these
failures happen.

-----------------

**Checklist:**
- [x] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
