### PR TITLE
lrbd service restart instead of reload on `ui_iscsi.deploy`

### DIFF
--- a/srv/modules/runners/ui_iscsi.py
+++ b/srv/modules/runners/ui_iscsi.py
@@ -372,7 +372,7 @@ def _deploy_in_minions(minions):
         target = 'L@{}'.format(','.join(minions))
     else:
         target = 'I@roles:igw'
-    state_res = local.cmd(target, 'state.apply', ['ceph.igw.restart'], tgt_type="compound")
+    state_res = local.cmd(target, 'state.apply', ['ceph.igw.restart.force'], tgt_type="compound")
     for minion, states in state_res.items():
         result['minions'][minion] = _check_state_result(states)
         if not result['minions'][minion]:


### PR DESCRIPTION
Signed-off-by: Ricardo Marques <rimarques@suse.com>
(cherry picked from commit 6af276d03ccd87e946c0c6ce8128f00d5985621b)

Conflicts:
	srv/modules/runners/ui_iscsi.py
- master uses "tgt_type" instead of "expr_form"

Forward port of #1442