### PR TITLE
proposal: remove target and std_args globals (bsc#1100609)

### DIFF
--- a/srv/modules/runners/proposal.py
+++ b/srv/modules/runners/proposal.py
@@ -92,33 +92,31 @@ List of recognized parameters and their defaults:
                     gibibytes (G), tebibytes (T), or pebibytes (P).
 '''
 
-target = deepsea_minions.DeepseaMinions()
-
-std_args = {
-    'leftovers': False,
-    'standalone': False,
-    'nvme-ssd-spinner': False,
-    'nvme-ssd': False,
-    'nvme-spinner': False,
-    'ssd-spinner': False,
-    'ratio': 5,
-    'db-ratio': 5,
-    'target': target.deepsea_minions,
-    'data': 0,
-    'journal': 0,
-    'wal': 0,
-    'name': 'default',
-    'format': 'bluestore',
-    'encryption': '',
-    'journal-size': '5g',
-    'db-size': '500m',
-    'wal-size': '500m',
-}
-
 base_dir = '/srv/pillar/ceph/proposals'
 
 
 def _parse_args(kwargs):
+    target = deepsea_minions.DeepseaMinions()
+    std_args = {
+        'leftovers': False,
+        'standalone': False,
+        'nvme-ssd-spinner': False,
+        'nvme-ssd': False,
+        'nvme-spinner': False,
+        'ssd-spinner': False,
+        'ratio': 5,
+        'db-ratio': 5,
+        'target': target.deepsea_minions,
+        'data': 0,
+        'journal': 0,
+        'wal': 0,
+        'name': 'default',
+        'format': 'bluestore',
+        'encryption': '',
+        'journal-size': '5g',
+        'db-size': '500m',
+        'wal-size': '500m',
+    }
     args = std_args.copy()
     args.update(kwargs)
     if 'kwargs' in kwargs:


### PR DESCRIPTION
When invoking `salt-run`, all runners are loaded, and thus all globals
in those runners are evaulated.  The proposal runner was invoking
deepsea_minions.DeepseaMinions() to set the target global, which results
in a pillar refresh and a couple of pillar gets across all nodes.  If
any nodes were down, these three operations would each take 15 seconds
to time out, resulting in a delay of up to 45 seconds invoking any
runner if any nodes were down.  It also added a slight (2-3 second)
delay in the normal case where all nodes are up.

Signed-off-by: Tim Serong <tserong@suse.com>

**Checklist:**
- [ ] Added unittests and or functional tests
- [ ] Adapted documentation
- [x] Referenced issues or internal bugtracker
- [ ] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
