### PR TITLE
Initial ceph-volume support

### DIFF
--- a/srv/salt/_modules/disk_part.py
+++ b/srv/salt/_modules/disk_part.py
@@ -1,0 +1,85 @@
+# -*- coding: utf-8 -*-
+
+"""
+disk management
+"""
+
+from __future__ import absolute_import
+import json
+import logging
+
+log = logging.getLogger(__name__)
+
+
+def configured():
+    """
+    Return the osds from the ceph namespace or original namespace, optionally
+    filtered by attributes.
+    """
+    _devices = []
+    if 'ceph' in __pillar__ and 'storage' in __pillar__['ceph'] and \
+       'osds' in __pillar__['ceph']['storage']:
+        _devices = __pillar__['ceph']['storage']['osds']
+    log.debug("devices: {}".format(_devices))
+
+    return _devices
+
+
+def create():
+    """
+    Create a single partition on OSD drives for LVM deployment
+    """
+    for device in configured():
+        _create_part(device)
+    return "success"
+
+
+def _create_part(device):
+    """
+    Use sgdisk to create a single partition
+    """
+    _rc, _out, _err = __salt__['helper.run'](['sgdisk', '-og', device])
+    _rc, start, _err = __salt__['helper.run'](['sgdisk', '-F', device])
+    _rc, end, _err = __salt__['helper.run'](['sgdisk', '-E', device])
+    _rc, _out, _err = __salt__['helper.run'](['sgdisk',
+                                              '-n',
+                                              '1:{}:{}'.format(start, end),
+                                              device])
+    return '{}1'.format(device)
+
+
+def remove():
+    """
+    remove all lvm related stuctures and parts from OSD drives
+    """
+    _remove_lvs_and_vgs()
+    _remove_pvs()
+    _zap_parts()
+
+
+def _remove_lvs_and_vgs():
+    """
+    remove volume groups and logical volumes
+    """
+    _rc, out, _err = __salt__['helper.run'](['lvs', '--reportformat', 'json'])
+    lvs = json.loads(out)
+    vg_names = ['{}'.format(lv['vg_name']) for lv in lvs['report'][0]['lv']]
+    _rc, _out, _err = __salt__['helper.run'](['vgremove', '-y'] + vg_names)
+
+
+def _remove_pvs():
+    """
+    remove physical volume
+    """
+    _rc, out, _err = __salt__['helper.run'](['pvs', '--reportformat', 'json'])
+    pvs = json.loads(out)
+    pv_names = ['{}'.format(pv['pv_name']) for pv in pvs['report'][0]['pv']]
+    _rc, _out, _err = __salt__['helper.run'](['pvremove', '-y'] + pv_names)
+
+
+def _zap_parts():
+    """
+    remove partition
+    """
+    for device in configured():
+        _rc, _out, _err = __salt__['helper.run'](['sgdisk', '-Z', device])

--- a/srv/salt/_modules/osd.py
+++ b/srv/salt/_modules/osd.py
@@ -2079,6 +2079,25 @@ def is_partitioned(device):
     return osdc.is_partitioned(device)
 
 
+def deploy_lvm():
+    """
+    Dummy implementation to deplioy a ceph-volume OSD on an existing lv
+    """
+    for device in configured():
+        _rc, _out, _err = __salt__['helper.run'](
+            ['ceph-volume',
+             'lvm',
+             'prepare',
+             '--bluestore',
+             '--data',
+             '{}1'.format(device)]
+        )
+    _rc, _out, _err = __salt__['helper.run'](['ceph-volume',
+                                              'lvm',
+                                              'activate',
+                                              '--all'])
+
+
 def deploy():
     """
     Partition, prepare and activate an OSD.

--- a/srv/salt/ceph/osd/default.sls
+++ b/srv/salt/ceph/osd/default.sls
@@ -2,7 +2,12 @@
 include:
   - .keyring
 
+create parts:
+  module.run:
+    - name: disk_part.create
+
+
 deploy OSDs:
   module.run:
-    - name: osd.deploy
+    - name: osd.deploy_lvm
 


### PR DESCRIPTION
This adds basic ceph-volume support. Only standalone OSDs can be deployed, no removal is implemented yet. This should enable dev clusters and CI workflows for now.

This is not intended for production work and thing _will_ change!
