### PR TITLE
[backport][SES5] populate/engulf: don't add cluster-unassigned line

### DIFF
--- a/srv/modules/runners/populate.py
+++ b/srv/modules/runners/populate.py
@@ -1255,7 +1255,6 @@ def engulf_existing_cluster(**kwargs):
     # ...but inject the unassigned line first so it takes precendence,
     # along with the global config bits (because they're prettier early)...
     policy_cfg = [
-        "cluster-unassigned/cluster/*.sls",
         "config/stack/default/ceph/cluster.yml",
         "config/stack/default/global.yml" ] + policy_cfg
 


### PR DESCRIPTION
Since the introduction of deepsea_minions, cluster-unassigned
isn't particularly useful, and in the engulf case is unnecessary
anyway as assigned nodes are specified individually rather than
by wildcard.

Fixes: https://github.com/SUSE/DeepSea/issues/1241
Signed-off-by: Tim Serong <tserong@suse.com>
(cherry picked from commit 2bfe79a33edaa9d1c33a5119f1455e59e8e28653)

-----------------

**Checklist:**
- [ ] Added unittests and or functional tests
- [ ] Adapted documentation
- [ ] Referenced issues or internal bugtracker
- [ ] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
