### PR TITLE
Remove journal_size if present

### DIFF
--- a/srv/modules/runners/push.py
+++ b/srv/modules/runners/push.py
@@ -333,6 +333,9 @@ def _migrate(yml, filename):
                 cso[osd]['db'] = cso[osd]['journal']
             # get rid of the old journal item
             yml['ceph']['storage']['osds'][osd].pop('journal')
+            if 'journal_size' in yml['ceph']['storage']['osds'][osd]:
+                yml['ceph']['storage']['osds'][osd].pop('journal_size')
+
     else:
         log.info("No migration for {} - copying".format(filename))
     return yml


### PR DESCRIPTION
Technically, this is impossible from the original intent of
the runner to convert the old storage format to the new format.
The old format did not support journal sizes.

Signed-off-by: Eric Jackson <ejackson@suse.com>
bnc#1073714

-----------------

**Checklist:**
- [ ] Added unittests and or functional tests
- [ ] Adapted documentation
- [x] Referenced issues or internal bugtracker
- [x] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
