### PR TITLE
cli: terminal_outputter: don't dereference a runner step that already finished

### DIFF
--- a/cli/monitors/terminal_outputter.py
+++ b/cli/monitors/terminal_outputter.py
@@ -822,7 +822,6 @@ class StepListPrinter(MonitorListener):
             elif self.step:
                 self.step.finished = True
                 self.print_step(self.step)
-            if self.step.step.jid == step.jid:
                 self.step = None
 
     def step_runner_skipped(self, step):


### PR DESCRIPTION
Fixes: bsc#1110936

Signed-off-by: Ricardo Dias <rdias@suse.com>
