### PR TITLE
Change default timeout to 1 hour for redeploying OSDs

### DIFF
--- a/srv/salt/ceph/redeploy/nodes/default.sls
+++ b/srv/salt/ceph/redeploy/nodes/default.sls
@@ -3,6 +3,9 @@ redeploy:
   module.run:
     - name: osd.redeploy
     - simultaneous: True
+    - kwargs:
+        timeout: 3600
+        delay: 60
 
 save grains:
   module.run:

--- a/srv/salt/ceph/redeploy/osds/default.sls
+++ b/srv/salt/ceph/redeploy/osds/default.sls
@@ -2,6 +2,9 @@
 redeploy:
   module.run:
     - name: osd.redeploy
+    - kwargs:
+        timeout: 3600
+        delay: 60
 
 save grains:
   module.run:


### PR DESCRIPTION
Increase the sliding window since some Ceph clusters take a substantial amount of time to evacuate an OSD.

Signed-off-by: Eric Jackson <ejackson@suse.com>
bnc: 1116375

-----------------

**Checklist:**
- [ ] Added unittests and or functional tests
- [ ] Adapted documentation
- [x] Referenced issues or internal bugtracker
- [ ] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
