### PR TITLE
[SES5][backport] tuned: disable dynamic tuning for all profiles

### DIFF
--- a/srv/salt/ceph/tuned/files/ceph-mgr/tuned.conf
+++ b/srv/salt/ceph/tuned/files/ceph-mgr/tuned.conf
@@ -3,4 +3,12 @@
 
 [main]
 include=network-latency
+dynamic_tuning = 0
 
+[disk]
+# hdparm -S 0 /dev/<disk>
+# Sets the timeout to 0 - A value of zero means "timeouts are disabled": the
+# device will not automatically enter standby mode.
+spindown = 0
+# Disable dynamic tuning for disk settings
+dynamic = 0

--- a/srv/salt/ceph/tuned/files/ceph-mon/tuned.conf
+++ b/srv/salt/ceph/tuned/files/ceph-mon/tuned.conf
@@ -3,4 +3,12 @@
 
 [main]
 include=network-latency
+dynamic_tuning = 0
 
+[disk]
+# hdparm -S 0 /dev/<disk>
+# Sets the timeout to 0 - A value of zero means "timeouts are disabled": the
+# device will not automatically enter standby mode.
+spindown = 0
+# Disable dynamic tuning for disk settings
+dynamic = 0

--- a/srv/salt/ceph/tuned/files/ceph-osd/tuned.conf
+++ b/srv/salt/ceph/tuned/files/ceph-osd/tuned.conf
@@ -3,4 +3,21 @@
 
 [main]
 include=throughput-performance
+dynamic_tuning = 0
 
+[disk]
+# hdparm -S 0 /dev/<disk>
+# Sets the timeout to 0 - A value of zero means "timeouts are disabled": the
+# device will not automatically enter standby mode.
+spindown = 0
+# hdparm -B 254 /dev/<disk>
+# Get/set Advanced Power Management feature. The highest I/O performance with a
+# setting of 254.
+apm = 254
+# Disable dynamic tuning for disk settings
+dynamic = 0
+
+[scsi_host]
+# ALPM is disabled; the link does not enter any low-power state when there is
+# no I/O on the disk.
+alpm = max_performance


### PR DESCRIPTION
Signed-off-by: Mohamad Gebai <mgebai@suse.com>
suse internal: bsc#1119260

-----------------

**Checklist:**
- [ ] Added unittests and or functional tests
- [ ] Adapted documentation
- [ ] Referenced issues or internal bugtracker
- [ ] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
