### PR TITLE
[SES5] Remove error condition, empty cluster network is valid

### DIFF
--- a/srv/modules/runners/populate.py
+++ b/srv/modules/runners/populate.py
@@ -1021,8 +1021,7 @@ def _replace_cluster_network_with_existing_cluster(osd_addrs, public_networks=[]
     """
     cluster_networks = _get_existing_cluster_networks(osd_addrs, public_networks)
     if not cluster_networks:
-        log.error("Failed to determine cluster's cluster_network.")
-        return { 'ret': False, 'cluster_networks': [] }
+        return { 'ret': True, 'cluster_networks': [] }
     else:
         return { 'ret': _replace_key_in_cluster_yml("cluster_network",
                                                     ", ".join(cluster_networks)),


### PR DESCRIPTION
Signed-off-by: Eric Jackson <ejackson@suse.com>
backport of #1391 
-----------------

**Checklist:**
- [ ] Added unittests and or functional tests
- [ ] Adapted documentation
- [x] Referenced issues or internal bugtracker
- [ ] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
