### PR TITLE
keyrings: remove x from rgw mon caps; not needed

### DIFF
--- a/srv/salt/ceph/rgw/files/rgw.j2
+++ b/srv/salt/ceph/rgw/files/rgw.j2
@@ -1,5 +1,5 @@
 [{{ client }}]
         key = {{ secret }}
-        caps mon = "allow rwx"
+        caps mon = "allow rw"
         caps osd = "allow rwx"
         caps mgr = "allow r"


### PR DESCRIPTION
Signed-off-by: Jan Fajerski <jfajerski@suse.com>
(cherry picked from commit 8dbb22f5841b47ec24fdabf5aa3f0386701d2be3)

Fixes part of bsc#1108495
Backport of #1395 

-----------------

- [x] Referenced issues or internal bugtracker
- [ ] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
