### PR TITLE
Add runner to enable/disable storage enclosure LED

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -196,6 +196,7 @@ copy-files:
 	install -m 644 srv/pillar/ceph/init.sls $(DESTDIR)/srv/pillar/ceph/
 	install -m 644 srv/pillar/ceph/deepsea_minions.sls $(DESTDIR)/srv/pillar/ceph/
 	install -m 644 srv/pillar/ceph/blacklist.sls $(DESTDIR)/srv/pillar/ceph/
+	install -m 644 srv/pillar/ceph/disk_led.sls $(DESTDIR)/srv/pillar/ceph/
 	install -d -m 755 $(DESTDIR)/srv/pillar/ceph/stack
 	install -m 644 srv/pillar/ceph/stack/stack.cfg $(DESTDIR)/srv/pillar/ceph/stack/stack.cfg
 	install -m 644 srv/pillar/top.sls $(DESTDIR)/srv/pillar/

--- a/deepsea.spec.in
+++ b/deepsea.spec.in
@@ -450,6 +450,7 @@ systemctl try-restart salt-api > /dev/null 2>&1 || :
 %config %attr(-, salt, salt) /srv/pillar/ceph/benchmarks/templates/*.j2
 %config(noreplace) %attr(-, salt, salt) /srv/pillar/ceph/deepsea_minions.sls
 %config(noreplace) %attr(-, salt, salt) /srv/pillar/ceph/blacklist.sls
+%config(noreplace) %attr(-, salt, salt) /srv/pillar/ceph/disk_led.sls
 %config %attr(-, salt, salt) /srv/pillar/ceph/stack/stack.cfg
 /srv/salt/_modules/*.py*
 /srv/salt/_states/*.py*

--- a/srv/modules/runners/disk_led.py
+++ b/srv/modules/runners/disk_led.py
@@ -1,0 +1,115 @@
+# -*- coding: utf-8 -*-
+"""
+This runner is used to turn on/off the ident and fault LED of a disk.
+"""
+from __future__ import absolute_import
+
+import logging
+import re
+
+import salt.client
+
+log = logging.getLogger(__name__)
+
+
+def _process(hostname, device_name, led, status):
+    """
+    Turn on/off the specified LED of the disk on the given host.
+    """
+    assert not device_name.startswith('/dev/')
+    assert led in ['ident', 'fault']
+
+    local_client = salt.client.LocalClient()
+    device_file = '/dev/{}'.format(device_name)
+    status = 'on' if status in [True, 'on'] else 'off'
+
+    # Get the configuration of the command to turn on/off the ident
+    # or fault LED on the target host.
+    result = local_client.cmd(
+        hostname, 'pillar.get', ['disk_led:cmd'], tgt_type='compound')
+    if not result or hostname not in result.keys():
+        raise RuntimeError(
+            'Failed to get "disk_led:cmd" configuration from pillar')
+    cmd_cfg = result[hostname]
+    if not isinstance(cmd_cfg, dict):
+        raise RuntimeError('Invalid "disk_led:cmd" configuration')
+
+    print('Turning {} the {} LED of disk "{}" on host "{}" ...'.format(
+        status, led, device_file, hostname))
+    _cmd_run(hostname, cmd_cfg[led][status].format(device_file=device_file))
+
+
+def _cmd_run(hostname, cmd):
+    """
+    Run the specified command line.
+    .. note:: This function has been introduced for easier unit testing.
+    """
+    local_client = salt.client.LocalClient()
+    result = local_client.cmd(
+        hostname, 'cmd.shell', [cmd], tgt_type='compound', full_return=True)
+    if result and hostname in result.keys():
+        if result[hostname]['retcode'] != 0:
+            raise RuntimeError('Failed to execute "{}" on "{}": {}'.format(
+                cmd, hostname, result[hostname]['ret']))
+
+
+def device(hostname, identifier, led, status):
+    """
+    Manage the storage enclosure LED by device name and host.
+    :param hostname: The host where the storage device is located.
+    :type hostname: str
+    :param identifier: The storage device identifier, e.g.
+        - sdg
+        - SanDisk_X400_M.2_1260_512GB_558924904728
+        - <VENDOR>_<MODEL>_<SERIAL>
+    :type identifier: str
+    :param led: The LED to be processed. This can be 'ident' or 'fault'.
+    :type led: str
+    :param status: Set to 'on' to switch on the light, otherwise 'off'.
+    :type status: str
+    """
+    device_name = None
+    local_client = salt.client.LocalClient()
+
+    grains = local_client.cmd(
+        hostname, 'grains.get', ['disks'], tgt_type='compound')
+    if hostname in grains:
+        # Process list of device names.
+        # {
+        #   ...
+        #   'data1.ceph': ['dm-1', 'vdf', 'vdd', 'sdg', ...],
+        #   ...
+        # }
+        for disk in grains[hostname]:
+            if disk == identifier:
+                device_name = disk
+                break
+
+            # Get all udev-created device symlinks.
+            # {
+            #   'data1.ceph': [
+            #     'disk/by-id/wwn-0x4003c435a4d43cd8',
+            #     'disk/by-path/pci-0000:00:15.0-ata-3',
+            #     'disk/by-id/ata-SanDisk_X400_M.2_2280_512GB_26453645624767'
+            #   ]
+            # }
+            device_links = local_client.cmd(
+                hostname,
+                'udev.links', ['/dev/{}'.format(disk)],
+                tgt_type='compound')
+
+            for device_link in device_links[hostname]:
+                # pylint: disable=line-too-long
+                # Search for device names like:
+                # - Crucial_CT1024M550SSD1_14160C164100 (disk/by-id/(ata|scsi|.+)-Crucial_CT1024M550SSD1_14160C164100)
+                # - wwn-0x4021b384a4d42ca5 (disk/by-id/wwn-0x4021b384a4d42ca5)
+                if re.match(r'^.+\/(ata|scsi|wwn)-{}$'.format(identifier),
+                            device_link):
+                    device_name = disk
+                    break
+
+    if device_name is not None:
+        _process(hostname, device_name, led, status)
+        return ''
+    return 'Could not find device "{}" on host "{}"'.format(
+        identifier, hostname)

--- a/srv/pillar/ceph/disk_led.sls
+++ b/srv/pillar/ceph/disk_led.sls
@@ -1,0 +1,15 @@
+# This is the default configuration for the storage enclosure LED blinking.
+# The placeholder {device_file} will be replaced with the device file of
+# the disk when the command is executed.
+#
+# Have a look into the /srv/pillar/ceph/README file to find out how to
+# customize this configuration per minion/host.
+
+disk_led:
+  cmd:
+    ident:
+      'on': lsmcli local-disk-ident-led-on --path '{device_file}'
+      'off': lsmcli local-disk-ident-led-off --path '{device_file}'
+    fault:
+      'on': lsmcli local-disk-fault-led-on --path '{device_file}'
+      'off': lsmcli local-disk-fault-led-off --path '{device_file}'

--- a/srv/pillar/ceph/init.sls
+++ b/srv/pillar/ceph/init.sls
@@ -2,3 +2,4 @@
 
 {% include 'ceph/deepsea_minions.sls' ignore missing %}
 {% include 'ceph/blacklist.sls' ignore missing %}
+{% include 'ceph/disk_led.sls' ignore missing %}

--- a/srv/salt/ceph/packages/common/default.sls
+++ b/srv/salt/ceph/packages/common/default.sls
@@ -27,6 +27,7 @@ stage prep dependencies suse:
       - tuned
       - libgio-2_0-0
       - polkit
+      - libstoragemgmt
     - fire_event: True
     - refresh: True
 
@@ -72,6 +73,7 @@ stage prep dependencies CentOS:
       - hwinfo
       - python-netaddr
       - jq
+      - libstoragemgmt
     - fire_event: True
     - refresh: True
 

--- a/tests/unit/runners/test_disk_led.py
+++ b/tests/unit/runners/test_disk_led.py
@@ -1,0 +1,102 @@
+import pytest
+import mock
+from srv.modules.runners import disk_led
+
+grains_get_result = {"data1.ceph": ["vdf"]}
+udev_links_result = {
+    "data1.ceph": [
+        "disk/by-id/wwn-0x4003c435a4d43cd8",
+        "disk/by-path/pci-0000:00:15.0-ata-3",
+        "disk/by-id/ata-SanDisk_X400_M.2_2280_512GB_26453645624767"
+    ]
+}
+pillar_get_result = {
+    "data1.ceph": {
+        "ident": {
+            "on": "xxx '{device_file}'",
+            "off": "yyy '{device_file}'"
+        },
+        "fault": {
+            "on": "aaa '{device_file}'",
+            "off": "bbb '{device_file}'"
+        }
+    }
+}
+invalid_pillar_get_result = {"data1.ceph": ""}
+
+
+class TestDiskLed:
+    @mock.patch('srv.modules.runners.disk_led._process', autospec=True)
+    @mock.patch('salt.client.LocalClient', autospec=True)
+    def test_device_by_device_name(self, mock_localclient, mock_process):
+        mock_localclient.return_value.cmd.side_effect = [
+            grains_get_result, udev_links_result
+        ]
+
+        disk_led.device('data1.ceph', 'vdf', 'ident', 'on')
+        mock_process.assert_called_once_with('data1.ceph', 'vdf', 'ident',
+                                             'on')
+
+    @mock.patch('srv.modules.runners.disk_led._process', autospec=True)
+    @mock.patch('salt.client.LocalClient', autospec=True)
+    def test_device_by_device_id(self, mock_localclient, mock_process):
+        mock_localclient.return_value.cmd.side_effect = [
+            grains_get_result, udev_links_result
+        ]
+
+        disk_led.device('data1.ceph',
+                        'SanDisk_X400_M.2_2280_512GB_26453645624767', 'fault',
+                        'off')
+        mock_process.assert_called_once_with('data1.ceph', 'vdf', 'fault',
+                                             'off')
+
+    @mock.patch('srv.modules.runners.disk_led._process', autospec=True)
+    @mock.patch('salt.client.LocalClient', autospec=True)
+    def test_device_failure(self, mock_localclient, mock_process):
+        mock_localclient.return_value.cmd.return_value = {}
+
+        result = disk_led.device('data2.ceph', 'sdg', 'ident', 'off')
+        assert not mock_process.called
+        assert result == 'Could not find device "sdg" on host "data2.ceph"'
+
+    @mock.patch('salt.client.LocalClient', autospec=True)
+    def test_process_get_pillar_failed(self, mock_localclient):
+        mock_localclient.return_value.cmd.return_value = []
+
+        with pytest.raises(RuntimeError):
+            disk_led._process('data1.ceph', 'vdf', 'ident', 'on')
+
+    @mock.patch('salt.client.LocalClient', autospec=True)
+    def test_process_invalid_config(self, mock_localclient):
+        mock_localclient.return_value.cmd.return_value = invalid_pillar_get_result
+
+        with pytest.raises(RuntimeError):
+            disk_led._process('data1.ceph', 'vdf', 'ident', 'on')
+
+    @mock.patch('srv.modules.runners.disk_led._cmd_run')
+    @mock.patch('salt.client.LocalClient', autospec=True)
+    def test_process(self, mock_localclient, mock_cmd_run):
+        mock_localclient.return_value.cmd.return_value = pillar_get_result
+
+        disk_led._process('data1.ceph', 'vdf', 'ident', 'on')
+        mock_cmd_run.assert_called_once_with('data1.ceph', 'xxx \'/dev/vdf\'')
+
+    def test_process_invalid_arg_1(self):
+        with pytest.raises(AssertionError):
+            disk_led._process('data1.ceph', '/dev/vdf', 'ident', 'on')
+
+    def test_process_invalid_arg_1(self):
+        with pytest.raises(AssertionError):
+            disk_led._process('data1.ceph', 'sdb', 'foo', 'on')
+
+    @mock.patch('salt.client.LocalClient', autospec=True)
+    def test_cmd_run_failure(self, mock_localclient):
+        mock_localclient.return_value.cmd.return_value = {
+            'data1.ceph': {
+                'ret': 'Command failed',
+                'retcode': 1
+            }
+        }
+
+        with pytest.raises(RuntimeError):
+            disk_led._cmd_run('data1.ceph', 'foo bar')


### PR DESCRIPTION
Add runner to enable/disable storage enclosure LED.

The interface is based on
- https://docs.google.com/document/d/1kGoGq5qRWBnuyH7ZTCGfb16uD7sd9hddIY6mqtFy8q8/edit#
- https://pad.ceph.com/p/blinky-lights

Examples:
```
$ salt-run disk_led.device data2.ceph vdf fault off
$ salt-run disk_led.device data2.ceph /dev/vdf fault on
$ salt-run disk_led.device data2.ceph /dev/disk/by-id/scsi-SATA_ST3200XXXX2AS_5XWXXXR6 ident off
$ salt-run disk_led.device data1.ceph SanDisk_X400_M.2_1260_512GB_558924904728 ident on
```

Signed-off-by: Volker Theile <vtheile@suse.com>

**Checklist:**
- [x] Added unittests and or functional tests
- [ ] Adapted documentation
- [ ] Referenced issues or internal bugtracker
- [x] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
