### PR TITLE
lrbd service restart instead of reload on `ui_iscsi.deploy`

### DIFF
--- a/srv/modules/runners/ui_iscsi.py
+++ b/srv/modules/runners/ui_iscsi.py
@@ -358,7 +358,7 @@ def _deploy_in_minions(minions):
         target = 'L@{}'.format(','.join(minions))
     else:
         target = 'I@roles:igw'
-    state_res = local.cmd(target, 'state.apply', ['ceph.igw.restart'], expr_form="compound")
+    state_res = local.cmd(target, 'state.apply', ['ceph.igw.restart.force'], expr_form="compound")
     for minion, states in state_res.items():
         result['minions'][minion] = _check_state_result(states)
         if not result['minions'][minion]:


### PR DESCRIPTION
`ui_iscsi.deploy` should apply state `ceph.igw.restart.force` instead of `ceph.igw.restart` to perform a service `restart` instead of `reload`.

Signed-off-by: Ricardo Marques <rimarques@suse.com>
