### PR TITLE
[backport][SES5] Fix: #1495  Fix unicode output error

### DIFF
--- a/srv/modules/runners/openstack.py
+++ b/srv/modules/runners/openstack.py
@@ -111,7 +111,7 @@ def integrate(**kwargs):
                               'pillar={"openstack_prefix": "' + kwargs['prefix'] + '"}'])
         # Set up prefix for subsequent string concatenation to match what's done
         # in the SLS files for keyring and pool names.
-        prefix = kwargs['prefix'] + "-"
+        prefix = "{}-".format(kwargs['prefix'])
     else:
         state_res = local.cmd(master_minion, 'state.apply', ['ceph.openstack'])
 


### PR DESCRIPTION
This patch adds a format() call to
eliminate the unwanted addition of "!!python/unicode" as part of the
prefix output.

Signed-off-by: Walter A. Boring IV <waboring@hemna.com>

Fixes #1495 


Description:


-----------------

**Checklist:**
- [ ] Added unittests and or functional tests
- [ ] Adapted documentation
- [ ] Referenced issues or internal bugtracker
- [ ] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
