### PR TITLE
Install python3-prometheus-client and make osd.py be compatible with Nautilus

### DIFF
--- a/srv/salt/_modules/osd.py
+++ b/srv/salt/_modules/osd.py
@@ -432,7 +432,7 @@ class CephPGs(object):
         cmd = json.dumps({"prefix": "pg stat", "format": "json"})
         _, output, _ = self.cluster.mon_command(cmd, b'', timeout=6)
         # log.debug(json.dumps((json.loads(output)['nodes']), indent=4))
-        return json.loads(output)['num_pg_by_state']
+        return json.loads(output)['pg_summary']['num_pg_by_state']
 
 
 def _settings(**kwargs):

--- a/srv/salt/ceph/monitoring/prometheus/exporters/ceph_rgw_exporter/default-install.sls
+++ b/srv/salt/ceph/monitoring/prometheus/exporters/ceph_rgw_exporter/default-install.sls
@@ -1,5 +1,5 @@
 install_package:
   pkg.installed:
-    - name: python-prometheus-client
+    - name: python3-prometheus-client
     - refresh: True
 

--- a/srv/salt/ceph/packages/remove/default.sls
+++ b/srv/salt/ceph/packages/remove/default.sls
@@ -35,6 +35,7 @@ obsolete packages:
       - python-execnet
       - python-gevent
       - python-greenlet
+      - python-prometheus-client
       - python-psycogreen
       - python-pushy
       - python-python-editor

--- a/srv/salt/ceph/rescind/rgw/monitoring/default.sls
+++ b/srv/salt/ceph/rescind/rgw/monitoring/default.sls
@@ -8,7 +8,7 @@ remove_rgw_exporter:
       - /var/lib/prometheus/node-exporter/ceph_rgw.py
       - /var/lib/prometheus/node-exporter/ceph_rgw.prom
 
-{% if 'python-prometheus-client' in salt['pkg.list_pkgs']() %}
+{% if 'python3-prometheus-client' in salt['pkg.list_pkgs']() %}
 
 uninstall_package:
   pkg.removed:


### PR DESCRIPTION
In openSUSE and SLE, packages starting with "python-..." are Python 2.
Since DeepSea is all on Python 3 now, we don't want to install any
packages starting with "python-...".

Also, without this patch Stage 4 fails on openSUSE Leap 15.0. On SLE-15, Stage 4 works even without the patch (not sure why).

Fixes: https://github.com/SUSE/DeepSea/issues/1463

-----------------

**Checklist:**
- [x] Referenced issues or internal bugtracker
- [ ] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
