### PR TITLE
[backport] [SES5] qa/deploy: fix error-reporting issues

### DIFF
--- a/qa/common/deploy.sh
+++ b/qa/common/deploy.sh
@@ -38,7 +38,6 @@ function _set_deepsea_minions {
 }
 
 function _initialize_minion_array {
-    set +x
     local m=
     local i=0
     if type salt-key > /dev/null 2>&1; then
@@ -53,7 +52,6 @@ function _initialize_minion_array {
         exit 1
     fi
     echo "There are $i minions in this Salt cluster"
-    set -x
 }
 
 function _update_salt {
@@ -118,17 +116,22 @@ function _zypper_ps {
     salt '*' cmd.run 'zypper ps -s' 2>/dev/null || true
 }
 
+function _python_versions {
+    type python2 > /dev/null 2>&1 && python2 --version || echo "Python 2 not installed"
+    type python3 > /dev/null 2>&1 && python3 --version || echo "Python 3 not installed"
+}
+
 function initialization_sequence {
     set +x
     _determine_master_minion
     _os_specific_install_deps
     _os_specific_repos_and_packages_info
-    python --version
-    python2 --version
-    python3 --version || true
-    deepsea --version || true
-    _set_deepsea_minions
+    set +e
+    _python_versions
+    type deepsea > /dev/null 2>&1 && deepsea --version || echo "deepsea CLI not installed"
     _initialize_minion_array
+    set -e
+    _set_deepsea_minions
     _update_salt
     cat_salt_config
     _initialize_storage_profile


### PR DESCRIPTION
backport of #1388 

- [x] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
