### PR TITLE
[SES5] Add rebuild orchestration, obliterate state

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -391,6 +391,13 @@ copy-files:
 	install -m 644 srv/salt/ceph/noout/set/*.sls $(DESTDIR)/srv/salt/ceph/noout/set
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/noout/unset
 	install -m 644 srv/salt/ceph/noout/unset/*.sls $(DESTDIR)/srv/salt/ceph/noout/unset
+	# state files - obliterate
+	install -d -m 755 $(DESTDIR)/srv/salt/ceph/obliterate
+	install -m 644 srv/salt/ceph/obliterate/*.sls $(DESTDIR)/srv/salt/ceph/obliterate/
+	install -d -m 755 $(DESTDIR)/srv/salt/ceph/obliterate/lock
+	install -m 644 srv/salt/ceph/obliterate/lock/*.sls $(DESTDIR)/srv/salt/ceph/obliterate/lock
+	install -d -m 755 $(DESTDIR)/srv/salt/ceph/obliterate/unlock
+	install -m 644 srv/salt/ceph/obliterate/unlock/*.sls $(DESTDIR)/srv/salt/ceph/obliterate/unlock
 	# state files - openattic
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/openattic
 	install -m 644 srv/salt/ceph/openattic/*.sls $(DESTDIR)/srv/salt/ceph/openattic/
@@ -496,6 +503,9 @@ copy-files:
 	# state files - reactor
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/reactor
 	install -m 644 srv/salt/ceph/reactor/*.sls $(DESTDIR)/srv/salt/ceph/reactor/
+	# state files - rebuild
+	install -d -m 755 $(DESTDIR)/srv/salt/ceph/rebuild
+	install -m 644 srv/salt/ceph/rebuild/*.sls $(DESTDIR)/srv/salt/ceph/rebuild/
 	# state files - refresh
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/refresh
 	install -m 644 srv/salt/ceph/refresh/*.sls $(DESTDIR)/srv/salt/ceph/refresh/

--- a/deepsea.spec.in
+++ b/deepsea.spec.in
@@ -199,6 +199,9 @@ systemctl try-restart salt-api > /dev/null 2>&1 || :
 %dir /srv/salt/ceph/noout
 %dir /srv/salt/ceph/noout/set
 %dir /srv/salt/ceph/noout/unset
+%dir /srv/salt/ceph/obliterate
+%dir /srv/salt/ceph/obliterate/lock
+%dir /srv/salt/ceph/obliterate/unlock
 %dir /srv/salt/ceph/openattic
 %dir /srv/salt/ceph/openattic/auth
 %dir /srv/salt/ceph/openstack
@@ -249,6 +252,7 @@ systemctl try-restart salt-api > /dev/null 2>&1 || :
 %dir /srv/salt/ceph/rbd/benchmarks
 %dir /srv/salt/ceph/rbd/benchmarks/files
 %dir /srv/salt/ceph/reactor
+%dir /srv/salt/ceph/rebuild
 %dir /srv/salt/ceph/refresh
 %dir /srv/salt/ceph/repo
 %dir /srv/salt/ceph/redeploy
@@ -516,6 +520,9 @@ systemctl try-restart salt-api > /dev/null 2>&1 || :
 %config /srv/salt/ceph/monitoring/prometheus/files/*.yml
 %config /srv/salt/ceph/noout/set/*.sls
 %config /srv/salt/ceph/noout/unset/*.sls
+%config /srv/salt/ceph/obliterate/*.sls
+%config /srv/salt/ceph/obliterate/lock/*.sls
+%config /srv/salt/ceph/obliterate/unlock/*.sls
 %config /srv/salt/ceph/openattic/*.sls
 %config /srv/salt/ceph/openattic/auth/*.sls
 %config /srv/salt/ceph/openattic/key/*.sls
@@ -562,6 +569,7 @@ systemctl try-restart salt-api > /dev/null 2>&1 || :
 %config /srv/salt/ceph/rbd/benchmarks/*.sls
 %config /srv/salt/ceph/rbd/benchmarks/files/keyring.j2
 %config /srv/salt/ceph/reactor/*.sls
+%config /srv/salt/ceph/rebuild/*.sls
 %config /srv/salt/ceph/refresh/*.sls
 %config /srv/salt/ceph/repo/*.sls
 %config /srv/salt/ceph/redeploy/nodes/*.sls

--- a/srv/modules/runners/advise.py
+++ b/srv/modules/runners/advise.py
@@ -33,6 +33,32 @@ def help():
     print usage
     return ""
 
+def rebuild():
+    """
+    """
+    message = '''
+All the storage nodes have been added to the rebuild queue.  View the list with
+# salt-run filequeue.ls queue=rebuild
+
+To remove any of the nodes from the queue, run
+# salt-run filequeue.remove queue=rebuild MINION
+
+Otherwise, rerun the orchestration again to start the rebuild
+# salt-run state.orch ceph.stage.rebuild
+
+In case of failures during the removal, resolve the issue and run
+# salt 'minionX*' state.apply ceph.obliterate.unlock
+
+Failures during the creation of an OSD may be restarted by running the rebuild
+command above.
+    '''
+    bold = '\033[1m'
+    endc = '\033[0m'
+    print "{}************* REBUILD INSTRUCTIONS *******************{}".format(bold, endc)
+    print message
+    return ""
+
+
 def salt_run():
     """
     The salt-run commands report when complete.  This can be unnerving to

--- a/srv/modules/runners/filequeue.py
+++ b/srv/modules/runners/filequeue.py
@@ -318,15 +318,16 @@ def queues(**kwargs):
     with Lock(fq.settings):
         return "\n".join(fq.dirs())
 
-def enqueue(queue = None, **kwargs):
+def enqueue(*args, **kwargs):
     """
     Add item
     """
-    log.debug("enqueue: queue = {}, kwargs = {}".format(queue, _skip_dunder(kwargs)))
+    log.debug("enqueue: kwargs = {}".format(_skip_dunder(kwargs)))
     fq = FileQueue(**kwargs)
     with Lock(fq.settings):
-        if queue:
-            ret = fq.touch(queue)
+        if args:
+            for arg in args:
+                ret = fq.touch(arg)
         elif 'item' in kwargs:
             ret = fq.touch(kwargs['item'])
         else:
@@ -368,6 +369,14 @@ def ls(**kwargs):
     with Lock(fq.settings):
         return "\n".join(fq.ls())
 
+def array(**kwargs):
+    """
+    """
+    log.debug("array: kwargs = {}".format(_skip_dunder(kwargs)))
+    fq = FileQueue(**kwargs)
+    with Lock(fq.settings):
+        return fq.ls()
+
 def items(**kwargs):
     """
     List items in time order
@@ -401,16 +410,20 @@ def check(queue = None, **kwargs):
             help()
             return
 
-def remove(queue = None, **kwargs):
+def remove(*args, **kwargs):
     """
     Remove specific item
     """
-    log.debug("remove: queue = {}, kwargs = {}".format(queue, _skip_dunder(kwargs)))
+    log.debug("remove: kwargs = {}".format(_skip_dunder(kwargs)))
 
     fq = FileQueue(**kwargs)
     with Lock(fq.settings):
-        if queue:
-            return fq.remove(queue)
+        if args:
+            for arg in args:
+                result = fq.remove(arg)
+                if result == False:
+                    return False
+            return True
         elif 'item' in kwargs:
             return fq.remove(kwargs['item'])
         else:

--- a/srv/salt/ceph/functests/1node/rebuild/init.sls
+++ b/srv/salt/ceph/functests/1node/rebuild/init.sls
@@ -1,0 +1,10 @@
+
+{# This is more of a namespace placeholder.  The difference between migrate
+and rebuild is the deletion of the OSDs.  The migrate tests actually remove
+all the OSDs ahead of time as part of the prepartion.  This is the same
+process as the rebuild orchestration.  With respect to needing to convert
+the different formats, rebuild covers the same scenarios. #}
+
+include:
+  - ..migrate
+

--- a/srv/salt/ceph/obliterate/default.sls
+++ b/srv/salt/ceph/obliterate/default.sls
@@ -1,0 +1,15 @@
+
+storage nop:
+  test.nop
+
+{% for id in salt['osd.list']() %}
+
+removing {{ id }}:
+  module.run:
+    - name: osd.remove
+    - osd_id: {{ id }}
+    - kwargs:
+        force: True
+
+{% endfor %}
+

--- a/srv/salt/ceph/obliterate/init.sls
+++ b/srv/salt/ceph/obliterate/init.sls
@@ -1,0 +1,4 @@
+
+
+include:
+  - .{{ salt['pillar.get']('ceph_obliterate', 'default') }}

--- a/srv/salt/ceph/obliterate/lock/default.sls
+++ b/srv/salt/ceph/obliterate/lock/default.sls
@@ -1,0 +1,9 @@
+
+{% set filename="/etc/ceph/obliterate.lock" %}
+{% if salt['file.file_exists'](filename) %}
+Run 'ceph.obliterate.unlock' to continue:
+  test.fail_without_changes
+{% else %}
+{{ filename }}:
+  file.touch
+{% endif %}

--- a/srv/salt/ceph/obliterate/lock/init.sls
+++ b/srv/salt/ceph/obliterate/lock/init.sls
@@ -1,0 +1,4 @@
+
+
+include:
+  - .{{ salt['pillar.get']('ceph_obliterate_lock', 'default') }}

--- a/srv/salt/ceph/obliterate/unlock/default.sls
+++ b/srv/salt/ceph/obliterate/unlock/default.sls
@@ -1,0 +1,4 @@
+
+{% set filename="/etc/ceph/obliterate.lock" %}
+{{ filename }}:
+  file.absent

--- a/srv/salt/ceph/obliterate/unlock/init.sls
+++ b/srv/salt/ceph/obliterate/unlock/init.sls
@@ -1,0 +1,4 @@
+
+
+include:
+  - .{{ salt['pillar.get']('ceph_obliterate_unlock', 'default') }}

--- a/srv/salt/ceph/rebuild/default.sls
+++ b/srv/salt/ceph/rebuild/default.sls
@@ -1,0 +1,93 @@
+
+{% set master = salt['pillar.get']('master_minion') %}
+
+{% if salt['saltutil.runner']('disengage.check', cluster='ceph') == False %}
+safety is engaged:
+  salt.state:
+    - tgt: {{ master }}
+    - name: "Run 'salt-run disengage.safety' to disable"
+    - failhard: True
+
+{% endif %}
+
+wait on healthy cluster:
+  salt.state:
+    - tgt: {{ master }}
+    - tgt_type: compound
+    - sls: ceph.wait.until.OK
+    - failhard: True
+
+{% if salt['saltutil.runner']('filequeue.empty', queue='rebuild') %}
+{% for host in salt.saltutil.runner('select.minions', cluster='ceph', roles='storage') %}
+queue {{ host }}:
+  salt.runner:
+    - name: filequeue.add
+    - queue: 'rebuild'
+    - item: {{ host }}
+
+{% endfor %}
+
+advise rebuild:
+  salt.runner:
+    - name: advise.rebuild
+
+{% endif %}
+
+{% for host in salt['saltutil.runner']('filequeue.array', queue='rebuild') %}
+lock obliterate {{ host }}:
+  salt.state:
+    - tgt: {{ host }}
+    - tgt_type: compound
+    - sls: ceph.obliterate.lock
+
+remove osds {{ host }}:
+  salt.state:
+    - tgt: {{ host }}
+    - tgt_type: compound
+    - sls: ceph.obliterate
+    - failhard: True
+    - require: 
+      - salt: lock obliterate {{ host }}
+
+create osds {{ host }}:
+  salt.state:
+    - tgt: {{ host }}
+    - tgt_type: compound
+    - sls: ceph.osd
+    - failhard: True
+
+update grains {{ host }}:
+  salt.state:
+    - tgt: {{ host }}
+    - tgt_type: compound
+    - sls: ceph.osd.grains
+    - failhard: True
+
+wait on healthy cluster {{ host }}:
+  salt.state:
+    - tgt: {{ master }}
+    - tgt_type: compound
+    - sls: ceph.wait.1hour.until.OK
+    - failhard: True
+
+queue {{ host }}:
+  salt.runner:
+    - name: filequeue.remove
+    - queue: 'rebuild'
+    - item: {{ host }}
+
+unlock obliterate {{ host }}:
+  salt.state:
+    - tgt: {{ host }}
+    - tgt_type: compound
+    - sls: ceph.obliterate.unlock
+    - failhard: True
+
+{% endfor %}
+
+cleanup osds:
+  salt.state:
+    - tgt: {{ master }}
+    - tgt_type: compound
+    - sls: ceph.remove.destroyed
+

--- a/srv/salt/ceph/rebuild/init.sls
+++ b/srv/salt/ceph/rebuild/init.sls
@@ -1,0 +1,4 @@
+
+
+include:
+  - .{{ salt['pillar.get']('rebuild_init', 'default') }}

--- a/tests/unit/runners/test_filequeue.py
+++ b/tests/unit/runners/test_filequeue.py
@@ -162,5 +162,142 @@ class TestFileQueue():
         shutil.rmtree(dirpath)
         assert checked == False
 
+    @patch('srv.modules.runners.filequeue.Lock', autospec=True)
+    @patch('srv.modules.runners.filequeue.FileQueue', autospec=True)
+    def test_enqueue_args(self, fq, lock):
+        '''
+        '''
+        args = ['abc']
+        mock_fq = fq.return_value
+        mock_fq.touch.return_value = True
+        mock_fq.settings = {}
 
+        result = filequeue.enqueue(args)
+        assert result == True
 
+    @patch('srv.modules.runners.filequeue.Lock', autospec=True)
+    @patch('srv.modules.runners.filequeue.FileQueue', autospec=True)
+    def test_enqueue_args_fail(self, fq, lock):
+        '''
+        '''
+        args = ['abc']
+        mock_fq = fq.return_value
+        mock_fq.touch.return_value = False
+        mock_fq.settings = {}
+
+        result = filequeue.enqueue(args)
+        assert result == False
+
+    @patch('srv.modules.runners.filequeue.Lock', autospec=True)
+    @patch('srv.modules.runners.filequeue.FileQueue', autospec=True)
+    def test_enqueue_kwargs(self, fq, lock):
+        '''
+        '''
+        kwargs = {'item': 'abc'}
+        mock_fq = fq.return_value
+        mock_fq.touch.return_value = True
+        mock_fq.settings = {}
+
+        result = filequeue.enqueue(kwargs)
+        assert result == True
+
+    @patch('srv.modules.runners.filequeue.Lock', autospec=True)
+    @patch('srv.modules.runners.filequeue.FileQueue', autospec=True)
+    def test_enqueue_kwargs_fail(self, fq, lock):
+        '''
+        '''
+        kwargs = {'item': 'abc'}
+        mock_fq = fq.return_value
+        mock_fq.touch.return_value = False
+        mock_fq.settings = {}
+
+        result = filequeue.enqueue(kwargs)
+        assert result == False
+
+    @patch('srv.modules.runners.filequeue.help', autospec=True)
+    @patch('srv.modules.runners.filequeue.Lock', autospec=True)
+    @patch('srv.modules.runners.filequeue.FileQueue', autospec=True)
+    def test_enqueue_help(self, fq, lock, mock_help):
+        '''
+        '''
+        mock_fq = fq.return_value
+        mock_fq.settings = {}
+
+        result = filequeue.enqueue()
+        assert result == None
+
+    @patch('srv.modules.runners.filequeue.Lock', autospec=True)
+    @patch('srv.modules.runners.filequeue.FileQueue', autospec=True)
+    def test_remove_args(self, fq, lock):
+        '''
+        '''
+        args = ['abc']
+        mock_fq = fq.return_value
+        mock_fq.remove.return_value = True
+        mock_fq.settings = {}
+
+        result = filequeue.remove(args)
+        assert result == True
+
+    @patch('srv.modules.runners.filequeue.Lock', autospec=True)
+    @patch('srv.modules.runners.filequeue.FileQueue', autospec=True)
+    def test_remove_args_fails(self, fq, lock):
+        '''
+        '''
+        args = ['abc']
+        mock_fq = fq.return_value
+        mock_fq.remove.return_value = False
+        mock_fq.settings = {}
+
+        result = filequeue.remove(args)
+        assert result == False
+
+    @patch('srv.modules.runners.filequeue.Lock', autospec=True)
+    @patch('srv.modules.runners.filequeue.FileQueue', autospec=True)
+    def test_remove_kwargs(self, fq, lock):
+        '''
+        '''
+        kwargs = {'item': 'abc'}
+        mock_fq = fq.return_value
+        mock_fq.remove.return_value = True
+        mock_fq.settings = {}
+
+        result = filequeue.remove(kwargs)
+        assert result == True
+
+    @patch('srv.modules.runners.filequeue.Lock', autospec=True)
+    @patch('srv.modules.runners.filequeue.FileQueue', autospec=True)
+    def test_remove_kwargs_fails(self, fq, lock):
+        '''
+        '''
+        kwargs = {'item': 'abc'}
+        mock_fq = fq.return_value
+        mock_fq.remove.return_value = False
+        mock_fq.settings = {}
+
+        result = filequeue.remove(kwargs)
+        assert result == False
+
+    @patch('srv.modules.runners.filequeue.help', autospec=True)
+    @patch('srv.modules.runners.filequeue.Lock', autospec=True)
+    @patch('srv.modules.runners.filequeue.FileQueue', autospec=True)
+    def test_remove_help(self, fq, lock, mock_help):
+        '''
+        '''
+        mock_fq = fq.return_value
+        mock_fq.settings = {}
+
+        result = filequeue.remove()
+        assert result == None
+
+    @patch('srv.modules.runners.filequeue.Lock', autospec=True)
+    @patch('srv.modules.runners.filequeue.FileQueue', autospec=True)
+    def test_array(self, fq, lock):
+        '''
+        '''
+        mock_fq = fq.return_value
+        mock_fq.ls.return_value = ['abc']
+        mock_fq.settings = {}
+
+        result = filequeue.array()
+        assert result == ['abc']


### PR DESCRIPTION
Rather than migrate storage nodes incrementally, the rebuild
orchestration removes all OSDs and then recreates the OSDs.  The
filequeue and lock allow for graceful restarts after resolving
failures.

Signed-off-by: Eric Jackson <ejackson@suse.com>
bsc#1105082

-----------------

**Checklist:**
- [ ] Added unittests and or functional tests
- [ ] Adapted documentation
- [ ] Referenced issues or internal bugtracker
- [ ] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
