### PR TITLE
Add validation for pending updates

### DIFF
--- a/srv/modules/runners/populate.py
+++ b/srv/modules/runners/populate.py
@@ -73,24 +73,6 @@ def _cmp(x, y):
 
     return (x > y) - (x < y)
 
-class Settings(object):
-    """
-    Common settings
-    """
-
-    def __init__(self):
-        """
-        Assign root_dir, salt __opts__ and stack configuration.  (Stack
-        configuration is not used currently.)
-        """
-        __opts__ = salt.config.client_config('/etc/salt/master')
-        self.__opts__ = __opts__
-
-        for ext in __opts__['ext_pillar']:
-            if 'stack' in ext:
-                self.stack = ext['stack']
-        self.root_dir = "/srv/pillar/ceph/proposals"
-
 
 class SaltWriter(object):
     """
@@ -847,7 +829,7 @@ def show(**kwargs):
     print ("DEPRECATION WARNING: the generation of storage profiles is now"
            " handled by the proposal runner. This function will go away in the"
            " future.")
-    settings = Settings()
+    settings = __utils__['settings.self_']()
 
     salt_writer = SaltWriter(**kwargs)
 
@@ -894,7 +876,7 @@ def proposals(**kwargs):
     Collect the hardware profiles, all possible role assignments and common
     configuration under /srv/pillar/ceph/proposals
     """
-    settings = Settings()
+    settings = __utils__['settings.self_']()
 
     salt_writer = SaltWriter(**kwargs)
 
@@ -1077,9 +1059,9 @@ def engulf_existing_cluster(**kwargs):
 
     search = __utils__['deepsea_minions.show']()
     local = salt.client.LocalClient()
-    settings = Settings()
-    salt_writer = SaltWriter(overwrite=True)
     exception = kwargs.get('exception', False)
+    settings = __utils__['settings.self_']()
+    salt_writer = SaltWriter(overwrite=True)
 
     # Make sure deepsea_minions contains valid minions before proceeding with engulf.
     from . import validate

--- a/srv/modules/runners/validate.py
+++ b/srv/modules/runners/validate.py
@@ -987,7 +987,13 @@ class Validate(Preparation):
         updates = self.local.cmd(self.matches,
                                  'packagemanager.list_salt_updates',
                                  tgt_type='list')
-        updates = [item for sublist in list(updates.values()) for item in sublist]
+        updates_list = list(updates.values())
+        status = [x['status'] for x in updates_list]
+        packages = [x['packages'] for x in updates_list]
+        if False in status:
+            self.warnings['refresh_repos'] = ["Experienced trouble refreshing repositories."]
+        # flatten the packages list to avoid iterating over all minion['packages']
+        updates = [item for sublist in packages for item in sublist]
         if not updates:
             self.passed['salt_updates'] = "valid"
         else:
@@ -1009,7 +1015,14 @@ class Validate(Preparation):
         updates = self.local.cmd(self.matches,
                                  'packagemanager.list_ceph_updates',
                                  tgt_type='list')
-        updates = [item for sublist in list(updates.values()) for item in sublist]
+
+        updates_list = list(updates.values())
+        status = [x['status'] for x in updates_list]
+        packages = [x['packages'] for x in updates_list]
+        if False in status:
+            self.warnings['refresh_repos'] = ["Experienced trouble refreshing the repositories."]
+        # flatten the packages list to avoid iterating over all minion['packages']
+        updates = [item for sublist in packages for item in sublist]
         if not updates:
             self.passed['ceph_updates'] = "valid"
         else:

--- a/srv/modules/runners/validate.py
+++ b/srv/modules/runners/validate.py
@@ -1020,14 +1020,15 @@ class Validate(Preparation):
         status = [x['status'] for x in updates_list]
         packages = [x['packages'] for x in updates_list]
         if False in status:
