### PR TITLE
build: Add %pretrans script to deal with dir->symlink change

### DIFF
--- a/deepsea.spec.in
+++ b/deepsea.spec.in
@@ -61,6 +61,15 @@ make DESTDIR=%{buildroot} DOCDIR=%{_docdir} copy-files VERSION=%{version}
 %__gzip %{buildroot}/%{_mandir}/man?/deepsea*
 python3 setup.py install --prefix=%{_prefix} --root=%{buildroot}
 
+# RPM can't cope with directories becoming symlinks, so remove the
+# old directory that is now a symlink, if it exists (for more details
+# see https://bugzilla.redhat.com/show_bug.cgi?id=447156)
+%pretrans -p <lua>
+st = posix.stat("/srv/salt/ceph/remove/migrated")
+if st and st.type == "directory" then
+   os.execute("rm -rf /srv/salt/ceph/remove/migrated")
+end
+
 %post
 # Initialize the shared secret key
 sed -i '/^sharedsecret: /s!{{ shared_secret }}!'`cat /proc/sys/kernel/random/uuid`'!' /etc/salt/master.d/sharedsecret.conf


### PR DESCRIPTION
Commit 8e2592c2 changed the directory /srv/salt/ceph/remove/migrated into
a symlink to /srv/salt/ceph/remove/destroyed.  RPM can't cope with directories
becoming symlinks (see https://bugzilla.redhat.com/show_bug.cgi?id=447156),
so we have to add a %pretrans script to the spec file to delete the old
'migrated' directory if it exists before RPM tries to do anything else.
Without this, the package can't be upgraded (it will fail complaining of
either file conflicts, or cpio rename failures, depending on whether you
do the upgrade with `rpm` or `zypper`).

Signed-off-by: Tim Serong <tserong@suse.com>