### PR TITLE
Makefile: drop redundant PIPCMD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,6 @@ VERSION ?= $(shell (git describe 2>/dev/null || echo '0.0.0') | sed -e 's/^v//' 
 DEEPSEA_DEPS=salt-api
 PYTHON_DEPS=python3-setuptools python3-click python3-tox
 PYTHON=python3
-PIPCMD=""
 
 OS=$(shell source /etc/os-release 2>/dev/null ; echo $$ID)
 ifeq ($(OS), opensuse)
@@ -966,7 +965,6 @@ install-deps:
 	# Using '|| true' to suppress failure (packages already installed, etc)
 	$(PKG_INSTALL) $(DEEPSEA_DEPS) || true
 	$(PKG_INSTALL) $(PYTHON_DEPS) || true
-	$(PIPCMD) >/dev/null 2>&1 || true
 
 install: pyc install-deps copy-files
 	sed -i '/^sharedsecret: /s!{{ shared_secret }}!'`cat /proc/sys/kernel/random/uuid`'!' $(DESTDIR)/etc/salt/master.d/sharedsecret.conf


### PR DESCRIPTION
This does nothing by default, and there's no documentation how to set it.

It was introduced by https://github.com/SUSE/DeepSea/pull/1173

-----------------

**Checklist:**
- [ ] Added unittests and or functional tests
- [ ] Adapted documentation
- [ ] Referenced issues or internal bugtracker
- [ ] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
