### PR TITLE
Refactor cephprocesses module and add tests for it V2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -202,6 +202,7 @@ copy-files:
 	install -m 644 srv/pillar/ceph/benchmarks/templates/*.j2 $(DESTDIR)/srv/pillar/ceph/benchmarks/templates/
 	install -m 644 srv/pillar/ceph/init.sls $(DESTDIR)/srv/pillar/ceph/
 	install -m 644 srv/pillar/ceph/deepsea_minions.sls $(DESTDIR)/srv/pillar/ceph/
+	install -m 644 srv/pillar/ceph/blacklist.sls $(DESTDIR)/srv/pillar/ceph/
 	install -d -m 755 $(DESTDIR)/srv/pillar/ceph/stack
 	install -m 644 srv/pillar/ceph/stack/stack.cfg $(DESTDIR)/srv/pillar/ceph/stack/stack.cfg
 	install -m 644 srv/pillar/top.sls $(DESTDIR)/srv/pillar/

--- a/deepsea.spec.in
+++ b/deepsea.spec.in
@@ -456,6 +456,7 @@ systemctl try-restart salt-api > /dev/null 2>&1 || :
 %config %attr(-, salt, salt) /srv/pillar/ceph/benchmarks/fio/*.yml
 %config %attr(-, salt, salt) /srv/pillar/ceph/benchmarks/templates/*.j2
 %config(noreplace) %attr(-, salt, salt) /srv/pillar/ceph/deepsea_minions.sls
+%config(noreplace) %attr(-, salt, salt) /srv/pillar/ceph/blacklist.sls
 %config %attr(-, salt, salt) /srv/pillar/ceph/stack/stack.cfg
 /srv/salt/_modules/*.py*
 /srv/salt/_states/*.py*

--- a/man/deepsea-stage-0.7
+++ b/man/deepsea-stage-0.7
@@ -3,14 +3,14 @@
 DeepSea stage 0 \- a deeper insight
 .SH DESCRIPTION
 .B DeepSea Stage 0 (Prep)
-is a Salt orchestration and exists mainly for cluster maintenance and operational/preparation tasks. 
+is a Salt orchestration and exists mainly for cluster maintenance and operational/preparation tasks.
 .RE
 .PD
 .SH Preface
 .PP
-Stage.0 behaves differently depending on the presence of a ceph cluster. 
-On the first invocation, or the install phase, DeepSea will run all operations 
-in parallel to speep up the process. Once you successfully deployed the cluster more caution is 
+Stage.0 behaves differently depending on the presence of a ceph cluster.
+On the first invocation, or the install phase, DeepSea will run all operations
+in parallel to speep up the process. Once you successfully deployed the cluster more caution is
 exercised and nodes are processed serially. The operation is chunked in three sections.
 .SS Master
 
@@ -30,12 +30,12 @@ DeepSea performs a set of system validation tests before running the remainder o
 
 .B Salt-Api
 .RS
-Since openATTIC communicates with DeepSea via Salt, the salt-api service must be 
+Since openATTIC communicates with DeepSea via Salt, the salt-api service must be
 enabled and running for openATTIC to establish a connection with Salt.
 .RE
 .B Sync
 .RS
-When a new salt or DeepSea version was installed, salt needs to make sure all modules 
+When a new salt or DeepSea version was installed, salt needs to make sure all modules
 are synced over to it's minions.
 .RE
 .B Updates
@@ -44,26 +44,26 @@ The master minion will be patched.
 .RE
 .B Reboot
 .RS
-By default the master will not reboot. 
+By default the master will not reboot.
 If you still need a reboot you can modify stage 0 defaults to "default-update-reboot"
 or any other available option.
 This can be done by adjusting
 
-.B stage_prep_master. See also deepsea-customization (7) 
+.B stage_prep_master. See also deepsea-customization (7)
 for more information on how to change the default behavior
 .RE
 
 .RE
 .B Readycheck
 .RS
-Make sure all minions are up. Bails out after 300seconds if not all minions 
+Make sure all minions are up. Bails out after 300seconds if not all minions
 haven't joined back.
 .RE
 
 .SS Minions
 .B Sync
 .RS
-If an update was applied to the master, make sure to sync the modules and 
+If an update was applied to the master, make sure to sync the modules and
 grains back to the minions
 .RE
 .B Mines
@@ -72,29 +72,44 @@ Mines are synced to the cluster. See deepsea-mines (7) for more information
 .RE
 .B Serial/Parallel
 .RS
-As described in the Preface, there are two different routes that DeepSea can take depending 
-on the presence of a cluster. When there is no cluster present, the next to steps are to 
-.B update 
+As described in the Preface, there are two different routes that DeepSea can take depending
+on the presence of a cluster. When there is no cluster present, the next to steps are to
+.B update
 and
 .B restart
-the cluster in parallel. The next chapters are written under the assumption that you have a running cluster. 
-All of the following operations are performed sequentially on 
+the cluster in parallel. The next chapters are written under the assumption that you have a running cluster.
+All of the following operations are performed sequentially on
 .B one node at a time
 following the recommended order. (Monitors, Object Storage Deamons, Managers, Metadata services, ...)
 If any of these operations are considered to be failed, the entire process is aborted and should be investigated.
 
 .B Wait for ceph's health
 .RS
-To be as disruption free as possible DeepSea expects the ceph cluster to be in a healthy state before continuing 
+To be as disruption free as possible DeepSea expects the ceph cluster to be in a healthy state before continuing
 with any further actions. If the cluster fails to get in a proper state the stage will be aborted.
 .RE
 .B Check running processes
 .RS
-Every assigned service should have a process up and running. If that's not the case the service is 
-considered to be failed. To detect problems early we check all corresponding services to be up and 
-running after processing a node. If the process is still not up after 15 Minutes on a physical machine 
-or 2 Minutes on a virtual machine,  the stage will abort to prevent causing harm to your system.
-Now it's up to the operator to investigate the failure.
+Every assigned service should have a process up and running. If that's not the case the service is
+considered to be failed. There are exceptions to this. Please see The 'Exceptions' paragraph.
+To detect problems early we check all corresponding services to be up and running after processing a node.
+If the process is still not up after 15 Minutes on a physical machine or 2 Minutes on a virtual machine,
+the stage will abort to prevent causing harm to your system.  Now it's up to the operator to investigate the failure.
+.RE
+.B Exceptions
+.RS
+If you however know that a service is not running properly(for whatever reason) and want to exclude it from the checks you can 
+disable the systemd unit. 
+E.g. systemctl disable ceph-mon@example_host
+The condition for the service to not get checked by the system is fulfilled when the service is disabled _AND_ not-running.
+The special case in this scenario have always been OSDs. In larger clusters you will encounter hardware failures periodically.
+If you, for whatever reason, can't replace the disks immediately and want to keep them online for i.e. further investigation,
+you can _blacklist_ them. Please see the 'Blacklisting OSDs' chapter for more information.
+.RE
+.B Blacklisting OSDs
+.RS
+You can exclude OSDs from the internal health-checks by adding the IDs to '/srv/pillar/ceph/blacklist.sls'
+Inside the file you will find more explanation and an example.
 .RE
 .B Apply updates
 .RS
@@ -102,29 +117,29 @@ DeepSea applies updates to get the cluster on the latest patchlevel.
 .RE
 .B Check for reboots
 .RS
-If the node received a crucial update, like a kernel patch, the node will need to reboot in order to apply it. 
-Before doing so, DeepSea sets a 'noout' flag to the cluster to prevent unneccessary data rebalancing while the 
-node performs the reboot. Please make sure to unset it when the node stays offline confirmably. 
+If the node received a crucial update, like a kernel patch, the node will need to reboot in order to apply it.
+Before doing so, DeepSea sets a 'noout' flag to the cluster to prevent unneccessary data rebalancing while the
+node performs the reboot. Please make sure to unset it when the node stays offline confirmably.
 If the node comes up without any problems the 'noout' flag is unset automatically.
 .RE
 
 .RE
 .SS Restart
-As we installed updates on the cluster, the services might be pointing to old and/or deleted files still. 
+As we installed updates on the cluster, the services might be pointing to old and/or deleted files still.
 In order to apply the correct versions we might need to perform a restart for those services.
-After updating all cluster nodes, DeepSea initiates the 'restart orchestration'. 
-This operation performs checks to determine whether a service restrart is required or not. 
+After updating all cluster nodes, DeepSea initiates the 'restart orchestration'.
+This operation performs checks to determine whether a service restrart is required or not.
 There are two types of criteria which can trigger a restart.
 
 .B Deleted Files
 and
 .B a configuration change
 
-The process of restarting services also happens in a non-disruptive manner by only restarting 
+The process of restarting services also happens in a non-disruptive manner by only restarting
 .B one service at a time
-followed by checking if it's up again and only then continue. 
+followed by checking if it's up again and only then continue.
 Here again, the orchestration exits if an error is detected to prevent harm.
-The restart happens automatically and will not impact your ability to read/write 
+The restart happens automatically and will not impact your ability to read/write
 data to the cluster via any interface.
 
 
@@ -133,7 +148,7 @@ deepsea salt-run state.orch ceph.stage.0
 .PP
 This command can also be used with the
 .B DeepSea cli
-to give feedback during the process from the Salt event bus. 
+to give feedback during the process from the Salt event bus.
 Salt orchestrations are unnervingly silent during execution and only report when complete.
 .PP
 deepsea stage run ceph.stage.0

--- a/srv/modules/runners/cephprocesses.py
+++ b/srv/modules/runners/cephprocesses.py
@@ -213,10 +213,12 @@ def wait(cluster='ceph', **kwargs):
 
     status = {}
     local = salt.client.LocalClient()
+    timeout = settings['timeout']
+    delay = settings['delay']
     status = local.cmd(search,
                        'cephprocesses.wait',
-                       ['timeout={}'.format(settings['timeout']),
-                        'delay={}'.format(settings['delay'])],
+                       kwarg={'timeout': timeout,
+                              'delay': delay},
                        tgt_type="compound")
 
     sys.stdout = _stdout

--- a/srv/pillar/ceph/blacklist.sls
+++ b/srv/pillar/ceph/blacklist.sls
@@ -1,0 +1,16 @@
+# This is an example file to give you some hints on how the strucutre should look like
+# By adjusting this file you can prevent the 'cephprocesses' module from failing if a
+# specified OSD is down. This can come in handy when you have a OSD/device that is known
+# the be failing but can't be removed for whatever reason.
+
+# Example:
+#
+#blacklist:
+#  ceph-osd:
+#    - 0
+#    - 223
+#    - 72
+#
+# This would exclude OSDs with ids 0, 223 and 72 from the checks.
+#
+# Currently there is only support for blacklisting OSDs.

--- a/srv/pillar/ceph/init.sls
+++ b/srv/pillar/ceph/init.sls
@@ -2,5 +2,6 @@
 {% include 'ceph/cluster/' + grains['id'] + '.sls' ignore missing %}
 
 {% include 'ceph/deepsea_minions.sls' ignore missing %}
+{% include 'ceph/blacklist.sls' ignore missing %}
 
 

--- a/srv/salt/_modules/cephprocesses.py
+++ b/srv/salt/_modules/cephprocesses.py
@@ -33,7 +33,6 @@ processes = {'mon': ['ceph-mon'],
              'rgw': ['radosgw'],
              'ganesha': ['ganesha.nfsd', 'rpcbind', 'rpc.statd'],
              'admin': [],
-             'openattic': ['httpd-prefork'],
              'client-cephfs': [],
              'client-iscsi': [],
              'client-nfs': [],
@@ -49,101 +48,322 @@ processes = {'mon': ['ceph-mon'],
 absent_processes = {'igw': ['lrbd']}
 
 
-def check(results=False, quiet=False, **kwargs):
+# pylint: disable=too-few-public-methods
+class SystemdUnit(object):
+    """
+    Class representation of the processes' systemd state
+    """
+
+    def __init__(self, proc_name=None, osd_id=None):
+        self.proc_name = proc_name
+        self._is_disabled = False
+        self.osd_id = osd_id
+        self.service_names = self._service_names()
+
+    @property
+    def is_disabled(self):
+        """
+        Reach out to systemctl and call is-enabled.
+        Property for this state
+        """
+        if not self.service_names:
+            return False
+
+        for fsn in self.service_names:
+            proc = Popen(shlex.split('systemctl is-enabled {}'.format(fsn)), stdout=PIPE)
+            stdout, stderr = proc.communicate()
+            if stderr:
+                # pylint: disable=line-too-long
+                log.error('Requesting the is-enabled flag from {} has resulted in {}'.format(fsn, stderr))
+                return False
+            try:
+                status = stdout.decode('utf-8').strip()
+            except AttributeError:
+                log.error("Could not decode type-> {}".format(type(stdout)))
+                status = ''
+            if status == 'disabled':
+                log.info("Found {} to be disabled".format(fsn))
+                return True
+            if status == 'enabled':
+                log.info("Found {} to be enabled".format(fsn))
+            else:
+                log.info("Expected to get disabled/enabled but got {} instead".format(status))
+        # Return False when no unit is 'disabled'
+        return False
+
+    def _service_names(self):
+        """
+        The construction of systemd unit names vary
+        from service to service
+        """
+        service_names = []
+        if self.osd_id and self.proc_name == 'ceph-osd':
+            service_names = ["{}@{}".format(self.proc_name, self.osd_id)]
+        if self.proc_name in ['ceph-mon', 'ceph-mgr', 'ceph-mds']:
+            service_names = ["{}@{}".format(self.proc_name, __grains__['host'])]
+        if self.proc_name == 'lrbd':
+            service_names = ['lrbd']
+        if self.proc_name == 'radosgw':
+            service_names = ["{}@{}".format('ceph-radosgw', __grains__['host'])]
+        if self.proc_name == 'ganesha.nfsd':
+            service_names = ['nfs-ganesha', 'rpcbind']
+        return service_names
+
+
+# pylint: disable=too-many-instance-attributes, too-few-public-methods
+class ProcInfo(object):
+    """
+    Maps processes to a helper class and tries to deduce
+    the osd_ids from the process.
+    """
+
+    def __init__(self, proc):
+        # the proc object
+        self.proc = proc
+        # e.g. python3, perl, etc
+        self.exe = os.path.basename(proc.exe())
+        # e.g. salt-call, ceph-osd
+        self.name = proc.name()
+        # e.g. systems pid
+        self.pid = proc.pid
+        # uid the proc is running under.
+        self.uid = proc.uids().real
+        # uid to name. (root, salt.. etc)
+        self.uid_name = pwd.getpwuid(self.uid).pw_name
+        if self.name == 'ceph-osd':
+            self.osd_id = self._map_osd_proc_to_osd_id()
+        else:
+            self.osd_id = None
+        if 'python' in self.exe:
+            self.exe = self.name
+        if self.proc.status() == 'running':
+            self.up = False
+        self._is_disabled = False
+
+    def __repr__(self):
+        """
+        custom __repr__ to identify the class a bit easier while debugging
+        """
+        return "Process <{}>".format(self.name)
+
+    def _map_osd_proc_to_osd_id(self):
+        """
+        Look into the commandline the process has been called
+        with and extract the --id portion.
+        """
+        _id = self.proc.cmdline()[self.proc.cmdline().index('--id') + 1]
+        if _id:
+            return _id
+        else:
+            raise NoOSDIDFound
+
+
+class NoOSDIDFound(Exception):
+    """
+    Custom Exception to raise when no OSD ID is found.
+    """
+    pass
+
+
+class MetaCheck(object):
+    """
+    Class to handle checks of Processes
+    """
+
+    def __init__(self, **kwargs):
+        self.up = list()
+        self.down = list()
+        self.running = True
+        self.quiet = kwargs.get('quiet', False)
+        self.insufficient_osd_count = False
+        self.__blacklist = kwargs.get('blacklist', dict())
+
+    @property
+    def blacklist(self):
+        """
+        The blacklist gets sourced from kwargs.
+        In our usecase we get the data from the salt-master
+        as a central place to annotate blacklisted OSDs
+        The current implementation only allows OSDs.
+        """
+        if self.__blacklist:
+            return self.__blacklist
+        return __salt__['pillar.get']('blacklist')
+
+    @blacklist.setter
+    def blacklist(self, bl):
+        """
+        For testing purposes
+        """
+        self.__blacklist = bl
+
+    @property
+    def expected_osds(self):
+        """
+        Return the expected OSDs ( Minus the blacklisted )
+        """
+        blacklisted_osds = []
+        blacklist = self.blacklist
+        if 'ceph-osd' in blacklist:
+            if blacklist['ceph-osd']:
+                blacklisted_osds = [str(x) for x in blacklist['ceph-osd']]
+                log.warning("You configured OSDs to be blacklisted. {}".format(blacklisted_osds))
+        return list(set(__salt__['osd.list']()) - set(blacklisted_osds))
+
+    def filter_for(self, prc_name):
+        """
+        utils method to filter for process names
+        """
+        return [x for x in self.up if x.exe == prc_name]
+
+    def add(self, prc, role):
+        """
+        Add a role to the self.up list if it's process is found
+        in the process dict.
+        Also do a special check for oA
+        """
+        if prc.exe in processes[role] or prc.name in processes[role]:
+            # Verify httpd-worker pid belongs to openattic.
+            if (role != 'openattic') or (role == 'openattic' and prc.uid_name == 'openattic'):
+                self.up.append(prc)
+
+    def check_inverts(self, role):
+        """
+        Running indicates whether the service is in its expected state
+        while here the logic is inverted.
+        If the process is considered 'running' it means that it has not
+        finished yet and is still 'working'
+        """
+        if role in absent_processes.keys():
+            for proc in absent_processes[role]:
+                if proc in [prc.name for prc in self.up]:
+                    self.running = False
+                    # pylint: disable=line-too-long
+                    log.error("ERROR: process {} for role {} is pending(working)".format(proc, role))
+
+    def check_absents(self, role):
+        """
+        If found processes are not in the list of required
+        processes, set running to False and mark as down
+        """
+        for proc in processes[role]:
+            if proc not in [prc.name for prc in self.up]:
+                if not self.quiet:
+                    # pylint: disable=line-too-long
+                    log.error("ERROR: process {} for role {} is not running".format(proc, role))
+                self.running = False
+                self.down.append(proc)
+
+    @property
+    def _up_osds(self):
+        """
+        Property that returns a str(osd_id) of filtered ceph-osd processes
+        """
+        return [str(x.osd_id) for x in self.filter_for('ceph-osd')]
+
+    @property
+    def _missing_osds(self):
+        """
+        Property that returns the diff between expected and up osds
+        """
+        return list(set(self.expected_osds) - set(self._up_osds))
+
+    def _insufficient_osd_count(self):
+        """
+        Check if the sufficient number of OSDs are up
+        """
+        if len(self.expected_osds) > len(self._up_osds):
+            if not self.quiet:
+                # pylint: disable=line-too-long
+                log.error("{} OSDs not running: {}".format(len(self._missing_osds), self._missing_osds))
+                log.error("Found less OSDs then expected. Expected {} | Found {}".format(len(self.expected_osds), len(self._up_osds)))
+            self.insufficient_osd_count = True
+        else:
+            self.insufficient_osd_count = False
+
+    def check_osds(self):
+        """
+        Check the count of OSDs
+        """
+        self._insufficient_osd_count()
+        if self.filter_for('ceph-osd'):
+            if self.insufficient_osd_count:
+                self.running = False
+
+    def report(self):
+        """
+        Format the structures so that salt understands it
+
+        {'up':   {'ceph-osd': [1,2,3],
+                  'ceph-mon': [1]
+                 },
+         'down': {'ceph-osd': [4],
+                  'lrbd': ['lrbd']
+                 }
+        }
+        In the down->ceph-osd case, the key describes the
+        osd_id which is down as opposed to the up->ceph-osd
+        where the key describes the process id.
+        """
+        res = {'up': {}, 'down': {}}
+        # initialize
+        for proc in self.up:
+            res['up'][proc.exe] = list()
+        for proc in self.down:
+            # We only consider down/enabled as abort condition
+            if not SystemdUnit(proc_name=proc).is_disabled:
+                res['down'][proc] = proc
+
+        for proc in self.up:
+            # We are checking if a systemd-unit is up,
+            # but not if it is disabled. maybe we should?
+            res['up'][proc.exe].append(proc.pid)
+        if self.insufficient_osd_count:
+            for missing_osd in self._missing_osds:
+                if not SystemdUnit(proc_name='ceph-osd', osd_id=missing_osd).is_disabled:
+                    res['down']['ceph-osd'] = self._missing_osds
+        return res
+
+
+def _extend_processes():
+    """
+    Extend the processes by rgw_configurations
+    """
+    if 'rgw_configurations' in __pillar__:
+        for rgw_config in __pillar__['rgw_configurations']:
+            processes[rgw_config] = ['radosgw']
+
+
+def check(results=False, **kwargs):
 
     """
     Query the status of running processes for each role.  Return False if any
     fail.  If results flag is set, return a dictionary of the form:
       { 'down': [ process, ... ], 'up': { process: [ pid, ... ], ...} }
     """
-    running = True
-    res = {'up': {}, 'down': []}
+    _extend_processes()
+    res = MetaCheck(**kwargs)
 
-    if 'rgw_configurations' in __pillar__:
-        for rgw_config in __pillar__['rgw_configurations']:
-            processes[rgw_config] = ['radosgw']
+    if 'roles' not in __pillar__:
+        log.error("Did not find _roles_ in pillar. Aborting")
+        return False
+    for role in kwargs.get('roles', __pillar__['roles']):
+        for running_proc in psutil.process_iter():
+            res.add(ProcInfo(running_proc), role)
+        res.check_inverts(role)
+        res.check_absents(role)
+        if role == 'storage':
+            res.check_osds()
 
-    # pylint: disable=too-many-nested-blocks
-    if 'roles' in __pillar__:
-        for role in kwargs.get('roles', __pillar__['roles']):
-            # Checking running first.
-            for running_proc in psutil.process_iter():
-                # NOTE about `ps` and psutils.Process():
-                # `ps -e` determines process names by examining
-                # /proc/PID/stat,status files.  The name derived
-                # there is also found in psutil.Process.name.
-                # `ps -ef`, according to strace, appears to also reference
-                # /proc/PID/cmdline when determining
-                # process names.  We have found that some processes (ie.
-                # ceph-mgr was noted) will _sometimes_
-                # contain a process name in /proc/PIDstat/stat,status that does
-                # not match that found in /proc/PID/cmdline.
-                # In our ceph-mgr example, the process name was found to be
-                # 'exe' (which happens to also be the name a of
-                # symlink in /proc/PID that points to the executable) while the
-                # cmdline entry contained 'ceph-mgr' etc.
-                # As such, we've decided that a check based on executable
-                # path is more reliable.
-                pdict = running_proc.as_dict(attrs=['pid', 'name', 'exe', 'uids'])
-                pdict_exe = os.path.basename(pdict['exe'])
-                pdict_name = pdict['name']
-                pdict_pid = pdict['pid']
-                # Convert the numerical UID to name.
-                pdict_uid = pwd.getpwuid(pdict['uids'].real).pw_name
-                if pdict_exe in processes[role] or pdict_name in processes[role]:
-                    # When we don't have a binary but a python program
-                    # we want to use it's name for the 'exe'
-                    # Example:
-                    # pdict_exe for a lrbd is '/usr/bin/python2.7'
-                    # pdict['name'] is the actual name of the .py file to be executed
-                    if 'python' in pdict_exe:
-                        pdict_exe = pdict_name
-                    # Verify httpd-worker pid belongs to openattic.
-                    if (role != 'openattic') or (role == 'openattic' and pdict_uid == 'openattic'):
-                        if pdict_exe in res['up']:
-                            res['up'][pdict_exe] = res['up'][pdict_exe] + [pdict_pid]
-                        else:
-                            res['up'][pdict_exe] = [pdict_pid]
-
-            if role in absent_processes.keys():
-                for proc in absent_processes[role]:
-                    if proc in res['up']:
-                        # running is deceptive here
-                        # running indicates wheter the service is in it's expected state
-                        running = False
-                        # pylint: disable=line-too-long
-                        log.error("ERROR: process {} for role {} is pending(working)".format(proc, role))
-            else:
-                for proc in processes[role]:
-                    if proc not in res['up']:
-                        if not quiet:
-                            # pylint: disable=line-too-long
-                            log.error("ERROR: process {} for role {} is not running".format(proc, role))
-                        running = False
-                        res['down'] += [proc]
-
-            # pylint: disable=fixme
-            # FIXME: Map osd.ids to processes.pid to improve qualitify of logging
-            # currently you can only say how many osds/ if any are down, but not
-            # which osd is down exactly.
-            if role == 'storage':
-                if 'ceph-osd' in res['up']:
-                    if len(__salt__['osd.list']()) > len(res['up']['ceph-osd']):
-                        if not quiet:
-                            log.error("ERROR: At least one OSD is not running")
-                        res = {'up': {}, 'down': {'ceph-osd': 'ceph-osd'}}
-                        running = False
-
-    return res if results else running
+    return res.report() if results else res.running
 
 
-# pylint: disable=unused-argument
-def down(**kwargs):
+def down():
     """
     Based on check(), return True/False if all Ceph processes that are meant
     to be running on a node are down.
     """
-    return True if not list(check(True, True)['up'].values()) else False
+    return True if not list(check(True)['up'].values()) else False
 
 
 def wait(**kwargs):

--- a/tests/unit/_modules/test_cephprocesses.py
+++ b/tests/unit/_modules/test_cephprocesses.py
@@ -1,0 +1,619 @@
+import pytest
+import sys
+sys.path.insert(0, 'srv/salt/_modules')
+from srv.salt._modules import cephprocesses, helper
+from mock import MagicMock, patch, mock_open, mock, create_autospec, ANY
+from tests.unit.helper.output import OutputHelper
+from tests.unit.helper.fixtures import helper_specs
+from collections import namedtuple
+
+DEFAULT_MODULE=cephprocesses
+
+class MockedPsUtil(object):
+
+    def __init__(self, name, pid, uid, exe, osd_id=0):
+        self._name = name
+        self._uid = uid
+        self._exe = exe
+        self.pid = pid
+        self.osd_id = osd_id
+
+    def name(self):
+        return self._name
+
+    def exe(self):
+        return self._exe
+
+    def uids(self):
+        Puids = namedtuple('Puids', 'real effective saved')
+        return Puids(self._uid, 0, 0)
+
+    def cmdline(self):
+        return ['/usr/bin/ceph-osd', '-f', '--cluster', 'ceph', '--id', '{}'.format(self.osd_id), '--setuser', 'ceph', '--setgroup', 'ceph']
+
+    def status(self):
+        return 'running'
+
+
+class TestCephprocessesProcInfo():
+
+    @pytest.fixture(scope='class')
+    def cpr(self):
+        yield MockedPsUtil('ceph-osd', 0, 0, '/usr/bin/ceph-osd')
+
+    def test_map_open_proc_to_osd_id_1(self, cpr):
+        """
+        passing a osd_id of 1 to the process, it also mocks the 'open_files'
+        namedtuple to match that ID. This tests the regex.
+        """
+        proc = MockedPsUtil('ceph-osd', 0, 0, '/usr/bin/ceph-osd', osd_id=1)
+        procinfo = cephprocesses.ProcInfo(proc)
+        assert procinfo.osd_id == '1'
+
+    def test_map_open_proc_to_osd_id_2digits(self):
+        """
+        passing a osd_id of 20 to the process, it also mocks the 'open_files'
+        namedtuple to match that ID. This tests the regex.
+        """
+        proc = MockedPsUtil('ceph-osd', 0, 0, '/usr/bin/ceph-osd', osd_id=20)
+        procinfo = cephprocesses.ProcInfo(proc)
+        assert procinfo.osd_id == '20'
+
+    def test_map_open_proc_to_osd_id_multiple_digits(self):
+        """
+        passing a osd_id of 99999 to the process, it also mocks the 'open_files'
+        namedtuple to match that ID. This tests the regex.
+        """
+        proc = MockedPsUtil('ceph-osd', 0, 0, '/usr/bin/ceph-osd', osd_id=99999)
+        procinfo = cephprocesses.ProcInfo(proc)
+        assert procinfo.osd_id == '99999'
+
+    def test_map_open_proc_to_osd_id_multiple_raises(self):
+        """
+        passing a osd_id of None  to the process, it also mocks the 'open_files'
+        namedtuple to match that ID. This tests the Exception
+        """
+        proc = MockedPsUtil('ceph-osd', 0, 0, '/usr/bin/ceph-osd', osd_id='')
+        with pytest.raises(cephprocesses.NoOSDIDFound):
+            procinfo = cephprocesses.ProcInfo(proc)
+
+class TestMetaCheck():
+
+    @pytest.fixture(scope='class')
+    def mc(self):
+        cephprocesses.__grains__ = {'host': 'a_hostname'}
+        self.set_osd_list([])
+        yield cephprocesses.MetaCheck()
+
+    def set_osd_list(self, osd_list):
+        cephprocesses.__salt__ = {'osd.list': lambda : osd_list}
+
+    @pytest.mark.skip(reason='Not fully implemented yet')
+    def test_blacklist(self):
+        pass
+
+    @pytest.mark.skip(reason='Not fully implemented yet')
+    def test_expected_osds(self, mc):
+        """
+        If no blacklist is set, expected OSDs are the osds that
+        are returned from __salt__['osd.list']
+        """
+        expect = ['1', '2']
+        self.set_osd_list(expect)
+        assert mc.expected_osds == expect
+
+    @pytest.mark.skip(reason='Not fully implemented yet')
+    def test_expected_osds_blacklist(self, mc):
+        """
+        if OSDs are blacklisted, expect to see it removed
+        from the list
+        """
+        expect = ['1', '2', '3']
+        mc.blacklist = {'ceph-osd': ['2']}
+        self.set_osd_list(expect)
+        assert mc.expected_osds == ['1', '3']
+
+    def mock_up(self):
+        ups = []
+        for prc_name, bin_names in cephprocesses.processes.items():
+            for bin_name in bin_names:
+                proc = MockedPsUtil(bin_name, 0, 0, '/usr/bin/{}'.format(bin_name))
+                procinfo = cephprocesses.ProcInfo(proc)
+                ups.append(procinfo)
+        return ups
+
+    def test_filter_ceph_osd(self, mc):
+        """
+        Len = 1 because we source from processes list
+        """
+        mc.up = self.mock_up()
+        expected_len = 1
+        ret = mc.filter_for('ceph-osd')
+        assert len(ret) == expected_len
+        assert ret[0].name == 'ceph-osd'
+
+    def test_filter_ceph_mon(self, mc):
+        mc.up = self.mock_up()
+        expected_len = 1
+        ret = mc.filter_for('ceph-mon')
+        assert len(ret) == expected_len
+        assert ret[0].name == 'ceph-mon'
+
+    def test_filter_ceph_osd_multiple(self, mc):
+        expected_len = 10
+        for i in range(1, expected_len):
+            mc.up.extend(self.mock_up())
+        ret = mc.filter_for('ceph-osd')
+        assert len(ret) == expected_len
+        assert ret[0].name == 'ceph-osd'
+
+    def build_proc(self, role_name, proc_name, uid=0):
+        proc = MockedPsUtil(proc_name, 0, uid, '/usr/bin/{}'.format(proc_name))
+        return cephprocesses.ProcInfo(proc)
+
+    def test_add_storage(self, mc):
+        mc.up = []
+        role_name = 'storage'
+        proc_name = 'ceph-osd'
+        mc.add(self.build_proc(role_name, proc_name), role_name)
+        assert len(mc.up) == 1
+        assert mc.up[0].name == 'ceph-osd'
+
+    def test_add_mon(self, mc):
+        mc.up = []
+        role_name = 'mon'
+        proc_name = 'ceph-mon'
+
+        mc.add(self.build_proc(role_name, proc_name), role_name)
+        assert len(mc.up) == 1
+        assert mc.up[0].name == proc_name
+
+    def test_add_mgr(self, mc):
+        mc.up = []
+        role_name = 'mgr'
+        proc_name = 'ceph-mgr'
+        mc.add(self.build_proc(role_name, proc_name), role_name)
+        assert len(mc.up) == 1
+        assert mc.up[0].name == proc_name
+
+    def test_add_mds(self, mc):
+        mc.up = []
+        role_name = 'mds'
+        proc_name = 'ceph-mds'
+        mc.add(self.build_proc(role_name, proc_name), role_name)
+        assert len(mc.up) == 1
+        assert mc.up[0].name == proc_name
+
+    def test_add_igw(self, mc):
+        mc.up = []
+        role_name = 'mds'
+        proc_name = 'ceph-mds'
+        mc.add(self.build_proc(role_name, proc_name), role_name)
+        assert len(mc.up) == 1
+        assert mc.up[0].name == proc_name
+
+    def test_add_rgw(self, mc):
+        mc.up = []
+        role_name = 'rgw'
+        proc_name = 'radosgw'
+        mc.add(self.build_proc(role_name, proc_name), role_name)
+        assert len(mc.up) == 1
+        assert mc.up[0].name == proc_name
+
+    def test_add_igw(self, mc):
+        mc.up = []
+        role_name = 'igw'
+        proc_name = 'lrbd'
+        mc.add(self.build_proc(role_name, proc_name), role_name)
+        assert len(mc.up) == 1
+        assert mc.up[0].name == proc_name
+
+    def test_add_ganesha(self, mc):
+        mc.up = []
+        role_name = 'ganesha'
+        proc_name = 'ganesha.nfsd'
+        proc_name2 = 'rpcbind'
+        proc_name3 = 'rpc.statd'
+        mc.add(self.build_proc(role_name, proc_name), role_name)
+        mc.add(self.build_proc(role_name, proc_name2), role_name)
+        mc.add(self.build_proc(role_name, proc_name3), role_name)
+        assert len(mc.up) == 3
+        assert mc.up[0].name == proc_name
+        assert mc.up[1].name == proc_name2
+        assert mc.up[2].name == proc_name3
+
+    @pytest.mark.skip(reason="openattic will be replaced by ceph-dashboard")
+    def test_add_openattic(self, mc):
+        mc.up = []
+        role_name = 'openattic'
+        proc_name = 'httpd-prefork'
+        proc = self.build_proc(role_name, proc_name)
+        proc.uid_name = 'openattic'
+        mc.add(proc, role_name)
+        assert len(mc.up) == 1
+        assert mc.up[0].name == proc_name
+
+    @pytest.mark.skip(reason="openattic will be replaced by ceph-dashboard")
+    def test_add_openattic_negative(self, mc):
+        mc.up = []
+        role_name = 'openattic'
+        proc_name = 'httpd-prefork'
+        proc = self.build_proc(role_name, proc_name)
+        # not fulfilled the if branch
+        proc.uid_name = 'openatticNOTNOT'
+        mc.add(proc, role_name)
+        assert len(mc.up) == 0
+
+    def test_check_inverts_positive(self, mc):
+        mc.up = []
+        role_name = 'igw'
+        proc_name = 'lrbd'
+        proc = self.build_proc(role_name, proc_name)
+        assert mc.running == True
+        mc.up.append(proc)
+        mc.check_inverts(role_name)
+        # TODO: Expect a log.error
+        assert mc.running == False
+
+    def test_check_inverts_negative(self, mc):
+        mc.up = []
+        mc.running = True
+        role_name = 'mds'
+        proc_name = 'ceph-mds'
+        proc = self.build_proc(role_name, proc_name)
+        assert mc.running == True
+        mc.up.append(proc)
+        mc.check_inverts(role_name)
+        assert mc.running == True
+
+    def test_check_absents(self, mc):
+        role_name = 'mds'
+        proc_name = 'ceph-mds'
+        proc = self.build_proc(role_name, proc_name)
+        mc.up = [proc]
+        mc.check_absents(role_name)
+        assert len(mc.down) == 0
+
+    def test_check_absents_negative(self, mc):
+        mc.up = []
+        role_name = 'mds'
+        mc.check_absents(role_name)
+        assert len(mc.down) == 1
+
+    def test_check_absents_negative_ganesha(self, mc):
+        mc.down = []
+        role_name = 'ganesha'
+        proc_name1 = 'ganesha.nfsd'
+        proc_name2 = 'rpcbind'
+        # expect to miss rpc.statd
+        proc1 = self.build_proc(role_name, proc_name1)
+        proc2 = self.build_proc(role_name, proc_name2)
+        mc.up = [proc1, proc2]
+        mc.check_absents(role_name)
+        assert len(mc.down) == 1
+        assert mc.down[0] == 'rpc.statd'
+
+    @mock.patch('srv.salt._modules.cephprocesses.MetaCheck.filter_for')
+    def test_missing_osds(self, filter_mock, mc):
+        """
+        osd.list return 1,2,3
+        blacklist holds 2
+        expected_osds will be 1,3
+        Now only 1 can be found in filter_for(ceph-osd)
+        Expect to return 3
+        """
+        self.set_osd_list(['1', '2', '3'])
+        mc.blacklist = {'ceph-osd': ['2']}
+        proc = MockedPsUtil('ceph-osd', 0, 0, '/usr/bin/ceph-osd', osd_id=1)
+        filter_mock.return_value = [proc]
+        assert mc._missing_osds == ['3']
+
+    @mock.patch('srv.salt._modules.cephprocesses.MetaCheck.filter_for')
+    def test_missing_osds_no_return(self, filter_mock, mc):
+        """
+        osd.list return 1,2,3
+        blacklist holds 2
+        expected_osds will be 1,3
+        1,3 can be found in filter_for(ceph-osd)
+        Expect to return 3
+        """
+        proc = MockedPsUtil('ceph-osd', 0, 0, '/usr/bin/ceph-osd', osd_id=1)
+        proc1 = MockedPsUtil('ceph-osd', 0, 0, '/usr/bin/ceph-osd', osd_id=3)
+        filter_mock.return_value = [proc, proc1]
+        assert mc._missing_osds == []
+
+    @mock.patch('srv.salt._modules.cephprocesses.MetaCheck.filter_for')
+    def test_insufficient_osd_count(self, filter_mock, mc):
+        """
+        expected_osds will be 1,3 -> len == 2
+        """
+        proc = MockedPsUtil('ceph-osd', 0, 0, '/usr/bin/ceph-osd', osd_id=1)
+        filter_mock.return_value = [proc]
+        # TODO: check for logging
+        assert mc.insufficient_osd_count == False
+        mc._insufficient_osd_count()
+        assert mc.insufficient_osd_count == True
+
+    @mock.patch('srv.salt._modules.cephprocesses.MetaCheck.filter_for')
+    def test_insufficient_osd_count_positive(self, filter_mock, mc):
+        """
+        expected_osds will be 1,3 -> len == 2
+        """
+        mc.insufficient_osd_count = False
+        proc = MockedPsUtil('ceph-osd', 0, 0, '/usr/bin/ceph-osd', osd_id=1)
+        proc1 = MockedPsUtil('ceph-osd', 0, 0, '/usr/bin/ceph-osd', osd_id=1)
+        filter_mock.return_value = [proc, proc1]
+        # TODO: check for logging
+        assert mc.insufficient_osd_count == False
+        mc._insufficient_osd_count()
+        assert mc.insufficient_osd_count == False
+
+    @mock.patch('srv.salt._modules.cephprocesses.MetaCheck.filter_for')
+    @mock.patch('srv.salt._modules.cephprocesses.MetaCheck._insufficient_osd_count')
+    def test_check_osd(self, insuf_mock, filter_mock, mc):
+        """
+        Filter for returns something
+        insuff is True
+        """
+        mc.running = True
+        filter_mock.return_value = ['notnull']
+        mc.insufficient_osd_count = True
+        mc.check_osds()
+        assert mc.running == False
+
+    @mock.patch('srv.salt._modules.cephprocesses.MetaCheck.filter_for')
+    @mock.patch('srv.salt._modules.cephprocesses.MetaCheck._insufficient_osd_count')
+    def test_check_osd_1(self, insuf_mock, filter_mock, mc):
+        """
+        filter_for does not return
+        """
+        mc.running = True
+        filter_mock.return_value = []
+        mc.check_osds()
+        assert mc.running == True
+
+    @mock.patch('srv.salt._modules.cephprocesses.MetaCheck.filter_for')
+    @mock.patch('srv.salt._modules.cephprocesses.MetaCheck._insufficient_osd_count')
+    def test_check_osd_2(self, insuf_mock, filter_mock, mc):
+        """
+        filter_for does return something
+        but isuff is False
+        """
+        mc.running = True
+        filter_mock.return_value = ['notnull']
+        mc.insufficient_osd_count = False
+        mc.check_osds()
+        assert mc.running == True
+
+    def test_report_empty(self, mc):
+        mc.up = []
+        mc.down = []
+        assert mc.report() == {'up': {}, 'down': {}}
+
+    def test_report_up(self, mc):
+        role_name = 'mds'
+        proc_name = 'ceph-mds'
+        proc = self.build_proc(role_name, proc_name)
+        mc.up = [proc]
+        mc.down = []
+        assert mc.report() == {'up': {'ceph-mds': [0]}, 'down': {}}
+
+    def test_report_down_not_disabled(self, mc):
+        with mock.patch('srv.salt._modules.cephprocesses.SystemdUnit.is_disabled', new_callable=mock.PropertyMock) as mock_my_property:
+            mock_my_property.return_value = False
+            proc_name = 'ceph-mds'
+            mc.up = []
+            mc.down = [proc_name]
+            assert mc.report() == {'up': {}, 'down': {'ceph-mds': 'ceph-mds'}}
+
+    def test_report_down_disabled(self, mc):
+        with mock.patch('srv.salt._modules.cephprocesses.SystemdUnit.is_disabled', new_callable=mock.PropertyMock) as mock_my_property:
+            mock_my_property.return_value = True
+            proc_name = 'ceph-mds'
+            mc.up = []
+            mc.down = [proc_name]
+            assert mc.report() == {'up': {}, 'down': {}}
+
+    def test_report_up_down(self, mc):
+        role_name = 'storage'
+        proc_name = 'ceph-osd'
+        proc_name_down = 'ceph-mds'
+        proc = self.build_proc(role_name, proc_name)
+        mc.up = [proc]
+        mc.down = [proc_name_down]
+        assert mc.report() == {'up': {'ceph-osd': [0]}, 'down': {'ceph-mds': 'ceph-mds'}}
+
+    @mock.patch('srv.salt._modules.cephprocesses.MetaCheck._missing_osds', new_callable=mock.PropertyMock)
+    def test_report_up_down_down(self, missing_mock, mc):
+        """
+        expected 1,3 up
+        0 is down
+        """
+        # 2 is blacklisted
+        missing_mock.return_value = ['1', '3']
+        role_name = 'storage'
+        proc_name = 'ceph-osd'
+        proc_name_down = 'ceph-mds'
+        mc.insufficient_osd_count = True
+        proc = self.build_proc(role_name, proc_name)
+        mc.up = [proc]
+        mc.down = [proc_name_down]
+        assert mc.report() == {'up': {'ceph-osd': [0]}, 'down': {'ceph-mds': 'ceph-mds', 'ceph-osd': ['1', '3']}}
+
+
+class TestInstanceMethods():
+
+    def test_check(self):
+        """
+        Exit if there is no pillar data
+        """
+        cephprocesses.__pillar__ = {}
+        assert cephprocesses.check() == False
+
+    @mock.patch('srv.salt._modules.cephprocesses.psutil')
+    @mock.patch('srv.salt._modules.cephprocesses.MetaCheck')
+    @mock.patch('srv.salt._modules.cephprocesses.ProcInfo')
+    def test_check_1(self, proc_mock, meta_mock, psutil_mock):
+        """
+        Exit if there is pillar data but no roles in it
+        """
+        cephprocesses.__pillar__ = {'NOroles': ['dummy']}
+        assert cephprocesses.check() == False
+
+    @pytest.mark.parametrize("test_input,expected", [
+        ("mgr", 'mgr'),
+        ("mon", 'mon'),
+        ("mds", 'mds'),
+        ("openattic", 'openattic'),
+        ("rgw", 'rgw'),
+        ("benchmark-rbd", 'benchmark-rbd'),
+        ("storage", 'storage'),
+        ("ganesha", 'ganesha')
+    ])
+    @mock.patch('srv.salt._modules.cephprocesses.psutil.process_iter')
+    @mock.patch('srv.salt._modules.cephprocesses.MetaCheck.report')
+    @mock.patch('srv.salt._modules.cephprocesses.MetaCheck.check_absents')
+    @mock.patch('srv.salt._modules.cephprocesses.MetaCheck.check_inverts')
+    @mock.patch('srv.salt._modules.cephprocesses.MetaCheck.check_osds')
+    @mock.patch('srv.salt._modules.cephprocesses.MetaCheck.add')
+    @mock.patch('srv.salt._modules.cephprocesses.ProcInfo')
+    def test_check_2(self, proc_mock, meta_mock, mock_check_osds, meta_check_invert, meta_check_absent, mock_report, psutil_mock, test_input, expected):
+        """
+        Parameterized test to verify that roles get passed down to methods
+        """
+        role = [test_input]
+        cephprocesses.__pillar__ = {'roles': role}
+        psutil_mock.return_value = ['proc1']
+        cephprocesses.check()
+        proc_mock.assert_called_with('proc1')
+        # ANY instance of ProcInfo
+        meta_mock.assert_called_with(ANY, expected)
+        meta_check_invert.assert_called_with(expected)
+        meta_check_absent.assert_called_with(expected)
+        mock_check_osds.assert_called_once is False
+        mock_report.assert_called
+
+class TestSystemdUnit():
+
+
+    def test_service_names_default_return(self):
+        obj = cephprocesses.SystemdUnit()
+        assert obj.service_names == []
+
+    def test_service_names_osd_no_id(self):
+        obj = cephprocesses.SystemdUnit('ceph-osd')
+        assert obj.service_names == []
+
+    def test_service_names_osd(self):
+        obj = cephprocesses.SystemdUnit('ceph-osd', 1)
+        assert obj.service_names == ['ceph-osd@1']
+
+    @pytest.mark.parametrize('proc_name', ['ceph-mon',
+                                           'ceph-mgr',
+                                           'ceph-mds'])
+    def test_service_names_with_grains_default(self, proc_name):
+        cephprocesses.__grains__ = {'host': 'a_host'}
+        obj = cephprocesses.SystemdUnit(proc_name)
+        assert obj.service_names == ['{}@{}'.format(proc_name, 'a_host')]
+
+    @pytest.mark.parametrize('proc_name', ['radosgw'])
+    def test_service_names_with_grains_non_default(self, proc_name):
+        cephprocesses.__grains__ = {'host': 'a_host'}
+        obj = cephprocesses.SystemdUnit(proc_name)
+        assert obj.service_names == ['{}@{}'.format('ceph-radosgw', 'a_host')]
+
+    @pytest.mark.parametrize('proc_name', ['ganesha.nfsd'])
+    def test_service_names_ganesha(self, proc_name):
+        obj = cephprocesses.SystemdUnit(proc_name)
+        assert obj.service_names == ['nfs-ganesha', 'rpcbind']
+
+    @pytest.mark.parametrize('proc_name', ['lrbd'])
+    def test_service_names_lrbd(self, proc_name):
+        obj = cephprocesses.SystemdUnit(proc_name)
+        assert obj.service_names == ['lrbd']
+
+    @patch('srv.salt._modules.cephprocesses.Popen')
+    def test_is_disabled_no_service_names(self, popen_mock):
+        ret = cephprocesses.SystemdUnit().is_disabled
+        assert ret is False
+
+    @patch('srv.salt._modules.cephprocesses.log')
+    @patch('srv.salt._modules.cephprocesses.Popen')
+    def test_is_disabled_1(self, po, log):
+        """
+        po returns 'enabled\n'
+        log should be called. (once)
+
+        """
+        cephprocesses.__grains__ = {'host': 'a_host'}
+        po.return_value.communicate.return_value = (b"enabled\n ", "")
+        ret = cephprocesses.SystemdUnit('ceph-mon').is_disabled
+        assert ret is False
+        log.info.assert_called_once_with('Found ceph-mon@a_host to be enabled')
+
+    @patch('srv.salt._modules.cephprocesses.log')
+    @patch('srv.salt._modules.cephprocesses.Popen')
+    def test_is_disabled_2(self, po, log):
+        """
+        po returns 'disabled\n'
+        log should be called. (once)
+        """
+        cephprocesses.__grains__ = {'host': 'a_host'}
+        po.return_value.communicate.return_value = (b"disabled\n ", "")
+        ret = cephprocesses.SystemdUnit('ceph-mon').is_disabled
+        assert ret is True
+        log.info.assert_called_once_with('Found ceph-mon@a_host to be disabled')
+
+    @patch('srv.salt._modules.cephprocesses.log')
+    @patch('srv.salt._modules.cephprocesses.Popen')
+    def test_is_disabled_3(self, po, log):
+        """
+        po returns 'undefinded\n'
+        log should be called. (once)
+        """
+        cephprocesses.__grains__ = {'host': 'a_host'}
+        po.return_value.communicate.return_value = (b"undefined\n ", "")
+        ret = cephprocesses.SystemdUnit('ceph-mon').is_disabled
+        assert ret is False
+        log.info.assert_called_once_with('Expected to get disabled/enabled but got undefined instead')
+
+    @patch('srv.salt._modules.cephprocesses.log')
+    @patch('srv.salt._modules.cephprocesses.Popen')
+    def test_is_disabled_4(self, po, log):
+        """
+        multiple entries in self.service_names
+        one is enabled, one is disabled.
+        expect to get True
+        log should be called. (twice)
+        """
+        cephprocesses.__grains__ = {'host': 'a_host'}
+        po.return_value.communicate.side_effect = [(b"enabled\n ", ""), (b"disabled\n ", "")]
+        ret = cephprocesses.SystemdUnit('ganesha.nfsd').is_disabled
+        assert ret is True
+        log.info.assert_called_with('Found rpcbind to be disabled')
+
+    @pytest.mark.skip(reason='Cant reproduce it in the tests, but can in the shell..')
+    @patch('srv.salt._modules.cephprocesses.log')
+    @patch('srv.salt._modules.cephprocesses.Popen')
+    def test_is_disabled_5(self, po, log):
+        """
+        test for AttributeError
+        """
+        cephprocesses.__grains__ = {'host': 'a_host'}
+        po.return_value.communicate.return_value = ("\n", "")
+        with pytest.raises(AttributeError):
+            ret = cephprocesses.SystemdUnit('ganesha.nfsd').is_disabled
+            assert ret is False
+            log.error.assert_called_with('Could not decode type->')
+
+    @patch('srv.salt._modules.cephprocesses.log')
+    @patch('srv.salt._modules.cephprocesses.Popen')
+    def test_is_disabled_6(self, po, log):
+        """
+        stderr
+        """
+        cephprocesses.__grains__ = {'host': 'a_host'}
+        po.return_value.communicate.return_value = ("", "stderr")
+        ret = cephprocesses.SystemdUnit('ceph-mon').is_disabled
+        assert ret is False
+        log.error.assert_called_once_with('Requesting the is-enabled flag from ceph-mon@a_host has resulted in stderr')

--- a/tests/unit/_modules/test_osd.py
+++ b/tests/unit/_modules/test_osd.py
@@ -3177,7 +3177,7 @@ class Test_is_incorrect():
         Test_is_incorrect.proc_mount.SetContents(
             '''/dev/sdb /var/lib/ceph/osd/ceph-1 rest\n''')
         ret = obj.is_incorrect()
-        assert ret == False
+        assert ret is False
 
     @pytest.mark.skip(reason="disabled until found out why pyfakefs is failing")
     @patch('os.path.exists', new=f_os.path.exists)

--- a/tox.ini
+++ b/tox.ini
@@ -21,6 +21,7 @@ passenv = CI TRAVIS TRAVIS_*
 deps =
     {[base]deps}
     mock
+    psutil
     pytest-cov
     pyfakefs<3.3
     pytest


### PR DESCRIPTION
* Add file based blacklisting

* disabled && non-running services will be considered as
  'not down' hence excluded from the checks.

Adds 60~ unittests

Signed-off-by: Joshua Schmid <jschmid@suse.de>

Fixes #1157 

TODO:

- [ ] Thinking about a way to utilize functests to test the 'disabled && not running' statement.
- [x] Adapt docs (especially the blacklist & is-disabled feature)

-----------------

**Checklist:**
- [x] Added unittests and or functional tests
- [ ] Adapted documentation
- [x] Referenced issues or internal bugtracker
- [x] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
