### PR TITLE
Fix: #1493  Fixes auth caps for openstack.integrate

### DIFF
--- a/srv/salt/ceph/openstack/cinder-backup/files/keyring.j2
+++ b/srv/salt/ceph/openstack/cinder-backup/files/keyring.j2
@@ -1,4 +1,4 @@
 [{{ client }}]
         key = {{ secret }}
         caps mon = "profile rbd"
-        caps osd = "profile rbd pool={{ prefix }}backups"
+        caps osd = "profile rbd pool={{ prefix }}cloud-backups"

--- a/srv/salt/ceph/openstack/cinder/files/keyring.j2
+++ b/srv/salt/ceph/openstack/cinder/files/keyring.j2
@@ -1,4 +1,4 @@
 [{{ client }}]
         key = {{ secret }}
         caps mon = "profile rbd"
-        caps osd = "profile rbd pool={{ prefix }}volumes, profile rbd pool={{ prefix }}vms, profile rbd pool={{ prefix }}images"
+        caps osd = "profile rbd pool={{ prefix }}cloud-volumes, profile rbd pool={{ prefix }}cloud-vms, profile rbd pool={{ prefix }}cloud-images"

--- a/srv/salt/ceph/openstack/glance/files/keyring.j2
+++ b/srv/salt/ceph/openstack/glance/files/keyring.j2
@@ -1,4 +1,4 @@
 [{{ client }}]
         key = {{ secret }}
         caps mon = "profile rbd"
-        caps osd = "profile rbd pool={{ prefix }}images"
+        caps osd = "profile rbd pool={{ prefix }}cloud-images"


### PR DESCRIPTION
This patch fixes incorrect pool names in the auth caps for
cinder, cinder-backup, and glance users.  The pools are created
with names of
<prefix>cloud-volumes
<prefix>cloud-backups
<prefix>cloud-vms
<prefix>cloud-images

but the auth caps were created with pool names of
<prefix>volumes
<prefix>backups
<prefix>vms
<prefix>images

This patch fixes the auth caps pool names to use
<prefix>cloud-volumes
<prefix>cloud-backups
<prefix>cloud-vms
<prefix>cloud-images

Signed-off-by: Walter A. Boring IV <waboring@hemna.com>

Fixes #


Description:


-----------------

**Checklist:**
- [ ] Added unittests and or functional tests
- [ ] Adapted documentation
- [ ] Referenced issues or internal bugtracker
- [ ] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
