### PR TITLE
Consider iptables not installed as passing

### DIFF
--- a/tests/unit/runners/test_ready.py
+++ b/tests/unit/runners/test_ready.py
@@ -9,7 +9,7 @@ class TestChecks():
 
     @patch('salt.client.LocalClient', autospec=True)
     def test_firewall(self, localclient):
-        result = { 'minion': "-P INPUT ACCEPT\n-P FORWARD ACCEPT\n-P OUTPUT ACCEPT"}
+        result = { 'minion': { 'retcode': 0, 'stdout': "-P INPUT ACCEPT\n-P FORWARD ACCEPT\n-P OUTPUT ACCEPT"}}
         local = localclient.return_value
         local.cmd.return_value = result
 
@@ -18,8 +18,18 @@ class TestChecks():
         assert check.passed['firewall'] == 'disabled'
 
     @patch('salt.client.LocalClient', autospec=True)
+    def test_firewall_not_installed(self, localclient):
+         result = { 'minion': { 'retcode': 127, 'stdout': "/bin/sh: /usr/sbin/iptables2: No such file or directory"}}
+         local = localclient.return_value
+         local.cmd.return_value = result
+
+         check = ready.Checks("I@cluster:ceph")
+         check.firewall()
+         assert check.passed['firewall'] == 'not installed'
+
+    @patch('salt.client.LocalClient', autospec=True)
     def test_firewall_with_chains(self, localclient):
-        result = { 'minion': "-P INPUT ACCEPT\n-P FORWARD ACCEPT\n-P OUTPUT ACCEPT\n-N neutron-filter-top\n-N neutron-openvswi-FORWARD"}
+        result = { 'minion': { 'retcode': 0, 'stdout': "-P INPUT ACCEPT\n-P FORWARD ACCEPT\n-P OUTPUT ACCEPT\n-N neutron-filter-top\n-N neutron-openvswi-FORWARD"}}
         local = localclient.return_value
         local.cmd.return_value = result
 
@@ -29,7 +39,7 @@ class TestChecks():
 
     @patch('salt.client.LocalClient', autospec=True)
     def test_firewall_issues_warning(self, localclient):
-        result = { 'minion': "-P INPUT DROP\n-P FORWARD DROP\n-P OUTPUT ACCEPT\n-N forward_ext\n-N input_ext\n-N reject_func"}
+        result = { 'minion': { 'retcode': 0, 'stdout': "-P INPUT DROP\n-P FORWARD DROP\n-P OUTPUT ACCEPT\n-N forward_ext\n-N input_ext\n-N reject_func"}}
         local = localclient.return_value
         local.cmd.return_value = result
 


### PR DESCRIPTION
The passing message will be "not installed" only if all minions do not
have iptables installed.  Otherwise, the original behavior takes
precedent.

Signed-off-by: Eric Jackson <ejackson@suse.com>
bsc#1115990

-----------------

**Checklist:**
- [ ] Added unittests and or functional tests
- [ ] Adapted documentation
- [ ] Referenced issues or internal bugtracker
- [ ] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
