### PR TITLE
Makefile: pass --long option to git describe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Override this to install docs somewhere else
 DOCDIR = /usr/share/doc/packages
-VERSION ?= $(shell (git describe 2>/dev/null || echo '0.0.0') | sed -e 's/^v//' -e 's/-/+/' -e 's/-/./')
+VERSION ?= $(shell (git describe --long 2>/dev/null || echo '0.0.0') | sed -e 's/^v//' -e 's/-/+/' -e 's/-/./')
 
 DEEPSEA_DEPS=salt-api
 PYTHON_DEPS=python3-setuptools python3-click python3-tox python3-configobj


### PR DESCRIPTION
Before this commit, we were generating the version number using
plain "git describe", which (according to the man page)

    "finds the most recent tag that is reachable from a commit. If the tag
    points to the commit, then only the tag is shown."

This had the undesirable effect of sometimes producing version numbers
that look like this:

    0.8.9+2.g14f2f94e

and other times like this:

    0.8.9

Depending on whether HEAD pointed to a tag or not. By passing the --long
option, we assure that the long format is used always.

Signed-off-by: Nathan Cutler <ncutler@suse.com>

Fixes #


Description:


-----------------

**Checklist:**
- [ ] Added unittests and or functional tests
- [ ] Adapted documentation
- [ ] Referenced issues or internal bugtracker
- [ ] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
