### PR TITLE
[backport][SES5] Remove hardcoded nvme devices, support generic convention

### DIFF
--- a/srv/salt/_modules/osd.py
+++ b/srv/salt/_modules/osd.py
@@ -82,7 +82,7 @@ def pairs():
     with open('/proc/mounts') as mounts:
         for line in mounts:
             _partition, path = line.split()[:2]
-            if path in _paths:
+            if path in paths:
                 match = re.match(r'^(.+)\d+$', _partition)
                 device = match.group(1)
                 if device.endswith('p'):
@@ -1114,7 +1114,7 @@ class OSDCommands(object):
             partitions = sorted([ re.sub(r"{}p?".format(device), '', p) for p in pathnames ], key=int, reverse=True)
             # best strategy? remove key=int and do checks before conversion ourselves?
             log.debug("partitions: {}".format(partitions))
-            for partition in partitions:
+            for _partition in partitions:
                 log.debug("checking partition {} on device {}".format(partition, device))
                 # Not confusing at all - use digit for NVMe too
                 if self.is_partition(partition_type, device, _partition):
@@ -1412,7 +1412,7 @@ def split_partition(partition):
     if disk.endswith('p'):
         disk = disk[:-1]
         log.debug("Truncating p {}".format(disk))
-    return disk, m.group(2)
+    return disk, match.group(2)
     #return None, None
 
 class OSDRemove(object):

--- a/srv/salt/_modules/osd.py
+++ b/srv/salt/_modules/osd.py
@@ -81,11 +81,11 @@ def pairs():
     pairs = []
     with open('/proc/mounts') as mounts:
         for line in mounts:
-            partition, path = line.split()[:2]
-            if path in paths:
-                m = re.match(r'^(.+)\d+$', partition)
-                device = m.group(1)
-                if 'nvme' in device:
+            _partition, path = line.split()[:2]
+            if path in _paths:
+                match = re.match(r'^(.+)\d+$', _partition)
+                device = match.group(1)
+                if device.endswith('p'):
                     device = device[:-1]
                 pairs.append([ device, path ])
 
@@ -95,15 +95,15 @@ def part_pairs():
     """
     Return an array of partitions and paths
     """
-    paths = [ pathname for pathname in glob.glob("/var/lib/ceph/osd/*") ]
+    paths = [pathname for pathname in glob.glob("/var/lib/ceph/osd/*")]
     pairs = []
     with open('/proc/mounts') as mounts:
-	for line in mounts:
-	    partition, path = line.split()[:2]
-	    if path in paths:
-		m = re.match(r'^(.+)\d+$', partition)
-		part = m.group(0)
-		pairs.append([ part, path ])
+        for line in mounts:
+            partition, path = line.split()[:2]
+            if path in paths:
+                m = re.match(r'^(.+)\d+$', partition)
+                part = m.group(0)
+                pairs.append([ part, path])
     return pairs
 
 def _filter_devices(devices, **kwargs):
@@ -564,7 +564,10 @@ def restore_weight(id, **kwargs):
     return True
 
 def _find_paths(device):
-    if 'nvme' in device:
+    """
+    Return matching pathnames, special case devices ending with digits
+    """
+    if re.match(r'.*\d$', device):
         pathnames = glob.glob("{}p[0-9]*".format(device))
     else:
         pathnames = glob.glob("{}[0-9]*".format(device))
@@ -1114,11 +1117,11 @@ class OSDCommands(object):
             for partition in partitions:
                 log.debug("checking partition {} on device {}".format(partition, device))
                 # Not confusing at all - use digit for NVMe too
-                if self.is_partition(partition_type, device, partition):
-                    log.debug("found partition {} on device {}".format(partition, device))
-                    if 'nvme' in device and nvme_partition:
-                        partition = "p{}".format(partition)
-                    return partition
+                if self.is_partition(partition_type, device, _partition):
+                    log.debug("found partition {} on device {}".format(_partition, device))
+                    if re.match(r'.*\d$', device) and nvme_partition:
+                        _partition = "p{}".format(_partition)
+                    return _partition
         self.error = "Partition type {} not found on {}".format(partition_type, device)
         log.error(self.error)
         return 0
