### PR TITLE
Assign drives based on filter rules (DriveGroups) SES-150

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -125,4 +125,5 @@ TAGS
 .mypy_cache/
 
 # projectile files
+.#*
 .projectile

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ version:
 setup.py:
 	sed "s/DEVVERSION/"$(VERSION)"/" setup.py.in > setup.py
 
-pyc: setup.py 
+pyc: setup.py
 	#make sure to create bytecode with the correct version
 	find srv/ -name '*.py' -exec $(PYTHON) -m py_compile {} \;
 	find cli/ -name '*.py' -exec $(PYTHON) -m py_compile {} \;
@@ -255,6 +255,7 @@ copy-files:
 	install -m 644 srv/salt/ceph/configuration/files/rgw.conf $(DESTDIR)/srv/salt/ceph/configuration/files/
 	install -m 644 srv/salt/ceph/configuration/files/rgw-ssl.conf $(DESTDIR)/srv/salt/ceph/configuration/files/
 	install -m 644 srv/salt/ceph/configuration/files/ceph.conf.import $(DESTDIR)/srv/salt/ceph/configuration/files/
+	install -m 644 srv/salt/ceph/configuration/files/drive_groups.yml $(DESTDIR)/srv/salt/ceph/configuration/files/
 	install -m 644 srv/salt/ceph/configuration/files/deprecated_map.yml $(DESTDIR)/srv/salt/ceph/configuration/files/
 	-chown salt:salt $(DESTDIR)/srv/salt/ceph/configuration/files/ceph.conf.import || true
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/configuration/files/ceph.conf.d
@@ -531,7 +532,7 @@ copy-files:
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/remove/destroyed
 	install -m 644 srv/salt/ceph/remove/destroyed/*.sls $(DESTDIR)/srv/salt/ceph/remove/destroyed/
 	# Renamed for deprecation
-	ln -sf destroyed	$(DESTDIR)/srv/salt/ceph/remove/migrated 
+	ln -sf destroyed	$(DESTDIR)/srv/salt/ceph/remove/migrated
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/remove/mgr
 	install -m 644 srv/salt/ceph/remove/mgr/*.sls $(DESTDIR)/srv/salt/ceph/remove/mgr/
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/remove/mon
@@ -544,8 +545,8 @@ copy-files:
 	install -m 644 srv/salt/ceph/remove/storage/*.sls $(DESTDIR)/srv/salt/ceph/remove/storage/
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/remove/storage/drain
 	install -m 644 srv/salt/ceph/remove/storage/drain/*.sls $(DESTDIR)/srv/salt/ceph/remove/storage/drain
-	install -d -m 755 $(DESTDIR)/srv/salt/ceph/remove/openattic	
-	install -m 644 srv/salt/ceph/remove/openattic/*.sls $(DESTDIR)/srv/salt/ceph/remove/openattic/	
+	install -d -m 755 $(DESTDIR)/srv/salt/ceph/remove/openattic
+	install -m 644 srv/salt/ceph/remove/openattic/*.sls $(DESTDIR)/srv/salt/ceph/remove/openattic/
 	# state files - rescind
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/rescind
 	install -m 644 srv/salt/ceph/rescind/*.sls $(DESTDIR)/srv/salt/ceph/rescind/
@@ -611,9 +612,9 @@ copy-files:
 	install -m 644 srv/salt/ceph/rescind/time/ntp/*.sls $(DESTDIR)/srv/salt/ceph/rescind/time/ntp
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/rescind/tuned
 	install -m 644 srv/salt/ceph/rescind/tuned/*.sls $(DESTDIR)/srv/salt/ceph/rescind/tuned/
-	install -d -m 755 $(DESTDIR)/srv/salt/ceph/rescind/openattic	
-	install -m 644 srv/salt/ceph/rescind/openattic/*.sls $(DESTDIR)/srv/salt/ceph/rescind/openattic/	
-	install -d -m 755 $(DESTDIR)/srv/salt/ceph/rescind/openattic/keyring	
+	install -d -m 755 $(DESTDIR)/srv/salt/ceph/rescind/openattic
+	install -m 644 srv/salt/ceph/rescind/openattic/*.sls $(DESTDIR)/srv/salt/ceph/rescind/openattic/
+	install -d -m 755 $(DESTDIR)/srv/salt/ceph/rescind/openattic/keyring
 	install -m 644 srv/salt/ceph/rescind/openattic/keyring/*.sls $(DESTDIR)/srv/salt/ceph/rescind/openattic/keyring/
 	# state files - repo
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/repo

--- a/cli/tests/test_monitor.py
+++ b/cli/tests/test_monitor.py
@@ -15,7 +15,6 @@ class MonTestListener(MonitorListener):
         self.parsing_error = None
         self.parsing_output = None
         self.finished = False
-
         self.steps = []
 
     def _last(self, search_sub=False):

--- a/deepsea.spec.in
+++ b/deepsea.spec.in
@@ -287,7 +287,7 @@ systemctl try-restart salt-api > /dev/null 2>&1 || :
 %dir /srv/salt/ceph/rescind/time/chrony
 %dir /srv/salt/ceph/rescind/time/ntp
 %dir /srv/salt/ceph/rescind/tuned
-%dir /srv/salt/ceph/rescind/openattic	
+%dir /srv/salt/ceph/rescind/openattic
 %dir /srv/salt/ceph/rescind/openattic/keyring
 %dir /srv/salt/ceph/restart
 %dir /srv/salt/ceph/restart/force
@@ -470,6 +470,7 @@ systemctl try-restart salt-api > /dev/null 2>&1 || :
 %config /srv/salt/ceph/configuration/files/*.conf
 %config /srv/salt/ceph/configuration/files/*.j2
 %config /srv/salt/ceph/configuration/files/deprecated_map.yml
+%config /srv/salt/ceph/configuration/files/drive_groups.yml
 %config(noreplace) %attr(-, salt, salt) /srv/salt/ceph/configuration/files/ceph.conf.import
 /srv/salt/ceph/configuration/files/ceph.conf.d/README
 %config /srv/salt/ceph/ganesha/*.sls

--- a/srv/modules/runners/disks.py
+++ b/srv/modules/runners/disks.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+""" This module will match disks based on applied filter rules
+
+Internally this will be called 'DriveGroups'
+"""
+
+from __future__ import absolute_import
+import logging
+import yaml
+import salt.client
+
+log = logging.getLogger(__name__)
+
+USAGE = """
+
+The disks runner is there to map the DriveGroup specification
+to actual disk representation and ceph-volume calls.
+
+It looks into your DriveGroup specs(/srv/salt/ceph/configuration/files/drive_groups.yml)
+For guidance and examples on how to structure that please look in the github wiki pages:
+https://github.com/SUSE/DeepSea/wiki/Drive-Groups
+
+Available Functions:
+
+## salt-run disks.list
+
+Gives you a list of drives that would match your DriveGroup specs.
+
+## salt-run disks.c_v_commands
+
+Gives you a list of commands that would be executed on the respective minions.
+
+## salt-run disks.report
+
+Gives you a detailed report about what the anticipated osd layout.
+
+## salt-run disks.deploy
+
+Will actually issue the commands generated from disks.d_v_commands.
+
+
+"""
+
+
+class NoTargetFound(Exception):
+    """ A critical error when no target is found for DriveGroup targeting
+    """
+    pass
+
+
+class NoFilterFound(Exception):
+    """ A critical error when no target is found for DriveGroup targeting
+    """
+    pass
+
+
+# pylint: disable=too-few-public-methods
+class DriveGroup(object):
+    """ The base class container for local_client and compound_target assignment
+    """
+
+    def __init__(self, drive_group_name, drive_group_values) -> None:
+        self.drive_group_name = drive_group_name
+        self.drive_group_values = drive_group_values
+
+    def target(self) -> str:
+        """ The 'target' key which the user identfies the OSD nodes
+
+        This will source the 'drive_group' pillar entry
+        and extract the 'target'
+
+        Salt tends to return all sorts of bulls^&%, hence the extensive
+        validation
+
+        :return: The target indentifying the osd nodes
+        :rtype: str
+        """
+
+        target: str = self.drive_group_values.get('target', '')
+
+        if target and isinstance(target, str):
+            return target
+        else:
+            raise NoTargetFound(
+                "Could not find a 'target' in the drive_group definition. "
+                "Please refer to the documentation")
+
+    def filter_args(self) -> dict:
+        """ The actual filter arguments"""
+        if self.drive_group_values and isinstance(self.drive_group_values,
+                                                  dict):
+            return self.drive_group_values
+        else:
+            raise NoFilterFound("Found not find a filter specification."
+                                "Please refer to the documentation")
+
+
+class DriveGroups(object):
+    """ A DriveGroup container class
+
+    self._data_devices = None
+    It resolves the 'target' from the drive_group spec and
+    feeds the 'target' one by one to the DriveGroup class.
+    This in turn filters all matching devices and returns
+    self._data_devices = None
+    matching disks based on the specified filters.
+    """
+
+    def __init__(self, **kwargs: dict) -> None:
+        self.local_client = salt.client.LocalClient()
+        self.dry_run: bool = kwargs.get('dry_run', False)
+        self.drive_groups_path: str = '/srv/salt/ceph/configuration/files/drive_groups.yml'
+        self.drive_groups: dict = self._get_drive_groups()
+
+    def _load_drive_group_file(self) -> str:
+        """ Load the drive_group file """
+        with open(self.drive_groups_path, 'r') as _fd:
+            return yaml.load(_fd)
+
+    def _get_drive_groups(self) -> dict:
+        """ Get the drive Group specs"""
+        ret = self._load_drive_group_file()
+        if not ret:
+            raise RuntimeError("Make sure to to populate {}.".format(
+                self.drive_groups_path))
+
+        if not isinstance(ret, dict):
+            raise RuntimeError("""DriveGroup is not in an expected structure.
+                Please consult the documentation.
+                Expected a dict - Got a {}""".format(type(ret)))
+
+        return ret
+
+    def call_out(self, command: str, alias: str = None) -> list:
+        """ Call minion modules to get matching disks"""
+        ret: list = list()
+        for dg_name, dg_values in self.drive_groups.items():
+            print("Found DriveGroup <{}>".format(dg_name))
+            dgo = DriveGroup(dg_name, dg_values)
+            ret.append(
+                self.call(
+                    dgo.target(), dgo.filter_args(), command, alias=alias))
+        # There is a __context__ variable which allow you to pass
+        # rcs and stuff to the orchestration
+        return ret
+
+    def call(self,
+             target: str,
+             filter_args: dict,
+             command: str,
+             alias: str = None):
+        """ Calls out to the minion"""
+        command_name: str = command
+        if alias:
+            command_name = alias
+        log.debug("Calling dg.{} on compound target {}".format(
+            command_name, target))
+        print("Calling dg.{} on compound target {}".format(
+            command_name, target))
+        ret: str = self.local_client.cmd(
+            target,
+            'dg.{}'.format(command),
+            kwarg={
+                'filter_args': filter_args,
+                'dry_run': self.dry_run
+            },
+            expr_form='compound')
+        return ret
+
+
+def list_(**kwargs):
+    """ List matching drives """
+    return DriveGroups(**kwargs).call_out('list_drives')
+
+
+def c_v_commands(**kwargs):
+    """ Return resulting ceph-volume command """
+    return DriveGroups(**kwargs).call_out('c_v_commands')
+
+
+def deploy(**kwargs):
+    """ Execute the ceph-volume command to deploy OSDs"""
+    return DriveGroups(**kwargs).call_out('deploy')
+
+
+def report(**kwargs):
+    """ Get the OSD deployment report """
+    kwargs.update({'dry_run': True})
+    return DriveGroups(**kwargs).call_out('deploy', alias='report')
+
+
+def help_():
+    """ Help/Usage class
+    """
+    print(USAGE)
+
+
+__func_alias__ = {
+    'help_': 'help',
+    'list_': 'list',
+}

--- a/srv/modules/runners/push.py
+++ b/srv/modules/runners/push.py
@@ -43,7 +43,7 @@ Customization:
     desired values in /srv/pillar/ceph/stack directory tree and likely
     unnecessary.  This will still work and may prove useful for some.
 
-All files are overwritten in the destination tree /srv/pillar/ceph/stack/default.
+All files are overwritten in the destination tree /srv/pillar/ceph/stack/default.sls
 
 """
 

--- a/srv/pillar/ceph/init.sls
+++ b/srv/pillar/ceph/init.sls
@@ -1,7 +1,4 @@
-
 {% include 'ceph/cluster/' + grains['id'] + '.sls' ignore missing %}
 
 {% include 'ceph/deepsea_minions.sls' ignore missing %}
 {% include 'ceph/blacklist.sls' ignore missing %}
-
-

--- a/srv/salt/_modules/dg.py
+++ b/srv/salt/_modules/dg.py
@@ -1,0 +1,822 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+""" This module will match disks based on applied filter rules
+
+Internally this will be called 'DriveGroups'
+"""
+
+from __future__ import absolute_import
+import json
+import re
+import logging
+from typing import Set, Tuple
+
+log = logging.getLogger(__name__)
+
+USAGE = """
+
+The (D)rive (G)roup module exists to filter for devices on the node
+based on the drive group specification received from the master.
+
+It mainly exposes three functions (They are not ment to be called manually)
+
+All function expect valid drive group specs as arguments.
+
+list_drives:
+
+This returns a dict() of matching drives.
+
+c_v_commands:
+
+Constructs valid ceph-volume calls based on the drive group specs and returns them
+
+deploy:
+
+A simple function that calls c_v_commands and executes it on the minion.
+
+
+"""
+
+
+class FilterNotSupported(Exception):
+    """ A critical error when the user specified filter is unsupported
+    """
+    pass
+
+
+class UnitNotSupported(Exception):
+    """ A critical error which encouters when a unit is parsed which
+    isn't supported.
+    """
+    pass
+
+
+class Filter(object):
+    """ Filter class to assign properties to bare filters.
+
+    This is a utility class that tries to simplify working
+    with information comming from a textfile/salt (drive_group.yaml)/(pillar)
+
+    """
+
+    def __init__(self, **kwargs):
+        self.name: str = str(kwargs.get('name', None))
+        self.matcher = kwargs.get('matcher', None)
+        self.value: str = str(kwargs.get('value', None))
+        self._assign_matchers()
+        log.debug("Initializing filter for {} with value {}".format(
+            self.name, self.value))
+
+    @property
+    def is_matchable(self) -> bool:
+        """ A property to indicate if a Filter has a matcher
+
+        Some filter i.e. 'limit' or 'osd_per_device' are valid filter
+        attributes but cannot be applied to a disk set. In this case
+        we return 'None'
+        :return: If a matcher is present True/Flase
+        :rtype: bool
+        """
+        return self.matcher is not None
+
+    def _assign_matchers(self) -> None:
+        """ Assign a matcher based on filter_name
+
+        This method assigns an individual Matcher based
+        on `self.name` and returns it.
+        """
+        if self.name == "size":
+            self.matcher = SizeMatcher(self.name, self.value)
+        elif self.name == "model":
+            self.matcher = SubstringMatcher(self.name, self.value)
+        elif self.name == "vendor":
+            self.matcher = SubstringMatcher(self.name, self.value)
+        elif self.name == "rotational":
+            self.matcher = EqualityMatcher(self.name, self.value)
+        elif self.name == "all":
+            self.matcher = AllMatcher(self.name, self.value)
+        else:
+            log.debug("No suitable matcher for {} could be found.")
+
+    def __repr__(self) -> str:
+        """ Visual representation of the filter
+        """
+        return 'Filter<{}>'.format(self.name)
+
+
+class Inventory():
+    """ The Inventory class
+
+    A container for the inventory call
+    This may be extended in the future, depending on our needs.
+    """
+
+    def __init__(self):
+        log.debug("Inventory init")
+
+    @property
+    def raw(self) -> str:
+        """ Raw data from a ceph-volume inventory call via salt
+        """
+        log.debug('Querying ceph-volume inventory')
+        return_code, stdout, stderr = __salt__['helper.run'](
+            "ceph-volume inventory --format json")
+        if return_code == 0:
+            return stdout
+        log.error('ceph-volume inventory --format json returned with {}'.
+                  format(return_code))
+        log.error(stderr)
+        log.error(stdout)
+        return '{}'
+
+    @property
+    def disks(self) -> list:
+        """ All disks found on the 'target'
+
+        Loads the json data from ceph-volume inventory
+        """
+        log.debug('Loading disks from inventory')
+        return json.loads(self.raw)
+
+
+# pylint: disable=too-few-public-methods
+class Matcher(object):
+    """ The base class to all Matchers
+
+    It holds utility methods such as _virtual, _get_disk_key
+    and handles the initialization.
+
+    """
+
+    def __init__(self, key: str, value: str) -> None:
+        """ Initialization of Base class
+
+        :param str key: Attribute like 'model, size or vendor'
+        :param str value: Value of attribute like 'X123, 5G or samsung'
+        """
+        self.key: str = key
+        self.value: str = value
+        self.fallback_key: str = ''
+        self.virtual: bool = self._virtual()
+
+    # pylint: disable=no-self-use
+    def _virtual(self) -> bool:
+        """ Detect if any of the hosts is virtual
+
+        In vagrant(libvirt) environments the 'model' flag is not set.
+        I assume this is flag is set everywhere else. However:
+
+        This can possibly lead to bugs since all our testing
+        runs on virtual environments. This is subject to be
+        moved/changed/removed
+        """
+        virtual: str = __grains__['virtual']
+        if virtual != "physical":
+            log.debug("I seem to be a VM")
+            return True
+        return False
+
+    # pylint: disable=inconsistent-return-statements
+    def _get_disk_key(self, disk: dict) -> str:
+        """ Helper method to safely extract values form the disk dict
+
+        There is a 'key' and a _optional_ 'fallback' key that can be used.
+        The reason for this is that the output of ceph-volume is not always
+        consistent (due to a bug currently, but you never know).
+        There is also a safety measure for a disk_key not existing on
+        virtual environments. ceph-volume apparently sources its information
+        from udev which seems to not populate certain fields on VMs.
+
+        :param dict disk: A disk representation
+        :raises: A generic Exception when no disk_key could be found.
+        :return: A disk value
+        :rtype: str
+        """
+        disk_value: str = disk.get(self.key, None)
+        if not disk_value and self.fallback_key:
+            disk_value = disk.get(self.fallback_key, None)
+        if disk_value:
+            return disk_value
+        if self.virtual:
+            log.info(
+                "Virtual-env detected. Not raising Exception on missing keys."
+                " {} and {} appear not to be present".format(
+                    self.key, self.fallback_key))
+            return ''
+        else:
+            raise Exception("No value found for {} or {}".format(
+                self.key, self.fallback_key))
+
+    def compare(self, disk: dict):
+        """ Implements a valid comparison method for a SubMatcher
+        This will get overwritten by the individual classes
+
+        :param dict disk: A disk representation
+        """
+        pass
+
+
+# pylint: disable=too-few-public-methods
+class SubstringMatcher(Matcher):
+    """ Substring matcher subclass
+    """
+
+    def __init__(self, key: str, value: str, fallback_key=None) -> None:
+        Matcher.__init__(self, key, value)
+        self.fallback_key = fallback_key
+
+    def compare(self, disk: dict) -> bool:
+        """ Overwritten method to match substrings
+
+        This matcher does substring matching
+        :param dict disk: A disk representation (see base for examples)
+        :return: True/False if the match succeeded
+        :rtype: bool
+        """
+        if not disk:
+            return False
+        disk_value: str = self._get_disk_key(disk)
+        if str(self.value) in str(disk_value):
+            return True
+        return False
+
+
+# pylint: disable=too-few-public-methods
+class AllMatcher(Matcher):
+    """ All matcher subclass
+    """
+
+    def __init__(self, key: str, value: str, fallback_key=None) -> None:
+        Matcher.__init__(self, key, value)
+        self.fallback_key = fallback_key
+
+    def compare(self, disk: dict) -> bool:
+        """ Overwritten method to match all
+
+        A rather dump matcher that just accepts all disks
+        (regardless of the value)
+        # note:
+            Should it be possible to set all: False ?
+            I don't think so.. We have limit for that
+        :param dict disk: A disk representation (see base for examples)
+        :return: always True
+        :rtype: bool
+        """
+        if not disk:
+            return False
+        return True
+
+
+# pylint: disable=too-few-public-methods
+class EqualityMatcher(Matcher):
+    """ Equality matcher subclass
+    """
+
+    def __init__(self, key: str, value: str) -> None:
+        Matcher.__init__(self, key, value)
+
+    def compare(self, disk: dict) -> bool:
+        """ Overwritten method to match equality
+
+        This matcher does value comparison
+        :param dict disk: A disk representation
+        :return: True/False if the match succeeded
+        :rtype: bool
+        """
+        if not disk:
+            return False
+        disk_value: str = self._get_disk_key(disk)
+        if int(disk_value) == int(self.value):
+            return True
+        return False
+
+
+class SizeMatcher(Matcher):
+    """ Size matcher subclass
+    """
+
+    # pylint: disable=too-many-instance-attributes
+    def __init__(self, key: str, value: str) -> None:
+        # The 'key' value is overwritten here because
+        # the user_defined attribute does not neccessarily
+        # correspond to the desired attribute
+        # requested from the inventory output
+        Matcher.__init__(self, key, value)
+        self.key: str = "human_readable_size"
+        self.fallback_key: str = "size"
+        self._high = None
+        self._high_suffix = None
+        self._low = None
+        self._low_suffix = None
+        self._exact = None
+        self._exact_suffix = None
+        self._parse_filter()
+
+    @property
+    def low(self) -> Tuple:
+        """ Getter for 'low' matchers
+        """
+        return self._low, self._low_suffix
+
+    @low.setter
+    def low(self, low: Tuple) -> None:
+        """ Setter for 'low' matchers
+        """
+        self._low, self._low_suffix = low
+
+    @property
+    def high(self) -> Tuple:
+        """ Getter for 'high' matchers
+        """
+        return self._high, self._high_suffix
+
+    @high.setter
+    def high(self, high: Tuple) -> None:
+        """ Setter for 'high' matchers
+        """
+        self._high, self._high_suffix = high
+
+    @property
+    def exact(self) -> Tuple:
+        """ Getter for 'exact' matchers
+        """
+        return self._exact, self._exact_suffix
+
+    @exact.setter
+    def exact(self, exact: Tuple) -> None:
+        """ Setter for 'exact' matchers
+        """
+        self._exact, self._exact_suffix = exact
+
+    @property
+    def supported_suffixes(self) -> list:
+        """ Only power of 10 notation is supported
+        """
+        return ["MB", "GB", "TB", "M", "G", "T"]
+
+    def _normalize_suffix(self, suffix: str) -> str:
+        """ Normalize any supported suffix
+
+        Since the Drive Groups are user facing, we simply
+        can't make sure that all users type in the requested
+        form. That's why we have to internally agree on one format.
+        It also checks if any of the supported suffixes was used
+        and raises an Exception otherwise.
+
+        :param str suffix: A suffix ('G') or ('M')
+        :return: A normalized output
+        :rtype: str
+        """
+        if suffix not in self.supported_suffixes:
+            raise UnitNotSupported("Unit '{}' not supported".format(suffix))
+        if suffix == "G":
+            return "GB"
+        if suffix == "T":
+            return "TB"
+        if suffix == "M":
+            return "MB"
+        return suffix
+
+    def _parse_suffix(self, obj: str) -> str:
+        """ Wrapper method to find and normalize a prefix
+
+        :param str obj: A size filtering string ('10G')
+        :return: A normalized unit ('GB')
+        :rtype: str
+        """
+        return self._normalize_suffix(re.findall(r"[a-zA-Z]+", obj)[0])
+
+    def _get_k_v(self, data: str) -> Tuple:
+        """ Helper method to extract data from a string
+
+        It uses regex to extract all digits and calls _parse_suffix
+        which also uses a regex to extract all letters and normalizes
+        the resulting suffix.
+
+        :param str data: A size filtering string ('10G')
+        :return: A Tuple with normalized output (10, 'GB')
+        :rtype: tuple
+        """
+        return (re.findall(r"\d+", data)[0], self._parse_suffix(data))
+
+    def _parse_filter(self):
+        """ Identifies which type of 'size' filter is applied
+
+        There are four different filtering modes:
+
+        1) 10G:50G (high-low)
+           At least 10G but at max 50G of size
+
+        2) :60G
+           At max 60G of size
+
+        3) 50G:
+           At least 50G of size
+
+        4) 20G
+           Exactly 20G in size
+
+        This method uses regex to identify and extract this information
+        and raises if none could be found.
+        """
+        low_high = re.match(r"\d+[A-Z]{1,2}:\d+[A-Z]{1,2}", self.value)
+        if low_high:
+            low, high = low_high.group().split(":")
+            self.low = self._get_k_v(low)
+            self.high = self._get_k_v(high)
+
+        low = re.match(r"\d+[A-Z]{1,2}:$", self.value)
+        if low:
+            self.low = self._get_k_v(low.group())
+
+        high = re.match(r"^:\d+[A-Z]{1,2}", self.value)
+        if high:
+            self.high = self._get_k_v(high.group())
+
+        exact = re.match(r"^\d+[A-Z]{1,2}$", self.value)
+        if exact:
+            self.exact = self._get_k_v(exact.group())
+
+        if not self.low and not self.high and not self.exact:
+            raise Exception("Couldn't parse {}".format(self.value))
+
+    @staticmethod
+    # pylint: disable=inconsistent-return-statements
+    def to_byte(tpl: Tuple) -> float:
+        """ Convert any supported unit to bytes
+
+        :param tuple tpl: A tuple with ('10', 'GB')
+        :return: The converted byte value
+        :rtype: float
+        """
+        value = float(tpl[0])
+        suffix = tpl[1]
+        if suffix == "MB":
+            return value * 1e+6
+        elif suffix == "GB":
+            return value * 1e+9
+        elif suffix == "TB":
+            return value * 1e+12
+        # checkers force me to return something, although
+        # it's not quite good to return something here.. ignore?
+        return 0.00
+
+    # pylint: disable=inconsistent-return-statements
+    def compare(self, disk: dict) -> bool:
+        """ Convert MB/GB/TB down to bytes and compare
+
+        1) Extracts information from the to-be-inspected disk.
+        2) Depending on the mode, apply checks and return
+
+        # This doesn't seem very solid and _may_
+        be re-factored
+
+
+        """
+        if not disk:
+            return False
+        disk_value = self._get_disk_key(disk)
+        # This doesn't neccessarily have to be a float.
+        # The current output from ceph-volume gives a float..
+        # This may change in the future..
+        # todo: harden this paragraph
+        disk_size = float(re.findall(r"\d+\.\d+", disk_value)[0])
+        disk_suffix = self._parse_suffix(disk_value)
+        disk_size_in_byte = self.to_byte((disk_size, disk_suffix))
+
+        if all(self.high) and all(self.low):
+            if disk_size_in_byte <= self.to_byte(
+                    self.high) and disk_size_in_byte >= self.to_byte(self.low):
+                return True
+            # is a else: return False neccessary here?
+            # (and in all other branches)
+            log.debug("Disk didn't match for 'high/low' filter")
+
+        elif all(self.low) and not all(self.high):
+            if disk_size_in_byte >= self.to_byte(self.low):
+                return True
+            log.debug("Disk didn't match for 'low' filter")
+
+        elif all(self.high) and not all(self.low):
+            if disk_size_in_byte <= self.to_byte(self.high):
+                return True
+            log.debug("Disk didn't match for 'high' filter")
+
+        elif all(self.exact):
+            if disk_size_in_byte == self.to_byte(self.exact):
+                return True
+            log.debug("Disk didn't match for 'exact' filter")
+        else:
+            log.debug("Neither high, low, nor exact was given")
+            raise Exception("No filters applied")
+        return False
+
+
+class DriveGroup(object):
+    """ The Drive-Group class
+
+    Targets one node and applies filters on the node's inventory.
+    It mainly exposes:
+
+    `data_devices`
+    `wal_devices`
+    `db_devices`
+    """
+
+    # pylint: disable=too-many-instance-attributes
+    def __init__(self, filter_args: dict) -> None:
+        self.filter_args: dict = filter_args
+        self._check_filter_support()
+        self._data_devices = None
+        self._wal_devices = None
+        self._db_devices = None
+
+    @property
+    def db_slots(self) -> dict:
+        """ Property of db_slots
+
+        db_slots are essentially ratio indicators
+        :return: The value of db_slots
+        :rtype: dict
+        """
+        return self.filter_args.get("db_slots", False)
+
+    @property
+    def wal_slots(self) -> dict:
+        """ Property of wal_slots
+
+        wal_slots are essentially ratio indicators
+        """
+        return self.filter_args.get("wal_slots", False)
+
+    @property
+    def encryption(self) -> dict:
+        """ Property of encryption
+
+        True/Flase if encryption is enabled
+        """
+        return self.filter_args.get("encryption", False)
+
+    @property
+    def data_device_attrs(self) -> dict:
+        """ Data Device attributes
+        """
+        return self.filter_args.get("data_devices", dict())
+
+    @property
+    def db_device_attrs(self) -> dict:
+        """ Db Device attributes
+        """
+        return self.filter_args.get("db_devices", dict())
+
+    @property
+    def wal_device_attrs(self) -> dict:
+        """ Wal Device attributes
+        """
+        return self.filter_args.get("wal_devices", dict())
+
+    @property
+    def limit(self) -> int:
+        """ Limits the amount of devices assigned
+
+        Limit 0 -> unlimited
+        """
+        return self.data_device_attrs.get("limit", 0)
+
+    @property
+    def inventory(self) -> dict:
+        """
+        Disks found in the inventory
+        """
+        return Inventory().disks
+
+    @property
+    def data_devices(self) -> list:
+        """ Filter for (bluestore) DATA devices
+        """
+        log.debug("Scanning for data devices")
+        return self._filter_devices(self.data_device_attrs)
+
+    @property
+    def wal_devices(self) -> list:
+        """ Filter for bluestore WAL devices
+        """
+        log.debug("Scanning for WAL devices")
+        return self._filter_devices(self.wal_device_attrs)
+
+    @property
+    def db_devices(self) -> list:
+        """ Filter for bluestore DB devices
+        """
+        log.debug("Scanning for db devices")
+        return self._filter_devices(self.db_device_attrs)
+
+    def _limit_reached(self, len_devices: int, disk_path: str) -> bool:
+        """ Check for the <limit> property and apply logic
+
+        If a limit is set in 'device_attrs' we have to stop adding
+        disks at some point.
+
+        If limit is set (>0) and len(devices) >= limit
+
+        :param int len_devices: Length of the already populated device set/list
+        :param str disk_path: The disk identifier (for logging purposes)
+        :return: True/False if the device should be added to the list of devices
+        :rtype: bool
+        """
+        if self.limit > 0 and len_devices >= self.limit:
+            log.info("Refuse to add {} due to limit policy of {}>".format(
+                disk_path, self.limit))
+            return True
+        return False
+
+    def _filter_devices(self, device_filter: dict) -> list:
+        """ Filters devices with applied filters
+
+        Iterates over all applied filter (there can be multiple):
+
+        size: 10G:50G
+        model: Fujitsu
+        rotational: 1
+
+        Question: ##############################
+        This currently acts as a OR gate. Should this be a AND gate?
+        Question: #############################
+
+        Iterates over all known disk and checks
+        for matches by using the matcher subclasses.
+
+        :param dict device_filter: Device filter as in description above
+        :return: Set of devices that matched the filter
+        :rtype set:
+        """
+        devices: Set = set()
+        for name, val in device_filter.items():
+            _filter = Filter(name=name, value=val)
+            for disk in self.inventory:
+                # continue criterias
+                if not _filter.is_matchable:
+                    continue
+
+                if not _filter.matcher.compare(self._reduce_inventory(disk)):
+                    continue
+
+                if not self._has_mandatory_idents(disk):
+                    continue
+
+                if self._limit_reached(len(devices), disk.get('path')):
+                    continue
+
+                devices.add(disk.get("path"))
+
+        # sorted() returns a sorted list by the cost of losing the <set>
+        return sorted(devices)
+
+    @staticmethod
+    def _has_mandatory_idents(disk: dict) -> bool:
+        """ Check for mandatory indentification fields
+        """
+        if disk.get("path", None):
+            log.debug("Found matching disk: {}".format(disk.get("path")))
+            return True
+        else:
+            raise Exception(
+                "Disk {} doesn't have a 'path' identifier".format(disk))
+
+    @property
+    def _supported_filters(self) -> list:
+        """ List of supported filters
+        """
+        return [
+            "size", "vendor", "model", "rotational", "limit",
+            "osds_per_device", "all"
+        ]
+
+    def _check_filter_support(self) -> None:
+        """ Iterates over attrs to check support
+        """
+        for attr in [
+                self.data_device_attrs,
+                self.wal_device_attrs,
+                self.db_device_attrs,
+        ]:
+            self._check_filter(attr)
+
+    def _check_filter(self, attr: dict) -> None:
+        """ Check if the used filters are supported
+
+        :param dict attr: A dict of filters
+        :raises: FilterNotSupported if not supported
+        :return: None
+        """
+        for applied_filter in list(attr.keys()):
+            if applied_filter not in self._supported_filters:
+                raise FilterNotSupported(
+                    "Filtering for {} is not supported".format(applied_filter))
+
+    @staticmethod
+    # pylint: disable=inconsistent-return-statements
+    def _reduce_inventory(disk: dict) -> dict:
+        """ Wrapper to validate 'ceph-volume inventory' output
+        """
+        # Temp disable this check, only for testing purposes
+        # maybe this check doesn't need to be here as ceph-volume
+        # does this check aswell..
+        # This also mostly exists due to:
+        # https://github.com/ceph/ceph/pull/25390
+        # maybe this can and should be dropped when the fix is public
+        if not disk:
+            return {}
+        if disk["available"] is True:
+            try:
+                reduced_disk = {"path": disk.get("path")}
+
+                reduced_disk["size"] = disk.get("sys_api", {}).get(
+                    "human_readable_size", "")
+                reduced_disk["vendor"] = disk.get("sys_api", {}).get(
+                    "vendor", "")
+                reduced_disk["bare_size"] = disk.get("sys_api", {}).get(
+                    "size", "")
+                reduced_disk["model"] = disk.get("sys_api", {}).get(
+                    "model", "")
+                reduced_disk["rotational"] = disk.get("sys_api", {}).get(
+                    "rotational", "")
+
+                return reduced_disk
+            except KeyError("Could not retrieve mandatory key from disk spec"):
+                raise
+
+
+def list_drives(**kwargs):
+    """
+    A public method that returns a dict
+    of matching disks
+    """
+    filter_args = kwargs.get('filter_args', dict())
+    if not filter_args:
+        Exception("No filter_args provided")
+    dgo = DriveGroup(filter_args)
+    return dict(
+        data_devices=dgo.data_devices,
+        wal_devices=dgo.wal_devices,
+        db_devices=dgo.db_devices)
+
+
+def c_v_commands(**kwargs):
+    """
+    Construct the ceph-volume command based on the
+    matching disks
+    """
+    filter_args = kwargs.get('filter_args', dict())
+    if not filter_args:
+        Exception("No filter_args provided")
+    dgo = DriveGroup(filter_args)
+    log.debug("Received call for ceph-volume command generation")
+    log.error(kwargs)
+    if not dgo.data_devices:
+        return ""
+    cmd = "ceph-volume lvm batch {}".format(' '.join(dgo.data_devices))
+
+    # Compute difference between two lists
+
+    # This validation should belong to ceph-volume
+    # and will evetually end up there:
+    # trackerbug: http://tracker.ceph.com/issues/38473
+
+    extra_db_devices = [
+        x for x in set(dgo.db_devices) if x not in set(dgo.wal_devices)
+    ]
+
+    if dgo.wal_devices and dgo.db_devices:
+        cmd += " --wal-devices {}".format(' '.join(dgo.wal_devices))
+        if extra_db_devices:
+            log.info(
+                "wal and db are same except for {}".format(extra_db_devices))
+            cmd += "--db-devices {}".format(' '.join(extra_db_devices))
+    elif dgo.wal_devices and not dgo.db_devices:
+        cmd += " --wal-devices {}".format(' '.join(dgo.wal_devices))
+    elif dgo.db_devices and not dgo.wal_devices:
+        cmd += " --db-devices {}".format(' '.join(dgo.db_devices))
+    else:
+        log.info("Neither wal nor db devices are specified")
+    if kwargs.get('dry_run', False):
+        cmd += " --report"
+    else:
+        cmd += " --yes"
+    return cmd
+
+
+def deploy(**kwargs):
+    """ Execute the generated ceph-volume commands """
+    return __salt__['helper.run'](c_v_commands(**kwargs))
+
+
+def _help():
+    """ Help/Usage class
+    """
+    print(USAGE)
+
+
+__func_alias__ = {
+    'help_': 'help',
+}

--- a/srv/salt/ceph/configuration/files/drive_groups.yml
+++ b/srv/salt/ceph/configuration/files/drive_groups.yml
@@ -1,0 +1,19 @@
+# default:
+#   target: 'data*'
+#   data_devices:
+#     size: 20G
+#   wal_devices:
+#     size: 10G
+#     rotational: 1
+# allflash:
+#   target: 'fast_nodes*'
+#   data_devices:
+#     size: 100G
+#   wal_devices:
+#     size: 50G
+#     rotational: 0
+
+default:
+  target: '*'
+  data_devices:
+    all: true

--- a/srv/salt/ceph/stage/deploy/core/default.sls
+++ b/srv/salt/ceph/stage/deploy/core/default.sls
@@ -1,4 +1,3 @@
-
 {% set master = salt['master.minion']() %}
 
 {% set FAIL_ON_WARNING = salt['pillar.get']('FAIL_ON_WARNING', 'True') %}
@@ -135,18 +134,16 @@ sysctl:
     - sls: ceph.sysctl
     - failhard: True
 
-storage:
+set osd keyrings:
   salt.state:
     - tgt: 'I@roles:storage and I@cluster:ceph'
     - tgt_type: compound
-    - sls: ceph.osd
+    - sls: ceph.osd.keyring
     - failhard: True
 
-grains:
-  salt.state:
-    - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
-    - tgt_type: compound
-    - sls: ceph.osd.grains
+deploy osds:
+  salt.runner:
+    - name: disks.deploy
     - failhard: True
 
 mgr tuned:

--- a/tests/unit/_modules/test_dg.py
+++ b/tests/unit/_modules/test_dg.py
@@ -1,0 +1,804 @@
+import pytest
+from mock import patch, call, Mock, PropertyMock
+from srv.salt._modules import dg
+
+
+class TestInventory(object):
+    """ Test Inventory container class
+    """
+
+    def test_inventory_raw(self):
+        """ Check if c-v inv gets called
+        """
+        dg.__salt__ = {}
+        dg.__salt__['helper.run'] = Mock()
+        dg.__salt__['helper.run'].return_value = (1, "out", "err")
+        dg.Inventory().raw
+        call1 = call("ceph-volume inventory --format json")
+        assert call1 in dg.__salt__['helper.run'].call_args_list
+
+
+class TestMatcher(object):
+    """ Test Matcher base class
+    """
+
+    @patch(
+        "srv.salt._modules.dg.Matcher._virtual",
+        autospec=True,
+        return_value=True)
+    def test_get_disk_key_1(self, whatthefuck):
+        """
+        virtual is True
+        key is found
+        return value of key is expected
+        """
+        disk_map = dict(path='/dev/vdb', foo='bar')
+        ret = dg.Matcher('foo', 'bar')._get_disk_key(disk_map)
+        assert ret == disk_map.get('foo')
+
+    @patch("srv.salt._modules.dg.Matcher._virtual", autospec=True)
+    def test_get_disk_key_2(self, virtual_mock):
+        """
+        virtual is True
+        key is not found
+        retrun False is expected
+        """
+        virtual_mock.return_value = True
+        disk_map = dict(path='/dev/vdb')
+        ret = dg.Matcher('bar', 'foo')._get_disk_key(disk_map)
+        assert ret is ''
+
+    @patch("srv.salt._modules.dg.Matcher._virtual", autospec=True)
+    def test_get_disk_key_3(self, virtual_mock):
+        """
+        virtual is False
+        key is found
+        retrun value of key is expected
+        """
+        virtual_mock.return_value = False
+        disk_map = dict(path='/dev/vdb', foo='bar')
+        ret = dg.Matcher('foo', 'bar')._get_disk_key(disk_map)
+        assert ret is disk_map.get('foo')
+
+    @patch("srv.salt._modules.dg.Matcher._virtual", autospec=True)
+    def test_get_disk_key_4(self, virtual_mock):
+        """
+        virtual is False
+        key is not found
+        expect raise Exception
+        """
+        virtual_mock.return_value = False
+        disk_map = dict(path='/dev/vdb')
+        with pytest.raises(
+                Exception, message="No disk_key found for foo or None"):
+            dg.Matcher('bar', 'foo')._get_disk_key(disk_map)
+
+    def test_virtual(self):
+        """ Test if virtual
+        """
+        dg.__grains__ = {'virtual': 'kvm'}
+        obj = dg.Matcher(None, None)
+        obj.virtual is True
+
+    def test_virtual_1(self):
+        """ all hosts are physical
+        """
+        dg.__grains__ = {'virtual': 'pysical'}
+        obj = dg.Matcher(None, None)
+        obj.virtual is False
+
+
+class TestSubstringMatcher(object):
+    @patch("srv.salt._modules.dg.Matcher._virtual", autospec=True)
+    def test_compare(self, virtual_mock):
+        virtual_mock.return_value = False
+        disk_dict = dict(path='/dev/vdb', model='samsung')
+        matcher = dg.SubstringMatcher('model', 'samsung')
+        ret = matcher.compare(disk_dict)
+        assert ret is True
+
+    @patch("srv.salt._modules.dg.Matcher._virtual", autospec=True)
+    def test_compare_false(self, virtual_mock):
+        virtual_mock.return_value = False
+        disk_dict = dict(path='/dev/vdb', model='nothing_matching')
+        matcher = dg.SubstringMatcher('model', 'samsung')
+        ret = matcher.compare(disk_dict)
+        assert ret is False
+
+
+class TestEqualityMatcher(object):
+    @patch("srv.salt._modules.dg.Matcher._virtual", autospec=True)
+    def test_compare(self, virtual_mock):
+        virtual_mock.return_value = False
+        disk_dict = dict(path='/dev/vdb', rotates='1')
+        matcher = dg.EqualityMatcher('rotates', '1')
+        ret = matcher.compare(disk_dict)
+        assert ret is True
+
+    @patch("srv.salt._modules.dg.Matcher._virtual", autospec=True)
+    def test_compare_false(self, virtual_mock):
+        virtual_mock.return_value = False
+        disk_dict = dict(path='/dev/vdb', rotates='1')
+        matcher = dg.EqualityMatcher('rotates', '0')
+        ret = matcher.compare(disk_dict)
+        assert ret is False
+
+
+class TestAllMatcher(object):
+    @patch("srv.salt._modules.dg.Matcher._virtual", autospec=True)
+    def test_compare(self, virtual_mock):
+        virtual_mock.return_value = False
+        disk_dict = dict(path='/dev/vdb')
+        matcher = dg.AllMatcher('all', 'True')
+        ret = matcher.compare(disk_dict)
+        assert ret is True
+
+    @patch("srv.salt._modules.dg.Matcher._virtual", autospec=True)
+    def test_compare_value_not_true(self, virtual_mock):
+        virtual_mock.return_value = False
+        disk_dict = dict(path='/dev/vdb')
+        matcher = dg.AllMatcher('all', 'False')
+        ret = matcher.compare(disk_dict)
+        assert ret is True
+
+
+class TestSizeMatcher(object):
+    @patch("srv.salt._modules.dg.Matcher._virtual", autospec=True)
+    def test_parse_filter_exact(self, virtual_mock):
+        """ Testing exact notation with 20G """
+        virtual_mock.return_value = False
+        matcher = dg.SizeMatcher('size', '20G')
+        assert isinstance(matcher.exact, tuple)
+        assert matcher.exact[0] == '20'
+        assert matcher.exact[1] == 'GB'
+
+    @patch("srv.salt._modules.dg.Matcher._virtual", autospec=True)
+    def test_parse_filter_exact_GB_G(self, virtual_mock):
+        """ Testing exact notation with 20G """
+        virtual_mock.return_value = False
+        matcher = dg.SizeMatcher('size', '20GB')
+        assert isinstance(matcher.exact, tuple)
+        assert matcher.exact[0] == '20'
+        assert matcher.exact[1] == 'GB'
+
+    @patch("srv.salt._modules.dg.Matcher._virtual", autospec=True)
+    def test_parse_filter_high_low(self, virtual_mock):
+        """ Testing high-low notation with 20G:50G """
+        virtual_mock.return_value = False
+        matcher = dg.SizeMatcher('size', '20G:50G')
+        assert isinstance(matcher.exact, tuple)
+        assert matcher.low[0] == '20'
+        assert matcher.high[0] == '50'
+        assert matcher.low[1] == 'GB'
+        assert matcher.high[1] == 'GB'
+
+    @patch("srv.salt._modules.dg.Matcher._virtual", autospec=True)
+    def test_parse_filter_max_high(self, virtual_mock):
+        """ Testing high notation with :50G """
+        virtual_mock.return_value = False
+        matcher = dg.SizeMatcher('size', ':50G')
+        assert isinstance(matcher.exact, tuple)
+        assert matcher.high[0] == '50'
+        assert matcher.high[1] == 'GB'
+
+    @patch("srv.salt._modules.dg.Matcher._virtual", autospec=True)
+    def test_parse_filter_min_low(self, virtual_mock):
+        """ Testing low notation with 20G: """
+        virtual_mock.return_value = False
+        matcher = dg.SizeMatcher('size', '50G:')
+        assert isinstance(matcher.exact, tuple)
+        assert matcher.low[0] == '50'
+        assert matcher.low[1] == 'GB'
+
+    @patch("srv.salt._modules.dg.Matcher._virtual", autospec=True)
+    def test_to_byte_GB(self, virtual_mock):
+        """ Pretty nonesense test.."""
+        virtual_mock.return_value = False
+        ret = dg.SizeMatcher('size', '10G').to_byte(('10', 'GB'))
+        assert ret == 10 * 1e+9
+
+    @patch("srv.salt._modules.dg.Matcher._virtual", autospec=True)
+    def test_to_byte_MB(self, virtual_mock):
+        """ Pretty nonesense test.."""
+        virtual_mock.return_value = False
+        ret = dg.SizeMatcher('size', '10M').to_byte(('10', 'MB'))
+        assert ret == 10 * 1e+6
+
+    @patch("srv.salt._modules.dg.Matcher._virtual", autospec=True)
+    def test_to_byte_TB(self, virtual_mock):
+        """ Pretty nonesense test.."""
+        virtual_mock.return_value = False
+        ret = dg.SizeMatcher('size', '10T').to_byte(('10', 'TB'))
+        assert ret == 10 * 1e+12
+
+    @patch("srv.salt._modules.dg.Matcher._virtual", autospec=True)
+    def test_to_byte_PB(self, virtual_mock):
+        """ Expect to raise """
+        virtual_mock.return_value = False
+        with pytest.raises(dg.UnitNotSupported):
+            dg.SizeMatcher('size', '10P').to_byte(('10', 'PB'))
+        assert 'Unit \'P\' is not supported'
+
+    @patch("srv.salt._modules.dg.Matcher._virtual", autospec=True)
+    def test_compare_exact(self, virtual_mock):
+        virtual_mock.return_value = False
+        matcher = dg.SizeMatcher('size', '20GB')
+        disk_dict = dict(path='/dev/vdb', size='20.00 GB')
+        ret = matcher.compare(disk_dict)
+        assert ret is True
+
+    @pytest.mark.parametrize("test_input,expected", [
+        ("1.00 GB", False),
+        ("20.00 GB", True),
+        ("50.00 GB", True),
+        ("100.00 GB", True),
+        ("101.00 GB", False),
+        ("1101.00 GB", False),
+    ])
+    @patch("srv.salt._modules.dg.Matcher._virtual", autospec=True)
+    def test_compare_high_low(self, virtual_mock, test_input, expected):
+        virtual_mock.return_value = False
+        matcher = dg.SizeMatcher('size', '20GB:100GB')
+        disk_dict = dict(path='/dev/vdb', size=test_input)
+        ret = matcher.compare(disk_dict)
+        assert ret is expected
+
+    @pytest.mark.parametrize("test_input,expected", [
+        ("1.00 GB", True),
+        ("20.00 GB", True),
+        ("50.00 GB", True),
+        ("100.00 GB", False),
+        ("101.00 GB", False),
+        ("1101.00 GB", False),
+    ])
+    @patch("srv.salt._modules.dg.Matcher._virtual", autospec=True)
+    def test_compare_high(self, virtual_mock, test_input, expected):
+        virtual_mock.return_value = False
+        matcher = dg.SizeMatcher('size', ':50GB')
+        disk_dict = dict(path='/dev/vdb', size=test_input)
+        ret = matcher.compare(disk_dict)
+        assert ret is expected
+
+    @pytest.mark.parametrize("test_input,expected", [
+        ("1.00 GB", False),
+        ("20.00 GB", False),
+        ("50.00 GB", True),
+        ("100.00 GB", True),
+        ("101.00 GB", True),
+        ("1101.00 GB", True),
+    ])
+    @patch("srv.salt._modules.dg.Matcher._virtual", autospec=True)
+    def test_compare_low(self, virtual_mock, test_input, expected):
+        virtual_mock.return_value = False
+        matcher = dg.SizeMatcher('size', '50GB:')
+        disk_dict = dict(path='/dev/vdb', size=test_input)
+        ret = matcher.compare(disk_dict)
+        assert ret is expected
+
+    @patch("srv.salt._modules.dg.Matcher._virtual", autospec=True)
+    def test_compare_raise(self, virtual_mock):
+        virtual_mock.return_value = False
+        matcher = dg.SizeMatcher('size', 'None')
+        disk_dict = dict(path='/dev/vdb', size='20.00 GB')
+        with pytest.raises(Exception, message="Couldn't parse size"):
+            matcher.compare(disk_dict)
+
+    @pytest.mark.parametrize("test_input,expected", [
+        ("10G", ('10', 'GB')),
+        ("20GB", ('20', 'GB')),
+    ])
+    @patch("srv.salt._modules.dg.Matcher._virtual", autospec=True)
+    def test_get_k_v(self, virtual_mock, test_input, expected):
+        virtual_mock.return_value = False
+        assert dg.SizeMatcher('size', '10G')._get_k_v(test_input) == expected
+
+    @pytest.mark.parametrize("test_input,expected", [
+        ("10G", ('GB')),
+        ("20GB", ('GB')),
+        ("20TB", ('TB')),
+        ("20T", ('TB')),
+        ("20MB", ('MB')),
+        ("20M", ('MB')),
+    ])
+    @patch("srv.salt._modules.dg.Matcher._virtual", autospec=True)
+    def test_parse_suffix(self, virtual_mock, test_input, expected):
+        virtual_mock.return_value = False
+        assert dg.SizeMatcher('size',
+                              '10G')._parse_suffix(test_input) == expected
+
+    @pytest.mark.parametrize("test_input,expected", [
+        ("G", 'GB'),
+        ("GB", 'GB'),
+        ("TB", 'TB'),
+        ("T", 'TB'),
+        ("MB", 'MB'),
+        ("M", 'MB'),
+    ])
+    @patch("srv.salt._modules.dg.Matcher._virtual", autospec=True)
+    def test_normalize_suffix(self, virtual_mock, test_input, expected):
+        virtual_mock.return_value = False
+        assert dg.SizeMatcher('10G',
+                              'size')._normalize_suffix(test_input) == expected
+
+    @patch("srv.salt._modules.dg.Matcher._virtual", autospec=True)
+    def test_normalize_suffix_raises(self, virtual_mock):
+        virtual_mock.return_value = False
+        with pytest.raises(
+                dg.UnitNotSupported, message="Unit 'P' not supported"):
+            dg.SizeMatcher('10P', 'size')._normalize_suffix("P")
+
+
+class TestDriveGroup(object):
+    @pytest.fixture(scope='class')
+    def test_fix(self, empty=None):
+        def make_sample_data(empty=empty, limit=0):
+            raw_sample = {
+                'target': 'data*',
+                'data_devices': {
+                    'size': '10G:29G',
+                    'model': 'foo',
+                    'vendor': '1x',
+                    'limit': limit
+                },
+                'wal_devices': {
+                    'model': 'fast'
+                },
+                'db_devices': {
+                    'size': ':10G'
+                },
+                'db_slots': 5,
+                'wal_slots': 5,
+                'objectstore': 'bluestore',
+                'encryption': True,
+            }
+            if empty:
+                raw_sample = {}
+
+            self.check_filter_support = patch(
+                'srv.salt._modules.dg.DriveGroup._check_filter_support',
+                new_callable=Mock,
+                return_value=True)
+
+            self.check_filter_support.start()
+
+            dgo = dg.DriveGroup(raw_sample)
+            return dgo
+
+            self.check_filter_support.stop()
+
+        return make_sample_data
+
+    def test_encryption_prop(self, test_fix):
+        test_fix = test_fix()
+        assert test_fix.encryption is True
+
+    def test_encryption_prop_empty(self, test_fix):
+        test_fix = test_fix(empty=True)
+        assert test_fix.encryption is False
+
+    def test_db_slots_prop(self, test_fix):
+        test_fix = test_fix()
+        assert test_fix.db_slots is 5
+
+    def test_db_slots_prop_empty(self, test_fix):
+        test_fix = test_fix(empty=True)
+        assert test_fix.db_slots is False
+
+    def test_wal_slots_prop(self, test_fix):
+        test_fix = test_fix()
+        assert test_fix.wal_slots is 5
+
+    def test_wal_slots_prop_empty(self, test_fix):
+        test_fix = test_fix(empty=True)
+        assert test_fix.wal_slots is False
+
+    def test_data_devices_prop(self, test_fix):
+        test_fix = test_fix()
+        assert test_fix.data_device_attrs == {
+            'model': 'foo',
+            'size': '10G:29G',
+            'vendor': '1x',
+            'limit': 0
+        }
+
+    def test_data_devices_prop_empty(self, test_fix):
+        test_fix = test_fix(empty=True)
+        assert test_fix.data_device_attrs == {}
+
+    def test_db_devices_prop(self, test_fix):
+        test_fix = test_fix()
+        assert test_fix.db_device_attrs == {
+            'size': ':10G',
+        }
+
+    def test_db_devices_prop_empty(self, test_fix):
+        test_fix = test_fix(empty=True)
+        assert test_fix.db_device_attrs == {}
+
+    def test_wal_device_prop(self, test_fix):
+        test_fix = test_fix()
+        assert test_fix.wal_device_attrs == {
+            'model': 'fast',
+        }
+
+    def test_wal_device_prop_empty(self, test_fix):
+        test_fix = test_fix(empty=True)
+        assert test_fix.wal_device_attrs == {}
+
+    @patch(
+        'srv.salt._modules.dg.DriveGroup._filter_devices', new_callable=Mock)
+    def test_db_devices(self, filter_mock, test_fix):
+        test_fix = test_fix()
+        test_fix.data_devices
+        filter_mock.assert_called_once_with({
+            'size': '10G:29G',
+            'model': 'foo',
+            'vendor': '1x'
+        })
+
+    @patch(
+        'srv.salt._modules.dg.DriveGroup._filter_devices', new_callable=Mock)
+    def test_wal_devices(self, filter_mock, test_fix):
+        test_fix = test_fix()
+        test_fix.wal_devices
+        filter_mock.assert_called_once_with({'model': 'fast'})
+
+    @patch(
+        'srv.salt._modules.dg.DriveGroup._filter_devices', new_callable=Mock)
+    def test_db_devices(self, filter_mock, test_fix):
+        test_fix = test_fix()
+        test_fix.db_devices
+        filter_mock.assert_called_once_with({'size': ':10G'})
+
+    @pytest.fixture
+    def inventory(self, available=True):
+        def make_sample_data(available=available):
+            inventory_sample = [
+                {
+                    'available': available,
+                    'lvs': [],
+                    'path': '/dev/vda',
+                    'rejected_reasons': ['locked'],
+                    'sys_api': {
+                        'human_readable_size': '10.00 GB',
+                        'locked': 1,
+                        'model': 'modelA',
+                        'nr_requests': '256',
+                        'partitions': {
+                            'vda1': {
+                                'sectors': '41940992',
+                                'sectorsize': 512,
+                                'size': '10.00 GB',
+                                'start': '2048'
+                            }
+                        },
+                        'path': '/dev/vda',
+                        'removable': '0',
+                        'rev': '',
+                        'ro': '0',
+                        'rotational': '1',
+                        'sas_address': '',
+                        'sas_device_handle': '',
+                        'scheduler_mode': 'mq-deadline',
+                        'sectors': 0,
+                        'sectorsize': '512',
+                        'size': 10474836480.0,
+                        'support_discard': '',
+                        'vendor': 'samsung'
+                    }
+                },
+                {
+                    'available':
+                    available,
+                    'lvs': [{
+                        'block_uuid':
+                        'EbnVK1-chW6-NfEA-0RY4-dWjo-0AeL-b1V9hv',
+                        'cluster_fsid':
+                        'b9f1174e-fc02-4142-8816-172f20573c13',
+                        'cluster_name':
+                        'ceph',
+                        'name':
+                        'osd-block-d8a50e9b-2ea3-43a8-9617-2edccfee0c28',
+                        'osd_fsid':
+                        'd8a50e9b-2ea3-43a8-9617-2edccfee0c28',
+                        'osd_id':
+                        '0',
+                        'type':
+                        'block'
+                    }],
+                    'path':
+                    '/dev/vdb',
+                    'rejected_reasons': ['locked'],
+                    'sys_api': {
+                        'human_readable_size': '20.00 GB',
+                        'locked': 1,
+                        'model': 'modelB',
+                        'nr_requests': '256',
+                        'partitions': {
+                            'vdb1': {
+                                'sectors': '41940959',
+                                'sectorsize': 512,
+                                'size': '20.00 GB',
+                                'start': '2048'
+                            }
+                        },
+                        'path': '/dev/vdb',
+                        'removable': '0',
+                        'rev': '',
+                        'ro': '0',
+                        'rotational': '0',
+                        'sas_address': '',
+                        'sas_device_handle': '',
+                        'scheduler_mode': 'mq-deadline',
+                        'sectors': 0,
+                        'sectorsize': '512',
+                        'size': 21474836480.0,
+                        'support_discard': '',
+                        'vendor': 'intel'
+                    }
+                },
+                {
+                    'available':
+                    available,
+                    'lvs': [{
+                        'block_uuid':
+                        'ArrVrZ-5wIc-sDbu-gTkW-OFcc-uMy1-WuRbUZ',
+                        'cluster_fsid':
+                        'b9f1174e-fc02-4142-8816-172f20573c13',
+                        'cluster_name':
+                        'ceph',
+                        'name':
+                        'osd-block-ec36354c-110d-4273-8e47-f1fe78195860',
+                        'osd_fsid':
+                        'ec36354c-110d-4273-8e47-f1fe78195860',
+                        'osd_id':
+                        '4',
+                        'type':
+                        'block'
+                    }],
+                    'path':
+                    '/dev/vdc',
+                    'rejected_reasons': ['locked'],
+                    'sys_api': {
+                        'human_readable_size': '30.00 GB',
+                        'locked': 1,
+                        'model': 'modelC',
+                        'nr_requests': '256',
+                        'partitions': {
+                            'vdc1': {
+                                'sectors': '41940959',
+                                'sectorsize': 512,
+                                'size': '30.00 GB',
+                                'start': '2048'
+                            }
+                        },
+                        'path': '/dev/vdc',
+                        'removable': '0',
+                        'rev': '',
+                        'ro': '0',
+                        'rotational': '1',
+                        'sas_address': '',
+                        'sas_device_handle': '',
+                        'scheduler_mode': 'mq-deadline',
+                        'sectors': 0,
+                        'sectorsize': '512',
+                        'size': 32474836480.0,
+                        'support_discard': '',
+                        'vendor': 'micron'
+                    }
+                }
+            ]
+            self.raw_property = patch(
+                'srv.salt._modules.dg.Inventory.raw',
+                new_callable=PropertyMock,
+                return_value=[])
+            self.dg_property = patch(
+                'srv.salt._modules.dg.Inventory.disks',
+                new_callable=PropertyMock,
+                return_value=inventory_sample)
+            self.raw_property.start()
+            self.dg_property.start()
+
+            inv = dg.Inventory
+            return inv
+
+            self.raw_property.stop()
+            self.dg_property.stop()
+
+        return make_sample_data
+
+    def test_filter_devices_2_size_min_max(self, test_fix, inventory):
+        """ Test_fix's data_device_attrs is configured to take any disk from
+        10G - 29G.  This means that in this test two out of three disks should
+        appear in the output
+        (Disks are 10G/20G/30G)
+        """
+        # initialize inventory once (scope is session by default)
+        inventory()
+        test_fix = test_fix()
+        ret = test_fix._filter_devices(test_fix.data_device_attrs)
+        assert len(ret) == 2
+
+    def test_filter_devices_1_size_exact(self, test_fix, inventory):
+        """
+        Configure to only take disks with 10G
+        """
+        test_fix = test_fix()
+        ret = test_fix._filter_devices(dict(size='10G'))
+        assert len(ret) == 1
+
+    def test_filter_devices_3_max(self, test_fix, inventory):
+        """
+        Configure to only take disks with a max of 30G
+        """
+        test_fix = test_fix()
+        ret = test_fix._filter_devices(dict(size=':30G'))
+        assert len(ret) == 3
+
+    def test_filter_devices_1_max(self, test_fix, inventory):
+        """
+        Configure to only take disks with a max of 10G
+        """
+        test_fix = test_fix()
+        ret = test_fix._filter_devices(dict(size=':10G'))
+        assert len(ret) == 1
+
+    def test_filter_devices_1_min(self, test_fix, inventory):
+        """
+        Configure to only take disks with a min of 10G
+        """
+        test_fix = test_fix()
+        ret = test_fix._filter_devices(dict(size='10G:'))
+        assert len(ret) == 3
+
+    def test_filter_devices_2_min(self, test_fix, inventory):
+        """
+        Configure to only take disks with a min of 20G
+        """
+        test_fix = test_fix()
+        ret = test_fix._filter_devices(dict(size='20G:'))
+        assert len(ret) == 2
+
+    def test_filter_devices_1_model(self, test_fix, inventory):
+        """
+        Configure to only take disks with a model of modelA
+        """
+        test_fix = test_fix()
+        ret = test_fix._filter_devices(dict(model='modelA'))
+        assert len(ret) == 1
+
+    def test_filter_devices_3_model(self, test_fix, inventory):
+        """
+        Configure to only take disks with a model of model*(wildcard)
+        """
+        test_fix = test_fix()
+        ret = test_fix._filter_devices(dict(model='model'))
+        assert len(ret) == 3
+
+    def test_filter_devices_1_vendor(self, test_fix, inventory):
+        """
+        Configure to only take disks with a vendor of samsung
+        """
+        test_fix = test_fix()
+        ret = test_fix._filter_devices(dict(vendor='samsung'))
+        assert len(ret) == 1
+
+    def test_filter_devices_1_rotational(self, test_fix, inventory):
+        """
+        Configure to only take disks with a rotational flag of 0
+        """
+        test_fix = test_fix()
+        ret = test_fix._filter_devices(dict(rotational='0'))
+        assert len(ret) == 1
+
+    def test_filter_devices_2_rotational(self, test_fix, inventory):
+        """
+        Configure to only take disks with a rotational flag of 1
+        """
+        test_fix = test_fix()
+        ret = test_fix._filter_devices(dict(rotational='1'))
+        assert len(ret) == 2
+
+    def test_filter_devices_limit(self, test_fix, inventory):
+        """
+        Configure to only take disks with a rotational flag of 1
+        This should take two disks, but limit=1 is in place
+        """
+        test_fix = test_fix(limit=1)
+        ret = test_fix._filter_devices(dict(rotational='1'))
+        assert len(ret) == 1
+
+    def test_filter_devices_empty_list_eq_matcher(self, test_fix, inventory):
+        """
+        Configure to only take disks with a rotational flag of 1
+        This should take two disks, but limit=1 is in place
+        """
+        inventory(available=False)
+        test_fix = test_fix(limit=1)
+        ret = test_fix._filter_devices(dict(rotational='1'))
+        assert len(ret) == 0
+
+    def test_filter_devices_empty_string_matcher(self, test_fix, inventory):
+        """
+        Configure to only take disks with a rotational flag of 1
+        This should take two disks, but limit=1 is in place
+        """
+        inventory(available=False)
+        test_fix = test_fix(limit=1)
+        ret = test_fix._filter_devices(dict(vendor='samsung'))
+        assert len(ret) == 0
+
+    def test_filter_devices_empty_size_matcher(self, test_fix, inventory):
+        """
+        Configure to only take disks with a rotational flag of 1
+        This should take two disks, but limit=1 is in place
+        """
+        inventory(available=False)
+        test_fix = test_fix(limit=1)
+        ret = test_fix._filter_devices(dict(size='10G:100G'))
+        assert len(ret) == 0
+
+    def test_filter_devices_empty_all_matcher(self, test_fix, inventory):
+        """
+        Configure to only take disks with a rotational flag of 1
+        This should take two disks, but limit=1 is in place
+        """
+        inventory(available=False)
+        test_fix = test_fix(limit=1)
+        ret = test_fix._filter_devices(dict(all=True))
+        assert len(ret) == 0
+
+    @patch('srv.salt._modules.dg.DriveGroup._check_filter')
+    def test_check_filter_support(self, check_filter_mock, test_fix):
+        test_fix = test_fix()
+        test_fix._check_filter_support()
+        check_filter_mock.assert_called
+
+    def test_check_filter(self, test_fix):
+        test_fix = test_fix()
+        ret = test_fix._check_filter(dict(model='foo'))
+        assert ret is None
+
+    def test_check_filter_raise(self, test_fix):
+        test_fix = test_fix()
+        with pytest.raises(
+                dg.FilterNotSupported,
+                message="Filter unknown is not supported"):
+            test_fix._check_filter(dict(unknown='foo'))
+
+
+class TestFilter(object):
+    def test_is_matchable(self):
+        ret = dg.Filter()
+        assert ret.is_matchable is False
+
+    def test_assign_matchers_all(self):
+        ret = dg.Filter(name='all', value='True')
+        assert isinstance(ret.matcher, dg.AllMatcher)
+        assert ret.is_matchable is True
+
+    def test_assign_matchers_all_2(self):
+        """ Should match regardless of value"""
+        ret = dg.Filter(name='all', value='False')
+        assert isinstance(ret.matcher, dg.AllMatcher)
+        assert ret.is_matchable is True
+
+    def test_assign_matchers_size(self):
+        ret = dg.Filter(name='size', value='10G')
+        assert isinstance(ret.matcher, dg.SizeMatcher)
+        assert ret.is_matchable is True
+
+    def test_assign_matchers_model(self):
+        ret = dg.Filter(name='model', value='abc123')
+        assert isinstance(ret.matcher, dg.SubstringMatcher)
+        assert ret.is_matchable is True
+
+    def test_assign_matchers_vendor(self):
+        ret = dg.Filter(name='vendor', value='samsung')
+        assert isinstance(ret.matcher, dg.SubstringMatcher)
+        assert ret.is_matchable is True
+
+    def test_assign_matchers_rotational(self):
+        ret = dg.Filter(name='rotational', value='0')
+        assert isinstance(ret.matcher, dg.EqualityMatcher)
+        assert ret.is_matchable is True

--- a/tests/unit/runners/test_disks.py
+++ b/tests/unit/runners/test_disks.py
@@ -1,0 +1,151 @@
+import pytest
+from mock import patch, call, Mock, PropertyMock
+from srv.modules.runners import disks
+
+
+class TestDriveGroups_Disks(object):
+    def test_target(self):
+        dgo = disks.DriveGroup('default', {'target': 'test_target'})
+        assert dgo.target() == 'test_target'
+
+    def test_target_not_present(self):
+        with pytest.raises(disks.NoTargetFound):
+            dgo = disks.DriveGroup('default', {'target': ''})
+            dgo.target()
+
+    def test_target_is_not_string(self):
+        with pytest.raises(disks.NoTargetFound):
+            dgo = disks.DriveGroup('default', {'target': int(9)})
+            dgo.target()
+
+    def test_filter_args(self):
+        filter_args = {'target': '', 'data_devices': {'size': '50G'}}
+        dgo = disks.DriveGroup('default', filter_args)
+        assert dgo.filter_args() == filter_args
+
+    def test_filter_args_not_present(self):
+        with pytest.raises(disks.NoFilterFound):
+            dgo = disks.DriveGroup('default', {})
+            dgo.filter_args()
+
+    def test_filter_args_is_not_dict(self):
+        with pytest.raises(disks.NoFilterFound):
+            dgo = disks.DriveGroup('default', str('raises'))
+            dgo.filter_args()
+
+
+class TestDriveGroup_Disks(object):
+
+    default_spec = {
+        'default': {
+            'target': 'data*',
+            'data_devices': {
+                'size': '50G'
+            }
+        },
+        'non_default': {
+            'target': 'other*',
+            'data_devices': {
+                'rotational': 1
+            },
+            'db_devices': {
+                'size': ':50G'
+            },
+            'wal_devices': {
+                'size': ':50G'
+            }
+        }
+    }
+
+    @pytest.fixture(scope='class')
+    def drive_groups_fixture(self, **kwargs):
+        def make_drive_group_object(**kwargs):
+            drive_groups = kwargs.get('drive_groups', self.default_spec)
+            self.load_drive_group = patch(
+                'srv.modules.runners.disks.DriveGroups._load_drive_group_file',
+                return_value=drive_groups)
+            self.localclient = patch(
+                'srv.modules.runners.disks.salt.client.LocalClient')
+            self.ldg_mock = self.load_drive_group.start()
+            self.local_client_mock = self.localclient.start()
+            return disks.DriveGroups(**kwargs)
+            self.ldg_mock = self.get_drive_group.stop()
+            self.local_client_mock = self.localclient.stop()
+
+        return make_drive_group_object
+
+    def test_class_defaults(self, drive_groups_fixture):
+        dgo = drive_groups_fixture()
+        assert dgo.dry_run is False
+        assert dgo.drive_groups_path == '/srv/salt/ceph/configuration/files/drive_groups.yml'
+
+    def test_class_non_default(self, drive_groups_fixture):
+        dgo = drive_groups_fixture(dry_run=True)
+        assert dgo.dry_run is True
+
+    def test_get_drive_groups(self, drive_groups_fixture):
+        dgo = drive_groups_fixture()
+        assert dgo.drive_groups == self.default_spec
+
+    def test_get_drive_groups_empty(self, drive_groups_fixture):
+        with pytest.raises(RuntimeError):
+            drive_groups_fixture(drive_groups={})
+
+    def test_get_drive_groups_not_dict(self, drive_groups_fixture):
+        with pytest.raises(RuntimeError):
+            drive_groups_fixture(drive_groups=str('not a dict'))
+
+    @patch('srv.modules.runners.disks.DriveGroup')
+    def test_call_out(self, drive_group, drive_groups_fixture):
+        dgo = drive_groups_fixture()
+        ret = dgo.call_out('test')
+
+        call0 = (call('default', {
+            'target': 'data*',
+            'data_devices': {
+                'size': '50G'
+            }
+        }))
+        assert call0 == drive_group.call_args_list[0]
+
+        call1 = call(
+            'non_default', {
+                'target': 'other*',
+                'data_devices': {
+                    'rotational': 1
+                },
+                'db_devices': {
+                    'size': ':50G'
+                },
+                'wal_devices': {
+                    'size': ':50G'
+                }
+            })
+        assert call1 == drive_group.call_args_list[1]
+        # maybe that would've been enough
+        assert len(self.default_spec) == len(drive_group.call_args_list)
+        assert isinstance(ret, list)
+
+    def test_call(self, drive_groups_fixture):
+        dgo = drive_groups_fixture()
+        dgo.call('target*', {'args'}, 'test_command')
+        dgo.local_client.cmd.assert_called_with(
+            'target*',
+            'dg.test_command',
+            expr_form='compound',
+            kwarg={
+                'filter_args': {'args'},
+                'dry_run': False
+            })
+
+    def test_call_dry(self, drive_groups_fixture):
+        dgo = drive_groups_fixture(dry_run=True)
+        dgo.call('target*', {'args'}, 'test_command')
+        dgo.local_client.cmd.assert_called_with(
+            'target*',
+            'dg.test_command',
+            expr_form='compound',
+            kwarg={
+                'filter_args': {'args'},
+                'dry_run': True
+            })


### PR DESCRIPTION
Signed-off-by: Joshua Schmid <jschmid@suse.de>

This is a first draft of the code that will transform a drive_group proposal to an actual list of devices.
Please read the wiki pages for [DriveGroups](https://github.com/SUSE/DeepSea/wiki/Drive-Groups) to get an idea on how specifications will look like.

~If you want to give this patch a try, there is a `drive_group.sls` in `/srv/pillar/ceph/` which can be adapted to your needs.~

I'll write a proper howto in the wikis soon.

~In this implementation the drive_group will reside in the pillar again..~
it will not. It will pull it from a file an stuff it down to the minions.

Expected to fail:

~* linter (there is a FIXME in it, which shouldn't be removed, yet - works besides this)~
done
~The runner call is `disks.test` which is just a temp name.~
done
~I have not added functionality to convert the output to ceph-volume understandable commands yet. (wip)~
done

The naming question also remains. A couple of suggestions:
salt-run
* drivegroups.generate
* drivegroups.match
* drivegroups.allocate
* disks.filter ..

I went with dg.py and disks.py for now.. Not very convinced with my naming scheme though..

~Unittests are not added yet, as the implementation will probably change a bit. I'll add them once we are all happy with this implementation.~

Added

----------

It may be noted that I used the optional static typing system introduced with python3 to harden the code. It runs well on any python3 environment. However this should not be used for any code that may get backported.. This is not one of those candidates I think.

-----------------

**Checklist:**
- [ ] Added unittests and or functional tests
- [ ] Adapted documentation
- [ ] Referenced issues or internal bugtracker
- [ ] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
