### PR TITLE
Makefile: Install python-configobj

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ DOCDIR = /usr/share/doc/packages
 VERSION ?= $(shell (git describe 2>/dev/null || echo '0.0.0') | sed -e 's/^v//' -e 's/-/+/' -e 's/-/./')
 
 DEEPSEA_DEPS=salt-api
-PYTHON_DEPS=python3-setuptools python3-click python3-tox
+PYTHON_DEPS=python3-setuptools python3-click python3-tox python3-configobj
 PYTHON=python3
 
 OS=$(shell source /etc/os-release 2>/dev/null ; echo $$ID)
@@ -23,7 +23,7 @@ USER=root
 GROUP=root
 ifeq ($(OS), centos)
 PKG_INSTALL=yum install -y
-PYTHON_DEPS=python-setuptools python-click python-tox
+PYTHON_DEPS=python-setuptools python-click python-tox python-configobj
 PYTHON=python
 else
 ifeq ($(OS), fedora)


### PR DESCRIPTION
Without this package, salt can like bellow:

[CRITICAL] Rendering SLS 'base:ceph.stage.0.master.default' failed: Jinja error: 'validate.setup'
Traceback (most recent call last):
File "/usr/lib/python2.7/site-packages/salt/utils/templates.py", line 368, in render_jinja_tmpl
output = template.render(**decoded_context)
File "/usr/lib/python2.7/site-packages/jinja2/environment.py", line 969, in render
return self.environment.handle_exception(exc_info, True)
File "/usr/lib/python2.7/site-packages/jinja2/environment.py", line 742, in handle_exception
reraise(exc_type, exc_value, tb)
File "", line 3, in top-level template code
File "/usr/lib/python2.7/site-packages/salt/modules/saltutil.py", line 1181, in runner
return rclient.cmd(name, kwarg=kwargs, print_event=False, full_return=True)
File "/usr/lib/python2.7/site-packages/salt/runner.py", line 144, in cmd
full_return)
File "/usr/lib/python2.7/site-packages/salt/client/mixins.py", line 225, in cmd
self.functions[fun], arglist, pub_data
File "/usr/lib/python2.7/site-packages/salt/loader.py", line 1086, in getitem
func = super(LazyLoader, self).getitem(item)
File "/usr/lib/python2.7/site-packages/salt/utils/lazy.py", line 101, in getitem
raise KeyError(key)
KeyError: 'validate.setup'

On opensuse-leap 15.0, installing python3-configobj solves this issue.

Fixes: #150

Signed-off-by: Marcos Paulo de Souza <mpdesouza@suse.de>

Fixes #


Description:


-----------------

**Checklist:**
- [ ] Added unittests and or functional tests
- [ ] Adapted documentation
- [ x ] Referenced issues or internal bugtracker
- [ ] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
