### PR TITLE
minion.ready returns bogus in the latest versions of salt

### DIFF
--- a/srv/modules/runners/minions.py
+++ b/srv/modules/runners/minions.py
@@ -68,7 +68,7 @@ def ready(**kwargs):
             print(client_error)
             return ret
 
-        actual = set(results.keys())
+        actual = set([k for k, v in results.items() if v])
 
         if settings['search']:
             pillar_util = salt.utils.master.MasterPillarUtil(


### PR DESCRIPTION
Description:

look for values of test.ping returns rather only the existence of the key

There seems to be a change on how test.ping returns 'down' minions.

Previously (salt 2016.x) it seemed to be fine to query the presence of
the key in the return. With at least salt-2018.x this is not true anymore

You get a return of {'node1': True, 'node2': False} (the entry remains in
the return of test.ping)

This entails that we always return True in 'minions.ready' although a node is
down.


-----------------

**Checklist:**
- [ ] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
