### PR TITLE
[forwardport] fix: only check OSDs after restarting an OSD

### DIFF
--- a/srv/salt/ceph/osd/restart/controlled/default.sls
+++ b/srv/salt/ceph/osd/restart/controlled/default.sls
@@ -10,6 +10,8 @@ restart osd {{ id }}:
 wait on processes after processing osd.{{ id }}:
   module.run:
     - name: cephprocesses.wait
+    - kwargs:
+        'roles': ["storage"]
     - fire_event: True
     - failhard: True
 


### PR DESCRIPTION
Signed-off-by: Joshua Schmid <jschmid@suse.de>
(cherry picked from commit 96239e7f27dd3eeea316301af1b5741f93879bc3)


forwardport of #1423 

-----------------

**Checklist:**
~- [ ] Added unittests and or functional tests~
~- [ ] Adapted documentation~
- [x] Referenced issues or internal bugtracker
- [ ] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
