### PR TITLE
[SES5] qa/iscsi: refactor iscsi_mount_and_sanity_test and enable targetcli debug logging

### DIFF
--- a/qa/common/common.sh
+++ b/qa/common/common.sh
@@ -377,7 +377,12 @@ function iscsi_mount_and_sanity_test {
     #
     local TESTSCRIPT=/tmp/iscsi_test.sh
     local CLIENTNODE=$(_client_node)
+    # FIXME: assert there is only one igw node
     local IGWNODE=$(_first_x_node igw)
+    if [ "$CLIENTNODE" = "$IGWNODE" ] ; then
+        echo "This test must run on a dedicated client node. It cannot run on the igw node."
+        exit 1
+    fi
     cat << EOF > $TESTSCRIPT
 set -e
 trap 'echo "Result: NOT_OK"' ERR
@@ -411,7 +416,6 @@ umount /mnt
 iscsiadm -m node --logout
 echo "Result: OK"
 EOF
-    # FIXME: assert script not running on the iSCSI gateway node
     _run_test_script_on_node $TESTSCRIPT $CLIENTNODE
 }
 

--- a/qa/common/common.sh
+++ b/qa/common/common.sh
@@ -97,6 +97,9 @@ function run_stage_3 {
 
 function run_stage_4 {
     _run_stage 4 "$@"
+    if [ -z "$STAGE_SUCCEEDED" ] ; then
+        test "$IGW" && iscsi_dump_targetcli_debug_logfile
+    fi
     test "$STAGE_SUCCEEDED"
 }
 
@@ -365,6 +368,44 @@ lrbd --output || true
 ls -lR /sys/kernel/config/target/ || true
 ss --tcp --numeric state listening
 echo "See 3260 there?"
+echo "Result: OK"
+EOF
+    _run_test_script_on_node $TESTSCRIPT $IGWNODE
+}
+
+function iscsi_enable_targetcli_debug_logging {
+    #
+    # install targetcli-rbd and enable debug level logging to file
+    #
+    local TESTSCRIPT=/tmp/iscsi_test.sh
+    local IGWNODE=$(_first_x_node igw)
+    cat << EOF > $TESTSCRIPT
+set -e
+trap 'echo "Result: NOT_OK"' ERR
+for delay in 60 60 60 60 ; do
+    sudo zypper --non-interactive --gpg-auto-import-keys refresh && break
+    sleep $delay
+done
+set -x
+zypper --non-interactive install --no-recommends targetcli-rbd
+targetcli / set global loglevel_file=debug
+echo "Result: OK"
+EOF
+    _run_test_script_on_node $TESTSCRIPT $IGWNODE
+}
+
+function iscsi_dump_targetcli_debug_logfile {
+    #
+    # dump the targetcli logfile
+    #
+    local TESTSCRIPT=/tmp/iscsi_test.sh
+    local IGWNODE=$(_first_x_node igw)
+    cat << EOF > $TESTSCRIPT
+set -e
+trap 'echo "Result: NOT_OK"' ERR
+echo "Dumping targetcli logfile..."
+set -x
+cat /root/.targetcli/log.txt
 echo "Result: OK"
 EOF
     _run_test_script_on_node $TESTSCRIPT $IGWNODE

--- a/qa/common/deploy.sh
+++ b/qa/common/deploy.sh
@@ -194,6 +194,7 @@ function deploy_ceph {
         echo "Stages 0-3 OK, no roles requiring Stage 4: $DEPLOY_PHASE_COMPLETE_MESSAGE"
         return 0
     fi
+    test -n "$IGW" && iscsi_enable_targetcli_debug_logging
     test -n "$NFS_GANESHA" && nfs_ganesha_no_root_squash
     run_stage_4 "$CLI"
     if [ -n "$NFS_GANESHA" ] ; then


### PR DESCRIPTION
multipath is not needed with a single igw, and using it like that
apparently triggers a kernel bug, so drop it.
    
Fixes: https://github.com/SUSE/DeepSea/issues/1385
    
Signed-off-by: David Disseldorp <ddiss@suse.com>
Signed-off-by: Nathan Cutler <ncutler@suse.com>

-----------------

**Checklist:**
- [x] Added unittests and or functional tests
~~- [ ] Adapted documentation~~
~~- [ ] Referenced issues or internal bugtracker~~
- [x] Ran integration tests successfully (tier1)
- [x] https://github.com/SUSE/teuthology/pull/148 merged
- [ ] Ran integration tests successfully (tier1/igw) in local environment
- [ ] targetcli debug messages visible in teuthology log
