### PR TITLE
Correct conditional check for custom configurations

### DIFF
--- a/srv/salt/ceph/stage/ganesha/core/default.sls
+++ b/srv/salt/ceph/stage/ganesha/core/default.sls
@@ -1,7 +1,7 @@
 
 {% set master = salt['master.minion']() %}
 
-{% if salt.saltutil.runner('select.minions', cluster='ceph', roles='ganesha') or salt.saltutil.runner('select.minions', cluster='ceph', roles='ganesha_configurations') %}
+{% if salt.saltutil.runner('select.minions', cluster='ceph', roles='ganesha') or salt.saltutil.runner('select.minions', cluster='ceph', ganesha_configurations='*') %}
 
 ganesha auth:
   salt.state:

--- a/srv/salt/ceph/stage/radosgw/core/default.sls
+++ b/srv/salt/ceph/stage/radosgw/core/default.sls
@@ -1,7 +1,7 @@
 
 {% set master = salt['master.minion']() %}
 
-{% if salt.saltutil.runner('select.minions', cluster='ceph', roles='rgw') or salt.saltutil.runner('select.minions', cluster='ceph', roles='rgw_configurations') %}
+{% if salt.saltutil.runner('select.minions', cluster='ceph', roles='rgw') or salt.saltutil.runner('select.minions', cluster='ceph', rgw_configurations='*') %}
 
 rgw auth:
   salt.state:


### PR DESCRIPTION
Configurations with only custom configurations never executed.   The check now queries the correct variable.

Signed-off-by: Eric Jackson <ejackson@suse.com>
bsc#1109973

-----------------

**Checklist:**
- [ ] Added unittests and or functional tests
- [ ] Adapted documentation
- [ ] Referenced issues or internal bugtracker
- [ ] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
