### PR TITLE
Various fixes for the upgrade procedure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,3 +111,18 @@ tags
 
 # backup
 *.bak
+
+# tag files
+GPATH
+GRTAGS
+GTAGS
+TAGS
+
+# org files
+*.org
+
+# mypy cache dirs
+.mypy_cache/
+
+# projectile files
+.projectile

--- a/Makefile
+++ b/Makefile
@@ -468,6 +468,8 @@ copy-files:
 	install -m 644 srv/salt/ceph/osd/keyring/*.sls $(DESTDIR)/srv/salt/ceph/osd/keyring/
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/osd/scheduler
 	install -m 644 srv/salt/ceph/osd/scheduler/*.sls $(DESTDIR)/srv/salt/ceph/osd/scheduler/
+	install -d -m 755 $(DESTDIR)/srv/salt/ceph/osd/takeover
+	install -m 644 srv/salt/ceph/osd/takeover/*.sls $(DESTDIR)/srv/salt/ceph/osd/takeover/
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/osd/files
 	install -m 644 srv/salt/ceph/osd/files/*.j2 $(DESTDIR)/srv/salt/ceph/osd/files/
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/osd/restart

--- a/deepsea.spec.in
+++ b/deepsea.spec.in
@@ -228,6 +228,7 @@ systemctl try-restart salt-api > /dev/null 2>&1 || :
 %dir /srv/salt/ceph/osd/restart/controlled
 %dir /srv/salt/ceph/osd/restart/parallel
 %dir /srv/salt/ceph/osd/scheduler
+%dir /srv/salt/ceph/osd/takeover
 %dir /srv/salt/ceph/packages
 %dir /srv/salt/ceph/packages/common
 %dir /srv/salt/ceph/packages/remove
@@ -567,6 +568,7 @@ systemctl try-restart salt-api > /dev/null 2>&1 || :
 %config /srv/salt/ceph/osd/restart/controlled/*.sls
 %config /srv/salt/ceph/osd/restart/parallel/*.sls
 %config /srv/salt/ceph/osd/scheduler/*.sls
+%config /srv/salt/ceph/osd/takeover/*.sls
 %config /srv/salt/ceph/packages/*.sls
 %config /srv/salt/ceph/packages/common/*.sls
 %config /srv/salt/ceph/packages/remove/*.sls

--- a/srv/modules/runners/validate.py
+++ b/srv/modules/runners/validate.py
@@ -847,7 +847,7 @@ class Validate(Preparation):
             warning_str = '{node}: {year}.{month}.{release} not supported' \
                           .format(node=node, year=year, month=month,
                                   release=release)
-            if int(year) < 2017 or int(year) > 2018:
+            if int(year) < 2017 or int(year) > 2019:
                 if 'salt_version' not in self.warnings:
                     self.warnings['salt_version'] = [warning_str]
                 else:
@@ -1445,6 +1445,7 @@ def setup(**kwargs):
         return False
 
     return True
+
 
 __func_alias__ = {
                  'help_': 'help',

--- a/srv/salt/_modules/osd.py
+++ b/srv/salt/_modules/osd.py
@@ -2435,6 +2435,36 @@ def _report_original_pillar(active):
     return unconfigured, changed
 
 
+def takeover():
+    """ This is horrible and should be implemented in ceph-volume """
+    # picking osd.list here as it lists osd_ids by looking at mountpoints
+    for osd_id in __salt__['osd.list']():
+        # Use the mountpoint to identify the disk
+        # another option is to use the partition but
+        # if a osd is not mounted there might be a bigger problem
+        cmd = "ceph-volume simple scan /var/lib/ceph/osd/ceph-{} --force".format(
+            osd_id)
+        return_code, _, stderr = __salt__['helper.run'](cmd)
+        if int(return_code) != 0:
+            log.error(stderr)
+            return False  # rc? or raise?
+    osd_ident_path = "/etc/ceph/osd/"
+    osd_files = list()
+    if os.path.exists(osd_ident_path):
+        osd_files = [
+            f for f in os.listdir(osd_ident_path)
+            if os.path.isfile(os.path.join(osd_ident_path, f))
+        ]
+    for osd_file in osd_files:
+        cmd = "ceph-volume simple activate --file {}".format(osd_ident_path +
+                                                             osd_file)
+        return_code, _, stderr = __salt__['helper.run'](cmd)
+        if int(return_code) != 0:
+            log.error(stderr)
+            return False  # rc? or raise?
+    return True
+
+
 __func_alias__ = {
                 'list_': 'list',
                 'empty': 'zero_weight',

--- a/srv/salt/_modules/packagemanager.py
+++ b/srv/salt/_modules/packagemanager.py
@@ -321,12 +321,12 @@ class Zypper(PackageManager):
             cmd.extend(strategy_flags)
             log.debug('Executing {}'.format(cmd))
             proc = Popen(cmd, stdout=PIPE, stderr=PIPE)
-            stdout, stderr = proc.communicate()
-            for line in stdout:
-                log.info(line)
-            for line in stderr:
-                log.info(line)
-            log.info("returncode: {}".format(proc.returncode))
+            _, _ = proc.communicate()
+            # for line in stdout:
+            #     log.info(line)
+            # for line in stderr:
+            #     log.info(line)
+            log.info("returncode for {} : {}".format(cmd, proc.returncode))
             self._check_for_reboots(proc.returncode)
         else:
             log.info("No updates available.")

--- a/srv/salt/ceph/maintenance/upgrade/master/default.sls
+++ b/srv/salt/ceph/maintenance/upgrade/master/default.sls
@@ -2,7 +2,23 @@
 {% set master = salt['master.minion']() %}
 
 {% set timeout=salt['pillar.get']('minions_ready_timeout', 30) %}
-{% if salt.saltutil.runner('minions.ready', timeout=timeout) and salt['saltutil.runner']('upgrade.check') and salt['saltutil.runner']('validate.setup') %}
+
+
+{% if salt.saltutil.runner('minions.ready', timeout=timeout) %}
+
+
+{% if salt['saltutil.runner']('upgrade.check') == False or salt['saltutil.runner']('validate.setup') == False %}
+
+
+validate failed:
+  salt.state:
+    - name: just.exit
+    - tgt: {{ master }}
+    - failhard: True
+
+{% endif %}
+
+{% else %}
 
 {% set notice = salt['saltutil.runner']('advise.salt_upgrade') %}
   
@@ -18,12 +34,6 @@ set sortbitwise flag:
     - tgt: {{ master }}
     - failhard: True
 
-# May generate an unpack error which is safe to ignore
-update deepsea and master:
-  salt.state:
-    - tgt: {{ master }}
-    - sls: ceph.updates.master
-
 upgrading:
   salt.state:
     - tgt: {{ master }}
@@ -35,13 +45,5 @@ reboot master:
   salt.state:
     - tgt: {{ master }}
     - sls: ceph.updates.restart
-
-{% else %}
-
-validate failed:
-  salt.state:
-    - name: just.exit
-    - tgt: {{ master }}
-    - failhard: True
 
 {% endif %}

--- a/srv/salt/ceph/osd/takeover/default.sls
+++ b/srv/salt/ceph/osd/takeover/default.sls
@@ -1,0 +1,14 @@
+{% if 'storage' in salt['pillar.get']('roles') %}
+
+ invoking osd.takeover:
+  module.run:
+    - name: osd.takeover
+    - fire_event: True
+    - failhard: True
+
+ {% else %}
+
+ no osd detected:
+  test.nop
+
+ {% endif %}

--- a/srv/salt/ceph/osd/takeover/init.sls
+++ b/srv/salt/ceph/osd/takeover/init.sls
@@ -1,0 +1,3 @@
+
+include:
+  - .{{ salt['pillar.get']('osd_takeover', 'default') }}

--- a/srv/salt/ceph/updates/restart/default.sls
+++ b/srv/salt/ceph/updates/restart/default.sls
@@ -1,4 +1,3 @@
-
 {% set kernel = grains['kernelrelease'] | replace('-default', '')  %}
 {% set installed = salt['kernel.installed_kernel_version']() %}
 
@@ -9,11 +8,11 @@ warning:
     - installed: {{ installed }}
     - unless: "echo {{ installed }} | grep -q {{ kernel }}"
 
-reboot:
+rebootj:
   cmd.run:
-    - name: "shutdown -r now"
+    # This one is nasty! Please see (https://github.com/SUSE/DeepSea/issues/1508) for an explanation
+    - name: "/usr/bin/nohup /bin/bash -c 'set -x && systemctl reboot' >> /var/log/salt/minion 2>&1 &"
     - shell: /bin/bash
     - unless: "echo {{ installed }} | grep -q {{ kernel }}"
-    - failhard: True
+    - failhard: False
     - fire_event: True
-

--- a/srv/salt/ceph/upgrade/zypper-dup.sls
+++ b/srv/salt/ceph/upgrade/zypper-dup.sls
@@ -6,4 +6,5 @@ packagemanager dup:
         'reboot': False
         'kernel': True
     - fire_event: True
-    - failhard: True
+      # testing, revert later FIXME
+    - failhard: False


### PR DESCRIPTION
* Do not execute a salt update in a orchestration
* Implement the ceph-disk->ceph-volume take-over
* Replace command we schedule reboots with

Due to changed behavior on the salt side we have to change the way we issue
reboots. See https://github.com/SUSE/DeepSea/issues/1508 for an explanation and
more information.

This will be the first branch to test the automated upgrade with.

Signed-off-by: Joshua Schmid <jschmid@suse.de>

-----------------

**Checklist:**
- [ ] Adapted documentation
- [ ] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
