### PR TITLE
Harden split_partition function in osd module

### DIFF
--- a/srv/salt/_modules/osd.py
+++ b/srv/salt/_modules/osd.py
@@ -1399,6 +1399,8 @@ def split_partition(_partition):
     # if os.path.exists(part):
     log.debug("splitting partition {}".format(part))
     match = re.match(r"(.+\D)(\d+)", part)
+    if not match:
+        return None, None
     disk = match.group(1)
     if disk.endswith('p'):
         disk = disk[:-1]
@@ -2340,14 +2342,16 @@ def _report_grains():
         for _id in __grains__['ceph']:
             _partition = readlink(__grains__['ceph'][_id]['partitions']['osd'])
             disk, _ = split_partition(_partition)
-            active.append(disk)
+            if disk:
+                active.append(disk)
             log.debug("checking /var/lib/ceph/osd/ceph-{}/fsid".format(_id))
             if not os.path.exists("/var/lib/ceph/osd/ceph-{}/fsid".format(_id)):
                 unmounted.append(disk)
             if 'lockbox' in __grains__['ceph'][_id]['partitions']:
                 _partition = readlink(__grains__['ceph'][_id]['partitions']['lockbox'])
                 disk, _ = split_partition(_partition)
-                active.append(disk)
+                if disk:
+                    active.append(disk)
     return active, unmounted
 
 


### PR DESCRIPTION
Harden split_partition function to do not fail in such case:
```
# salt-call grains.item ceph
local:
    ----------
    ceph:
        ----------
        0:
            ----------
            fsid:
                4720f8d1-bd87-4e2e-9af9-c6214f1adecc
            partitions:
                ----------
                block:
                    /dev/dm-0
                osd:
                    None
        1:
            ----------
            fsid:
                8fe7d512-d40a-4d9f-9dcb-9f9328bb6f11
            partitions:
                ----------
                block:
                    /dev/dm-1
                osd:
                    None
```
Signed-off-by: Volker Theile <vtheile@suse.com>

**Checklist:**
- [ ] Added unittests and or functional tests
- [ ] Adapted documentation
- [ ] Referenced issues or internal bugtracker
- [ ] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