-            self.warnings['refresh_repos'] = ["Experienced trouble refreshing the repositories."]
+            # pylint: disable=line-too-long
+            self.warnings['refresh_repos'] = ["Experienced trouble refreshing the repositories. Please find more information in the minion logs"]
         # flatten the packages list to avoid iterating over all minion['packages']
         updates = [item for sublist in packages for item in sublist]
         if not updates:
             self.passed['ceph_updates'] = "valid"
         else:
             # pylint: disable=line-too-long
-            msg = ("On or more of your minions have updates pending that might cause ceph-daemons to restart. This might extend the duration of this Stage depending on your cluster size.")
+            msg = ("On or more of your minions have updates pending that might cause ceph-daemons to restart. This might extend the duration of this Stage depending on your cluster size. If you want to find out which packages will be updated, you can get the full list with salt -I 'cluster:ceph' packagemanager.list_ceph_updates")
             self.warnings['ceph_updates'] = [msg]
 
     def report(self):

--- a/srv/modules/runners/validate.py
+++ b/srv/modules/runners/validate.py
@@ -976,7 +976,7 @@ class Validate(Preparation):
         """
         Salt Updates available?
         Adds ~3 seconds to the setup validation
-        indipendent of the cluster size
+        independent of the cluster size
         I tried using a mine(.get) here but it turns
         out that I _very_ often get stale results..
         Refreshing the mine everytime before running

--- a/srv/modules/utils/settings.py
+++ b/srv/modules/utils/settings.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=modernize-parse-error
+"""
+Settings Helper class to export the __opts__ dunder.
+"""
+
+from __future__ import absolute_import
+import salt.config
+
+
+# pylint: disable=too-few-public-methods
+class Settings(object):
+    """
+    Common settings
+    """
+    def __init__(self):
+        """
+        Assign root_dir, salt __opts__ and stack configuration.  (Stack
+        configuration is not used currently.)
+        """
+        __opts__ = salt.config.client_config('/etc/salt/master')
+        self.__opts__ = __opts__
+
+        for ext in __opts__['ext_pillar']:
+            if 'stack' in ext:
+                self.stack = ext['stack']
+        self.root_dir = "/srv/pillar/ceph/proposals"
+
+
+def self_():
+    """
+    Salt exporter func
+    """
+    return Settings()

--- a/srv/salt/_modules/packagemanager.py
+++ b/srv/salt/_modules/packagemanager.py
@@ -177,7 +177,6 @@ class Zypper(PackageManager):
     def _refresh(self):
         """
         Refresh Zypper before updating
