### PR TITLE
Makefile: Fix two missing $DESTDIRs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -970,8 +970,8 @@ install-deps:
 install: pyc install-deps copy-files
 	sed -i '/^sharedsecret: /s!{{ shared_secret }}!'`cat /proc/sys/kernel/random/uuid`'!' $(DESTDIR)/etc/salt/master.d/sharedsecret.conf
 	chown $(USER):$(GROUP) $(DESTDIR)/etc/salt/master.d/*
-	echo "deepsea_minions: '*'" > /srv/pillar/ceph/deepsea_minions.sls
-	chown -R $(USER) /srv/pillar/ceph
+	echo "deepsea_minions: '*'" > $(DESTDIR)/srv/pillar/ceph/deepsea_minions.sls
+	chown -R $(USER) $(DESTDIR)/srv/pillar/ceph
 	# Use '|| true' to suppress some error output in corner cases
 	systemctl restart salt-master
 	systemctl restart salt-api


### PR DESCRIPTION
Found while verifying https://github.com/SUSE/DeepSea/pull/1450.
That these $(DESTDIR) pieces were missing wouldn't actually cause
a problem for normal RPM builds (the spec file doesn't invoke
`make install` anyway, so won't hit these lines); it's only a
problem for weirdos like me ;-)

Signed-off-by: Tim Serong <tserong@suse.com>