### PR TITLE
[SES5] qa/igw: enable targetcli debug logging

### DIFF
--- a/qa/common/deploy.sh
+++ b/qa/common/deploy.sh
@@ -191,6 +191,7 @@ function deploy_ceph {
         echo "Stages 0-3 OK, no roles requiring Stage 4: deploy phase complete!"
         return 0
     fi
+    test -n "$IGW" && iscsi_enable_targetcli_debug_logging
     test -n "$NFS_GANESHA" && nfs_ganesha_no_root_squash
     run_stage_4 "$CLI"
     if [ -n "$NFS_GANESHA" ] ; then


### PR DESCRIPTION
When igw role is present, install targetcli-rbd on the igw node, enable
debug logging, and if Stage 4 fails, dump the logfile.

Signed-off-by: Nathan Cutler <ncutler@suse.com>

References: https://github.com/SUSE/DeepSea/issues/1385


-----------------

**Checklist:**
- [x] Added unittests and or functional tests
~~- [ ] Adapted documentation~~
- [x] Referenced issues or internal bugtracker
- [ ] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
- [ ] this PR merged
- [ ] forward-port to ses6