-        Raise RefreshFailed when returncode != 1
         """
         log.info("Refreshing Repositories..")
 

--- a/srv/salt/ceph/mines/default.sls
+++ b/srv/salt/ceph/mines/default.sls
@@ -1,5 +1,4 @@
 
-
 configure_mine_functions_conf:
   file.managed:
     - name: /etc/salt/minion.d/mine_functions.conf
@@ -17,4 +16,3 @@ manage_salt_minion_for_mines:
     - watch:
       - file: configure_mine_functions_conf
     - fire_event: True
-

--- a/tests/unit/_modules/test_packagemanager.py
+++ b/tests/unit/_modules/test_packagemanager.py
@@ -107,49 +107,57 @@ class TestZypper():
         ret = zypp._parse_xml('test')
         et_mock.fromstring.assert_called_once_with('test')
 
+    @pytest.mark.parametrize("refresh_return", [True, False])
+    @pytest.mark.parametrize("_parse_xml_return", [[{'name': 'ceph', 'arch': 'x86_64'}],
+                                                   [{'name': 'ceph-mds', 'arch': 'x86_64'}]])
     @mock.patch('srv.salt._modules.packagemanager.Zypper._refresh')
     @mock.patch('srv.salt._modules.packagemanager.log')
     @mock.patch('srv.salt._modules.packagemanager.Zypper._parse_xml')
     @mock.patch('srv.salt._modules.packagemanager.Popen')
-    def test_list_updates(self, po, parse_mock, log_mock, refresh_mock, zypp):
+    def test_list_updates(self, po, parse_mock, log_mock, refresh_mock, refresh_return, _parse_xml_return, zypp):
         """
         no filter
         """
-        inp =  [{'name': 'ceph', 'arch': 'x86_64'}]
         po.return_value.communicate.return_value = ("packages out", "error")
-        parse_mock.return_value = inp
+        parse_mock.return_value = _parse_xml_return
+        refresh_mock.return_value = refresh_return
         ret = zypp.list_updates()
-        assert ret == inp
+        assert ret == {'status': refresh_return, 'packages': _parse_xml_return}
 
+    @pytest.mark.parametrize("refresh_return", [True, False])
+    @pytest.mark.parametrize("_parse_xml_return", [[{'name': 'ceph', 'arch': 'x86_64'}],
+                                                   [{'name': 'ceph-mds', 'arch': 'x86_64'}]])
     @mock.patch('srv.salt._modules.packagemanager.Zypper._refresh')
     @mock.patch('srv.salt._modules.packagemanager.log')
     @mock.patch('srv.salt._modules.packagemanager.Zypper._parse_xml')
     @mock.patch('srv.salt._modules.packagemanager.Popen')
-    def test_list_updates_1(self, po, parse_mock, log_mock, refresh_mock, zypp):
+    def test_list_updates_1(self, po, parse_mock, log_mock, refresh_mock, refresh_return, _parse_xml_return, zypp):
         """
         with filter
         empty result
         """
-        inp =  [{'name': 'ceph', 'arch': 'x86_64'}]
         po.return_value.communicate.return_value = ("packages out", "error")
-        parse_mock.return_value = inp
+        parse_mock.return_value = _parse_xml_return
+        refresh_mock.return_value = refresh_return
         ret = zypp.list_updates(_filter=['no_match'])
-        assert ret == []
+        assert ret == {'status': refresh_return, 'packages': []}
 
+    @pytest.mark.parametrize("refresh_return", [True, False])
+    @pytest.mark.parametrize("_parse_xml_return", [[{'name': 'ceph', 'arch': 'x86_64'}, {'name': 'no_match', 'arch': 'x86_64'}]])
     @mock.patch('srv.salt._modules.packagemanager.Zypper._refresh')
     @mock.patch('srv.salt._modules.packagemanager.log')
     @mock.patch('srv.salt._modules.packagemanager.Zypper._parse_xml')
     @mock.patch('srv.salt._modules.packagemanager.Popen')
-    def test_list_updates_3(self, po, parse_mock, log_mock, refresh_mock, zypp):
+    def test_list_updates_3(self, po, parse_mock, log_mock, refresh_mock, refresh_return, _parse_xml_return, zypp):
         """
         with filter
         diff returns
         """
-        inp = [{'name': 'ceph', 'arch': 'x86_64'}, {'name': 'no-match', 'arch': 'x86_64'}]
         po.return_value.communicate.return_value = ("packages out", "error")
-        parse_mock.return_value = inp
+        parse_mock.return_value = _parse_xml_return
+        refresh_mock.return_value = refresh_return
         ret = zypp.list_updates(_filter=['ceph'])
-        assert ret == [{'name': 'ceph', 'arch': 'x86_64'}]
+        assert ret == {'status': refresh_return, 'packages': [{'name': 'ceph', 'arch': 'x86_64'}]}
 
 
     @mock.patch('srv.salt._modules.packagemanager.Popen')

--- a/tests/unit/runners/test_validate.py
+++ b/tests/unit/runners/test_validate.py
@@ -183,10 +183,35 @@ class TestValidation():
 
     @patch('salt.client.LocalClient', autospec=True)
     def test_ceph_updates(self, mock_localclient):
+        """
+        Refresh works for both minions
+        and there are new packages
+        """
         validate.__utils__ = {'deepsea_minions.show': lambda: '*'}
         validate.__utils__.update({'deepsea_minions.matches': lambda: ['node1', 'node2']})
-        fake_data = {'node1': [{'name': 'ceph'}],
-                     'node2': [{'name': 'ceph'}]}
+
+        fake_data = {'admin.ceph': {'packages': [{'arch': 'x86_64',
+                                                  'edition': '13.2.1.427+g6cd01d4dd2-1.10',
+                                                  'edition-old': '13.2.1.427+g6cd01d4dd2-1.8',
+                                                  'kind': 'package',
+                                                  'name': 'ceph'},
+                                                  {'arch': 'x86_64',
+                                                  'edition': '13.2.1.427+g6cd01d4dd2-1.10',
+                                                  'edition-old': '13.2.1.427+g6cd01d4dd2-1.8',
+                                                  'kind': 'package',
+                                                  'name': 'python3-cephfs'}],
+                                    'status': 'True'},
+                     'data1.ceph': {'packages': [{'arch': 'x86_64',
+                                                  'edition': '13.2.1.427+g6cd01d4dd2-1.10',
+                                                  'edition-old': '13.2.1.427+g6cd01d4dd2-1.8',
+                                                  'kind': 'package',
+                                                  'name': 'ceph'},
+                                                  {'arch': 'x86_64',
+                                                  'edition': '13.2.1.427+g6cd01d4dd2-1.10',
+                                                  'edition-old': '13.2.1.427+g6cd01d4dd2-1.8',
+                                                  'kind': 'package',
+                                                  'name': 'python3-cephfs'}],
+                                    'status': 'True'}}
 
         local = mock_localclient.return_value
         local.cmd.return_value = fake_data
@@ -197,11 +222,58 @@ class TestValidation():
         assert "On or more of your minions have updates pending that might cause ceph-daemons to restart. This might extend the duration of this Stage depending on your cluster size." in validator.warnings['ceph_updates'][0]
 
     @patch('salt.client.LocalClient', autospec=True)
-    def test_no_ceph_updates(self, mock_localclient):
+    def test_ceph_updates_1(self, mock_localclient):
+        """
+        Refresh fails for one of the minions
+        and there are new packages
+        """
         validate.__utils__ = {'deepsea_minions.show': lambda: '*'}
         validate.__utils__.update({'deepsea_minions.matches': lambda: ['node1', 'node2']})
-        fake_data = {'node1': [],
-                     'node2': []}
+
+        fake_data = {'admin.ceph': {'packages': [{'arch': 'x86_64',
+                                                  'edition': '13.2.1.427+g6cd01d4dd2-1.10',
+                                                  'edition-old': '13.2.1.427+g6cd01d4dd2-1.8',
+                                                  'kind': 'package',
+                                                  'name': 'ceph'},
+                                                  {'arch': 'x86_64',
+                                                  'edition': '13.2.1.427+g6cd01d4dd2-1.10',
+                                                  'edition-old': '13.2.1.427+g6cd01d4dd2-1.8',
+                                                  'kind': 'package',
+                                                  'name': 'python3-cephfs'}],
+                                    'status': False},
+                     'data1.ceph': {'packages': [{'arch': 'x86_64',
+                                                  'edition': '13.2.1.427+g6cd01d4dd2-1.10',
+                                                  'edition-old': '13.2.1.427+g6cd01d4dd2-1.8',
+                                                  'kind': 'package',
+                                                  'name': 'ceph'},
+                                                  {'arch': 'x86_64',
+                                                  'edition': '13.2.1.427+g6cd01d4dd2-1.10',
+                                                  'edition-old': '13.2.1.427+g6cd01d4dd2-1.8',
+                                                  'kind': 'package',
+                                                  'name': 'python3-cephfs'}],
+                                    'status': True}}
+
+        local = mock_localclient.return_value
+        local.cmd.return_value = fake_data
+        validator = validate.Validate("setup", search_pillar=True)
+        validator.ceph_updates()
+        assert len(validator.errors) == 0
+        assert len(validator.warnings) == 2
+        assert "On or more of your minions have updates pending that might cause ceph-daemons to restart. This might extend the duration of this Stage depending on your cluster size." in validator.warnings['ceph_updates'][0]
+        assert "Experienced trouble refreshing the repositories" in validator.warnings['refresh_repos'][0]
+
+    @patch('salt.client.LocalClient', autospec=True)
+    def test_no_ceph_updates(self, mock_localclient):
+        """
+        no updates
+        repos refresh works
+        """
+        validate.__utils__ = {'deepsea_minions.show': lambda: '*'}
+        validate.__utils__.update({'deepsea_minions.matches': lambda: ['node1', 'node2']})
+        fake_data = {'admin.ceph': {'packages': [],
+                                    'status': True},
+                     'data1.ceph': {'packages': [],
+                                    'status': True}}
 
         local = mock_localclient.return_value
         local.cmd.return_value = fake_data
@@ -211,12 +283,44 @@ class TestValidation():
         assert len(validator.warnings) == 0
 
     @patch('salt.client.LocalClient', autospec=True)
-    def test_salt_updates(self, mock_localclient):
+    def test_no_ceph_updates_1(self, mock_localclient):
+        """
+        no updates
+        repos refresh doesn't work for one node
+        """
         validate.__utils__ = {'deepsea_minions.show': lambda: '*'}
         validate.__utils__.update({'deepsea_minions.matches': lambda: ['node1', 'node2']})
-        fake_data = {'node1': [{'salt-minion': 'ceph'}],
-                     'node2': [{'salt-master': 'ceph'}]}
+        fake_data = {'admin.ceph': {'packages': [],
+                                    'status': False},
+                     'data1.ceph': {'packages': [],
+                                    'status': True}}
 
+        local = mock_localclient.return_value
+        local.cmd.return_value = fake_data
+        validator = validate.Validate("setup", search_pillar=True)
+        validator.ceph_updates()
+        assert len(validator.errors) == 0
+        assert len(validator.warnings) == 1
+        assert "Experienced trouble refreshing the repositories" in validator.warnings['refresh_repos'][0]
+
+    @patch('salt.client.LocalClient', autospec=True)
+    def test_salt_updates(self, mock_localclient):
+        """
+        updates
+        repo refresh works
+        """
+        validate.__utils__ = {'deepsea_minions.show': lambda: '*'}
+        validate.__utils__.update({'deepsea_minions.matches': lambda: ['node1', 'node2']})
+        fake_data = {'admin.ceph': {'packages': [{'arch': 'x86_64',
+                                                  'name': 'ceph'},
+                                                  {'arch': 'x86_64',
+                                                  'name': 'salt-minion'}],
+                                    'status': True},
+                     'data1.ceph': {'packages': [{'arch': 'x86_64',
+                                                  'name': 'ceph'},
+                                                  {'arch': 'x86_64',
+                                                  'name': 'salt-master'}],
+                                    'status': True}}
         local = mock_localclient.return_value
         local.cmd.return_value = fake_data
         validator = validate.Validate("setup", search_pillar=True)
@@ -226,11 +330,44 @@ class TestValidation():
         assert "You have a salt update pending" in validator.errors['salt_updates'][0]
 
     @patch('salt.client.LocalClient', autospec=True)
-    def test_no_salt_updates(self, mock_localclient):
+    def test_salt_updates_1(self, mock_localclient):
+        """
+        updates
+        repo refresh works on one node
+        """
         validate.__utils__ = {'deepsea_minions.show': lambda: '*'}
         validate.__utils__.update({'deepsea_minions.matches': lambda: ['node1', 'node2']})
-        fake_data = {'node1': [],
-                     'node2': []}
+        fake_data = {'admin.ceph': {'packages': [{'arch': 'x86_64',
+                                                  'name': 'ceph'},
+                                                  {'arch': 'x86_64',
+                                                  'name': 'salt-minion'}],
+                                    'status': False},
+                     'data1.ceph': {'packages': [{'arch': 'x86_64',
+                                                  'name': 'ceph'},
+                                                  {'arch': 'x86_64',
+                                                  'name': 'salt-master'}],
+                                    'status': True}}
+        local = mock_localclient.return_value
+        local.cmd.return_value = fake_data
+        validator = validate.Validate("setup", search_pillar=True)
+        validator.salt_updates()
+        assert len(validator.errors) == 1
+        assert len(validator.warnings) == 1
+        assert "You have a salt update pending" in validator.errors['salt_updates'][0]
+        assert "Experienced trouble refreshing repositories" in validator.warnings['refresh_repos'][0]
+
+    @patch('salt.client.LocalClient', autospec=True)
+    def test_no_salt_updates(self, mock_localclient):
+        """
+        updates present
+        refresh works
+        """
+        validate.__utils__ = {'deepsea_minions.show': lambda: '*'}
+        validate.__utils__.update({'deepsea_minions.matches': lambda: ['node1', 'node2']})
+        fake_data = {'admin.ceph': {'packages': [],
+                                    'status': True},
+                     'data1.ceph': {'packages': [],
+                                    'status': True}}
 
         local = mock_localclient.return_value
         local.cmd.return_value = fake_data
@@ -238,6 +375,27 @@ class TestValidation():
         validator.salt_updates()
         assert len(validator.errors) == 0
         assert len(validator.warnings) == 0
+
+    @patch('salt.client.LocalClient', autospec=True)
+    def test_no_salt_updates_1(self, mock_localclient):
+        """
+        updates present
+        refresh failed on one node
+        """
+        validate.__utils__ = {'deepsea_minions.show': lambda: '*'}
+        validate.__utils__.update({'deepsea_minions.matches': lambda: ['node1', 'node2']})
+        fake_data = {'admin.ceph': {'packages': [],
+                                    'status': False},
+                     'data1.ceph': {'packages': [],
+                                    'status': True}}
+
+        local = mock_localclient.return_value
+        local.cmd.return_value = fake_data
+        validator = validate.Validate("setup", search_pillar=True)
+        validator.salt_updates()
+        assert len(validator.errors) == 0
+        assert len(validator.warnings) == 1
+        assert "Experienced trouble refreshing repositories" in validator.warnings['refresh_repos'][0]
 
 
     @patch('salt.client.LocalClient', autospec=True)
@@ -458,7 +616,7 @@ class TestValidation():
         assert len(validator.passed) == 0
         validator.kernel()
         assert validator.passed['kernel_module'] == 'valid'
-    
+
 
     @patch('salt.client.LocalClient')
     def test_kernel_wrong(self, mock_localclient):


### PR DESCRIPTION
* add to setup(stage.0) validation
* notifies if there is a pending update
  with 'ceph' in its name.
* stops stage.0 when there is salt-master or salt-minion
  package in the queue and gives advise on how to proceed
* adds test

Signed-off-by: Joshua Schmid <jschmid@suse.de>

Fixes #1126

The checks add 3~seconds to the execution time respectively.

open questions:

1) Should the 'ceph-package' check also be included in stage.3 (adds ~3seconds)

2) I was _trying_ to use `mine.get` in the `validate.py` calls to reduce the invocation time
    for those checks. I had to find out that the mines lie quite often.. This might be something we want
    to look into a bit closer as we also rely on mines in the `replace.py` (where we do a complete `mine.flush` with a successive `mine.update` .. that's not ideal at best, imo.

3) How to handle the `salt has updates` for the CI? Do we force to update the base image? Should be build in a switch do disable this? (CI_MODE, ( we had this discussion in the past about another feature))


-----------------

**Checklist:**
- [x] Added unittests and or functional tests
~- [ ] Adapted documentation~
- [x] Referenced issues or internal bugtracker
- [ ] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
