### PR TITLE
Fix: #1493 and #1495  openstack.integrate fixes from master.

### DIFF
--- a/srv/modules/runners/openstack.py
+++ b/srv/modules/runners/openstack.py
@@ -111,7 +111,7 @@ def integrate(**kwargs):
                               'pillar={"openstack_prefix": "' + kwargs['prefix'] + '"}'])
         # Set up prefix for subsequent string concatenation to match what's done
         # in the SLS files for keyring and pool names.
-        prefix = kwargs['prefix'] + "-"
+        prefix = "{}-".format(kwargs['prefix'])
     else:
         state_res = local.cmd(master_minion, 'state.apply', ['ceph.openstack'])
 

--- a/srv/salt/ceph/openstack/cinder-backup/files/keyring.j2
+++ b/srv/salt/ceph/openstack/cinder-backup/files/keyring.j2
@@ -1,4 +1,4 @@
 [{{ client }}]
         key = {{ secret }}
         caps mon = "profile rbd"
-        caps osd = "profile rbd pool={{ prefix }}backups"
+        caps osd = "profile rbd pool={{ prefix }}cloud-backups"

--- a/srv/salt/ceph/openstack/cinder/files/keyring.j2
+++ b/srv/salt/ceph/openstack/cinder/files/keyring.j2
@@ -1,4 +1,4 @@
 [{{ client }}]
         key = {{ secret }}
         caps mon = "profile rbd"
-        caps osd = "profile rbd pool={{ prefix }}volumes, profile rbd pool={{ prefix }}vms, profile rbd pool={{ prefix }}images"
+        caps osd = "profile rbd pool={{ prefix }}cloud-volumes, profile rbd pool={{ prefix }}cloud-vms, profile rbd pool={{ prefix }}cloud-images"

--- a/srv/salt/ceph/openstack/glance/files/keyring.j2
+++ b/srv/salt/ceph/openstack/glance/files/keyring.j2
@@ -1,4 +1,4 @@
 [{{ client }}]
         key = {{ secret }}
         caps mon = "profile rbd"
-        caps osd = "profile rbd pool={{ prefix }}images"
+        caps osd = "profile rbd pool={{ prefix }}cloud-images"


### PR DESCRIPTION
This patch adds a format() call to
eliminate the unwanted addition of "!!python/unicode" as part of the
prefix output.

Signed-off-by: Walter A. Boring IV <waboring@hemna.com>

Fixes #


Description:


-----------------

**Checklist:**
- [ ] Added unittests and or functional tests
- [ ] Adapted documentation
- [ ] Referenced issues or internal bugtracker
- [ ] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
