### PR TITLE
mds/restart: fix restarts when minion_id is fqdn

### DIFF
--- a/srv/salt/ceph/restart/mds/default-shrink.sls
+++ b/srv/salt/ceph/restart/mds/default-shrink.sls
@@ -26,14 +26,14 @@ wait until all active mds but one have stopped:
 {% for standby in standbys %}
 shutdown standby daemon {{ standby }}:
   salt.state:
-    - tgt: {{ standby }}
+    - tgt: {{ standby }}*
     - sls: ceph.mds.shutdown
 {% endfor %}
 
 {% set active = salt['saltutil.runner']('cmd.run', cmd='ceph --format=json fs dump 2>/dev/null | jq --raw-output "[.filesystems[0].mdsmap.info|.[].name] | .[0]"') %}
 restarting remaing active {{ active }}:
   salt.state:
-    - tgt: '{{ active }}'
+    - tgt: {{ active }}*
     - sls: ceph.mds.restart
     - failhard: True
 
@@ -45,7 +45,7 @@ wait until all active mds are up and active:
 {% for standby in standbys %}
 start standby daemon {{ standby }}:
    salt.state:
-     - tgt: {{ standby }}
+     - tgt: {{ standby }}*
      - sls: ceph.mds
 {% endfor %}
 


### PR DESCRIPTION
MDS daemons are named after their nodes short hostname. Using these as
minion IDs fails in production environments (minion_id should be fqdn).
Add '*' to restart targets to catch this. This will work as long as we
name MDS daemons with short hostnames.

Fixes: bsc#1110852

Signed-off-by: Jan Fajerski <jfajerski@suse.com>

Fixes #


Description:


-----------------

**Checklist:**
- [ ] Added unittests and or functional tests
- [ ] Adapted documentation
- [ ] Referenced issues or internal bugtracker
- [ ] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