@@ -1226,7 +1229,7 @@ class OSDCommands(object):
         # fails if the device is already partitioned but the partitionnumber is not 1
         # should never be partitioned..
         if self.is_partitioned(self.osd.device):
-            if 'nvme' in self.osd.device:
+            if re.match(r'.*\d$', self.osd.device):
                 args += "{}p1".format(self.osd.device)
             else:
                 args += "{}1".format(self.osd.device)
@@ -1296,7 +1299,7 @@ class OSDCommands(object):
                 cmd = "/bin/true activated during prepare"
             else:
                 prefix = ''
-                if 'nvme' in self.osd.device:
+                if re.match(r'.*\d$', self.osd.device):
                     prefix = 'p'
                 cmd = "PYTHONWARNINGS=ignore ceph-disk -v activate --mark-init systemd --mount "
                 cmd += "{}{}{}".format(self.osd.device, prefix, self.osd_partition())
@@ -1404,9 +1407,9 @@ def split_partition(partition):
     part = readlink(partition)
     #if os.path.exists(part):
     log.debug("splitting partition {}".format(part))
-    m = re.match("(.+\D)(\d+)", part)
-    disk = m.group(1)
-    if 'nvme' in disk:
+    match = re.match(r"(.+\D)(\d+)", part)
+    disk = match.group(1)
+    if disk.endswith('p'):
         disk = disk[:-1]
         log.debug("Truncating p {}".format(disk))
     return disk, m.group(2)
@@ -2175,7 +2178,7 @@ def _fsck(device, partition):
     on some broken filesystems.  Not good for automation.
     """
     prefix = ''
-    if 'nvme' in device:
+    if re.match(r'.*\d$', device):
         prefix = 'p'
     #cmd = "/sbin/fsck -t xfs -n {}{}{}".format(device, prefix, partition)
     cmd = "/usr/sbin/xfs_admin -u {}{}{}".format(device, prefix, partition)

--- a/tests/unit/_modules/test_osd.py
+++ b/tests/unit/_modules/test_osd.py
@@ -1266,7 +1266,17 @@ class TestOSDPartitions():
         assert type(ret) is int
 
     @mock.patch('srv.salt._modules.osd.glob')
-    def test__last_partition_no_pathnames(self, glob_mock, osdp_o):
+    def test__last_partition_digits(self, glob_mock):
+        glob_mock.glob.return_value = ['/dev/sdx11']
+        osd_config = OSDConfig()
+        test_module = helper_specs(module=DEFAULT_MODULE)()
+        obj = test_module.OSDPartitions(osd_config)
+        ret = obj._last_partition(osd_config.device)
+        glob_mock.glob.assert_called_with('/dev/sdx[0-9]*')
+        assert ret == 11
+
+    @mock.patch('srv.salt._modules.osd.glob')
+    def test__last_partition_no_pathnames(self, glob_mock):
         glob_mock.glob.return_value = []
         osd_config = OSDConfig()
         obj = osdp_o(osd_config)

--- a/tests/unit/_modules/test_osd.py
+++ b/tests/unit/_modules/test_osd.py
@@ -1266,11 +1266,10 @@ class TestOSDPartitions():
         assert type(ret) is int
 
     @mock.patch('srv.salt._modules.osd.glob')
-    def test__last_partition_digits(self, glob_mock):
+    def test__last_partition_digits(self, glob_mock, osdp_o):
         glob_mock.glob.return_value = ['/dev/sdx11']
         osd_config = OSDConfig()
-        test_module = helper_specs(module=DEFAULT_MODULE)()
-        obj = test_module.OSDPartitions(osd_config)
+        obj = osdp_o(osd_config)
         ret = obj._last_partition(osd_config.device)
         glob_mock.glob.assert_called_with('/dev/sdx[0-9]*')
         assert ret == 11


### PR DESCRIPTION
backport of #1424 

Bcache and NVMe devices follow the same device naming convention.
Remove the hardcoded strings and check whether the device ends with a
digit to add the 'p' partition delimiter. Likewise, truncate the 'p'
after separating the partitions when necessary.

Signed-off-by: Eric Jackson ejackson@suse.com
bnc#1107925

-----------------

**Checklist:**
- [x] Added unittests and or functional tests
- [x] Referenced issues or internal bugtracker
- [ ] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
