### PR TITLE
Set the hwclock after sync'ing the system time

### DIFF
--- a/srv/salt/ceph/time/ntp/default.sls
+++ b/srv/salt/ceph/time/ntp/default.sls
@@ -9,6 +9,10 @@ ntp:
 sync time:
   cmd.run:
     - name: "sntp -S -c {{ salt['pillar.get']('time_server') }}"
+
+sync hardware clock:
+  cmd.run:
+    - name: "hwclock --systohc"
 {% endif %}
 
 {% if grains['id'] != salt['pillar.get']('time_server') %}


### PR DESCRIPTION
Signed-off-by: Eric Jackson <ejackson@suse.com>
bsc: 1119568
-----------------

**Checklist:**
- [ ] Added unittests and or functional tests
- [ ] Adapted documentation
- [x] Referenced issues or internal bugtracker
- [ ] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
