### PR TITLE
Check for digit before 'p'

### DIFF
--- a/srv/salt/_modules/osd.py
+++ b/srv/salt/_modules/osd.py
@@ -1434,7 +1434,7 @@ def split_partition(_partition):
     if not match:
         return None, None
     disk = match.group(1)
-    if disk.endswith('p'):
+    if re.match(r".+\dp$", disk):
         disk = disk[:-1]
         log.debug("Truncating p {}".format(disk))
     return disk, match.group(2)

--- a/tests/unit/_modules/test_osd.py
+++ b/tests/unit/_modules/test_osd.py
@@ -2232,6 +2232,32 @@ class TestOSDCommands():
     def test_detect(self):
         pass
 
+class Testsplit_partition():
+
+    @patch('srv.salt._modules.osd.readlink')
+    def test_split_partition(self, readlink):
+        readlink.return_value = "/dev/sda1"
+        disk, part = osd.split_partition("/dev/sda1")
+        assert disk == "/dev/sda"
+        assert part == "1"
+
+    @patch('srv.salt._modules.osd.readlink')
+    def test_split_partition_on_nvme(self, readlink):
+        readlink.return_value = "/dev/nvme0n1p1"
+        disk, part = osd.split_partition("/dev/nvme0n1p1")
+        assert disk == "/dev/nvme0n1"
+        assert part == "1"
+
+    @patch('srv.salt._modules.osd.readlink')
+    def test_split_partition_on_sdp(self, readlink):
+        """
+        Verify that the 'p' never gets truncated with /dev/sdp
+        """
+        readlink.return_value = "/dev/sdp1"
+        disk, part = osd.split_partition("/dev/sdp1")
+        assert disk == "/dev/sdp"
+        assert part == "1"
+
 class TestOSDRemove():
 
     @patch('osd.OSDRemove.set_partitions')


### PR DESCRIPTION
Devices such as nvme append a 'p' for partitions, for example nvme0n1p1.
The 'p' must not be truncated for devices such as /dev/sdp.

Signed-off-by: Eric Jackson <ejackson@suse.com>
bsc: 1123226
Port of #1518

**Checklist:**
- [x] Added unittests and or functional tests
- [ ] Adapted documentation
- [x] Referenced issues or internal bugtracker
- [ ] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
