### PR TITLE
Return version instead of printing it

### DIFF
--- a/srv/salt/_modules/cephdisks.py
+++ b/srv/salt/_modules/cephdisks.py
@@ -601,7 +601,7 @@ def version():
     """
     Displays version
     """
-    print(VERSION)
+    return VERSION
 
 
 __func_alias__ = {

--- a/tests/unit/_modules/test_cephdisks.py
+++ b/tests/unit/_modules/test_cephdisks.py
@@ -510,3 +510,7 @@ class TestCephDiskDevice():
 
         ret = cephdisks._prefer_underscores(devices)
         assert ret == -1
+
+    def test_version(self):
+        ret = cephdisks.version()
+        assert ret == cephdisks.VERSION


### PR DESCRIPTION
Return version in cephdisk.version() instead of printing it. So ``salt '*' cephdisks.version`` will output correct values instead of None.

Signed-off-by: Volker Theile <vtheile@suse.com>

**Checklist:**
- [x] Added unittests and or functional tests
- [ ] Adapted documentation
- [ ] Referenced issues or internal bugtracker
- [x] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
