### PR TITLE
fix: only check OSDs after restarting an OSD (bsc#1110759)

### DIFF
--- a/srv/salt/ceph/osd/restart/controlled/default.sls
+++ b/srv/salt/ceph/osd/restart/controlled/default.sls
@@ -10,6 +10,8 @@ restart osd {{ id }}:
 wait on processes after processing osd.{{ id }}:
   module.run:
     - name: cephprocesses.wait
+    - kwargs:
+        'roles': ["storage"]
     - fire_event: True
     - failhard: True
 


### PR DESCRIPTION
Signed-off-by: Joshua Schmid <jschmid@suse.de>

suse_internal: bsc#1110759

For some reason it makes a different to salt in which context the module is executed from:

from the CLI the cephprocesses.check works as expected.

in the context of $changed_file the functions goes crazy and returns:

```
 {'down': ['ceph-radosgw', 'rgw', 'nfs-ganesha'],
 'up': {'rpc.statd': [96081], 
        'ceph-mds': [41269], 
        'rpcbind': [96061],  
        'ganesha.nfsd': [689925],
        'radosgw': [689097],
        'ceph-osd': [715680, 715777, 719338, 719435, 719532]}}
```

By adding the kwargs: {roles: ['storage']} we bypass the failing checks. This can be considered a workaround. We only loose imo unnecessary checks as a restart of a osd should not correlate with any other service. (I guess)

-----------------

**Checklist:**
- [x] Referenced issues or internal bugtracker
- [ ] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
