### PR TITLE
Add doc for auto-deployment via terraform

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ For those interested in learning about some of the uses of Salt in DeepSea, see 
 ## Usage
 You need at least a minimum of 4 nodes to be able to test and use DeepSea properly.
 
+For automating the deployment of ceph and Deepsea, you can use: https://github.com/MalloZup/ceph-open-terrarium/.
+You will be able to easy create, deploy VMs and disks in configurable manner, and pre-configure/provisioning your vms for running `Deepsea`.
+
+
 To be able to use less than 4 nodes during the deployment stages (e.g. in a
 development/testing environment), you could set the option `DEV_ENV=true` as an
 environment variable or globally as a pillar variable in


### PR DESCRIPTION
## you can see the markdown here:
https://github.com/MalloZup/DeepSea/tree/deploy-doc#usage

# Description:

Reference `ceph-open-terrarium`

Im also open to move the github Project to organisation like `suse` or `opensuse` repos, or even `ceph` upstream if possible. 

Feel free to ask/suggest things and thank you in advance :+1: :rocket: :rabbit2: :purple_heart: 
( i am also adapting the doc in opensuse) 
