### PR TITLE
Check configs for deprecated k:v pairs and report

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -259,6 +259,7 @@ copy-files:
 	install -m 644 srv/salt/ceph/configuration/files/rgw.conf $(DESTDIR)/srv/salt/ceph/configuration/files/
 	install -m 644 srv/salt/ceph/configuration/files/rgw-ssl.conf $(DESTDIR)/srv/salt/ceph/configuration/files/
 	install -m 644 srv/salt/ceph/configuration/files/ceph.conf.import $(DESTDIR)/srv/salt/ceph/configuration/files/
+	install -m 644 srv/salt/ceph/configuration/files/deprecated_map.yml $(DESTDIR)/srv/salt/ceph/configuration/files/
 	-chown salt:salt $(DESTDIR)/srv/salt/ceph/configuration/files/ceph.conf.import || true
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/configuration/files/ceph.conf.d
 	install -m 644 srv/salt/ceph/configuration/files/ceph.conf.d/README $(DESTDIR)/srv/salt/ceph/configuration/files/ceph.conf.d

--- a/deepsea.spec.in
+++ b/deepsea.spec.in
@@ -484,6 +484,7 @@ systemctl try-restart salt-api > /dev/null 2>&1 || :
 %config /srv/salt/ceph/configuration/create/*.sls
 %config /srv/salt/ceph/configuration/files/*.conf
 %config /srv/salt/ceph/configuration/files/*.j2
+%config /srv/salt/ceph/configuration/files/deprecated_map.yml
 %config(noreplace) %attr(-, salt, salt) /srv/salt/ceph/configuration/files/ceph.conf.import
 /srv/salt/ceph/configuration/files/ceph.conf.d/README
 %config /srv/salt/ceph/ganesha/*.sls

--- a/srv/modules/runners/validate.py
+++ b/srv/modules/runners/validate.py
@@ -32,6 +32,7 @@ import salt.client
 import salt.utils
 import salt.utils.minions
 import salt.utils.error
+from configobj import ConfigObj
 # pylint: disable=relative-import
 
 
@@ -1043,8 +1044,36 @@ class Validate(Preparation):
             self.passed['ceph_updates'] = "valid"
         else:
             # pylint: disable=line-too-long
-            msg = ("On or more of your minions have updates pending that might cause ceph-daemons to restart. This might extend the duration of this Stage depending on your cluster size. If you want to find out which packages will be updated, you can get the full list with salt -I 'cluster:ceph' packagemanager.list_ceph_updates")
+            msg = ("On or more of your minions have updates pending "
+                   "that might cause ceph-daemons to restart. "
+                   "This might extend the duration of this "
+                   "Stage depending on your cluster size. "
+                   "If you want to find out which packages will be "
+                   "updated, you can get the full list with "
+                   "salt -I 'cluster:ceph' packagemanager.list_ceph_updates")
             self.warnings['ceph_updates'] = [msg]
+
+    def config_check(self):
+        """
+        Verify if config does not contain any deprecated config k:v pairs
+        """
+        issue_map = ConfigCheck().run()
+        for conf_obj in issue_map:
+            key = conf_obj.key
+            values = conf_obj.values
+            filename = conf_obj.filename
+            release = conf_obj.release
+            if not values:
+                msg = ("Key '{}' is deprecated since {release}. "
+                       "Please remove it from "
+                       "your config".format(key, release=release))
+            else:
+                values = '/'.join(values)
+                msg = ("Key '{}' with value(s) {} was "
+                       "found (deprecated since {}). "
+                       "Please adapt your config".format(key, values, release))
+
+            self.errors["{}::{}".format(filename, key)] = msg
 
     def report(self):
         """
@@ -1052,6 +1081,149 @@ class Validate(Preparation):
         """
         self.printer.add(self.name, self.skipped, self.passed, self.errors, self.warnings)
         self.printer.print_result()
+
+
+class ConfigCheck(object):
+    """Class to detect deprecated config values in files.
+
+    Attributes:
+        base_path (str): Base path
+        map_file (str): Map file path
+        conf_path (str): Conf file path
+        suffix (str): Suffix for config files
+        files (list): List of files from glob
+        map (dict): Map of deprecated k:v
+        issues (list): List of found incidents
+    """
+    def __init__(self):
+
+        self.base_path = '/srv/salt/ceph/configuration/files'
+        self.map_file = '{}/deprecated_map.yml'.format(self.base_path)
+        self.conf_path = '{}/ceph.conf.d'.format(self.base_path)
+        self.suffix = '.conf'
+        self.files = glob.glob("{path}/*{suffix}".format(path=self.conf_path,
+                                                         suffix=self.suffix))
+        self.imported_ceph_conf = ("/srv/salt/ceph/configuration"
+                                   "/files/ceph.conf.import")
+        if os.path.isfile(self.imported_ceph_conf):
+            self.files.append(self.imported_ceph_conf)
+        self.map = self.load_map()
+        self.issues = []
+
+    def load_map(self):
+        """
+        Loads k:v map from disk
+
+        Returns:
+            YAML map
+        Raises:
+            YAMLError
+        """
+        with open(self.map_file, 'r') as _fd:
+            try:
+                return yaml.load(_fd)
+            except yaml.YAMLError:
+                log.error('Could not read {}'.format(self.map_file))
+
+    def extract_k_v(self, filename):
+        """ Reads lines from an open file and returns a generator
+        Args:
+            fn (str): filename
+        Yields:
+            str: line from file
+        """
+        config = ConfigObj(filename)
+        for key, value in config.items():
+            yield key, value
+
+    def compare_k_v_to_map(self, key, value):
+        """ Compares k:v against a map of k:v that are know to be deprecated
+        Args:
+            k (str): key from config
+            v (str): value from config
+        Returns:
+            DeprecatedConf: instance of obj or None
+        """
+        obj = None
+        for release, kv_map in self.map.items():
+            if key not in kv_map:
+                continue
+            if isinstance(kv_map[key], list):
+                obj = DeprecatedConf(key=key,
+                                     release=release)
+                for depr_val in kv_map[key]:
+                    if value == depr_val:
+                        obj.add_value(depr_val)
+            if isinstance(kv_map[key], str):
+                if kv_map[key] == 'any':
+                    obj = DeprecatedConf(key=key,
+                                         release=release,
+                                         values=[])
+                if kv_map[key] == value:
+                    obj = DeprecatedConf(key=key,
+                                         release=release,
+                                         values=[value])
+        return obj
+
+    def normalize_config_key(self, key):
+        """
+        In the ceph.conf underscores doesn't matter:
+
+        a_key = 1
+
+        is the same as
+
+        a key = 1
+
+        Normalize it by replacing all underscores with spaces
+        """
+        return key.replace('_', ' ')
+
+    def run(self):
+        """
+        Returns:
+            list: contains objects of DeprecatedConf
+        """
+        for filename in self.files:
+            for key, value in self.extract_k_v(filename):
+                conf_object = self.compare_k_v_to_map(
+                    self.normalize_config_key(key), value)
+                if not conf_object:
+                    continue
+                conf_object.set_filename(filename)
+                self.issues.append(conf_object)
+        return self.issues
+
+
+class DeprecatedConf(object):
+    """Simple class to store and access information conveniently.
+
+    Attributes:
+        filename (str): Filename the k:v is associated with
+        release (str): Release the k:v is deprecated in
+        key (str): Name of the key
+        value (list): List of found deprecated values
+    """
+
+    def __init__(self, **kwargs):
+        self.filename = kwargs.get('filename', None)
+        self.release = kwargs.get('release', None)
+        self.key = kwargs.get('key', None)
+        self.values = kwargs.get('values', [])
+
+    def add_value(self, value):
+        """ Adds value to values attribute
+        Args:
+            value (str): Deprecated config value
+        """
+        self.values.append(value)
+
+    def set_filename(self, filename):
+        """ Sets filename
+        Args:
+            fn (str): Filename the object is associated with
+        """
+        self.filename = filename
 
 
 def help_():
@@ -1131,6 +1303,28 @@ def discovery(cluster=None, printer=None, **kwargs):
         valid.profiles_populated()
     valid.report()
 
+    if valid.errors:
+        return False
+
+    return True
+
+
+def config_check(cluster=None, printer=None, **kwargs):
+    """
+    Config Check user facing call
+    """
+    if not cluster:
+        usage(func='pillar')
+        exit(1)
+
+    # Restrict search to this cluster
+    search = "I@cluster:{}".format(cluster)
+
+    printer = get_printer(**kwargs)
+    valid = Validate(cluster, search_pillar=True, search_grains=True,
+                     printer=printer, search=search)
+    valid.config_check()
+    valid.report()
     if valid.errors:
         return False
 

--- a/srv/salt/ceph/configuration/files/deprecated_map.yml
+++ b/srv/salt/ceph/configuration/files/deprecated_map.yml
@@ -1,0 +1,37 @@
+# This file maintains data about deprecated config values
+# There are several options to define deprecated keys and values
+# First is to form a yaml dict that defines a single know to be
+# deprecated value for a known key
+#
+# named_release_a:
+#   deprecated_config_key: deprecated_config_value
+#
+# You can also define a list of deprecated values for that key
+#
+# named_release_b:
+#   deprecated_config_key:
+#     - deprecated_config_value_a
+#     - deprecated_config_value_b
+#     - deprecated_config_value_c
+#
+# If a key is deprecated alltogether assign a value of 'any'
+#
+# named_release_a:
+#   deprecated_config_key: any
+#
+# This list is maintained by the deepsea team but can be adapted to
+# manually if needed
+
+
+bobtail:
+    paxos max join drift: any
+    mock tick internal: any
+
+cuttlefish:
+    filestore flusher max fds: any
+    filestore sync flush: any
+    filestore fsync flushes journal data: any
+    filestore journal trailing: any
+
+dumpling:
+    rgw cluster root pool: any


### PR DESCRIPTION
This is part of the pre-upgrade validations.
 
Looks like this when executed.

```shell
admin:/deepsea # salt-run validate.config_check cluster=ceph
/srv/salt/ceph/configuration/files/ceph.conf.d/mon.conf::mock tick internal: Key 'mock tick internal' is deprecated since bobtail. Please remove it from your config
False
```

It's not yet 'activated'  in the sense of being part of one of the existing validations (pillar, setup etc..)

Addresses #1008 

The [file](https://github.com/SUSE/DeepSea/pull/1460/files#diff-109c03c6ddf40b08362f7fca3a1651b1) that maintains the map of deprecated k-v is taken from the official ceph documentation. If anyone has a more accurate source, please let me know

Signed-off-by: Joshua Schmid <jschmid@suse.de>


-----------------

**Checklist:**
- [x] Added unittests and or functional tests
- [x] Adapted documentation
- [x] Referenced issues or internal bugtracker
- [x] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
