### PR TITLE
Pin the linter to a pre-change version

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -34,4 +34,4 @@ commands = pylint --rcfile=.pylintrc  srv/
 deps =
     {[base]deps}
     pylint<2.0
-    saltpylint
+    saltpylint<2018.10.13


### PR DESCRIPTION
Signed-off-by: Joshua Schmid <jschmid@suse.de>

The linter fails since ~Nov 1st due to a release of SaltPyLint from 2018.10.12 to 2018.10.31.

This commit pins the version to the release we tailored our style-guide to.
