### PR TITLE
Makefile: Check for correct ID in /etc/os-release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ PYTHON_DEPS=python3-setuptools python3-click python3-tox
 PYTHON=python3
 
 OS=$(shell source /etc/os-release 2>/dev/null ; echo $$ID)
-ifeq ($(OS), opensuse)
+ifeq ($(OS), opensuse-leap)
 USER=salt
 GROUP=salt
 PKG_INSTALL=zypper -n install


### PR DESCRIPTION
Without this patch, is not possible to install DeepSea using openSuse
Leap 15.0, since the /etc/os-release ID field is "opensuse-leap" [1],
so the Makefile was checking for "opensuse", "opensuse-tumbleweed" and
"sles". Now zypper is able to install sal-api and other necessary
packages since Leap is detected and the PKG_INSTALL variable is
populated.

[1]: https://en.opensuse.org/SDB:Find_openSUSE_version

Signed-off-by: Marcos Paulo de Souza <marcos.souza.org@gmail.com>

Fixes #


Description:


-----------------

**Checklist:**
- [ ] Added unittests and or functional tests
- [ ] Adapted documentation
- [ ] Referenced issues or internal bugtracker
- [ ] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
