### PR TITLE
force 'adler32' as CRC method

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -891,6 +891,8 @@ copy-files:
 	# state files - salt
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/salt
 	install -m 644 srv/salt/ceph/salt/*.sls $(DESTDIR)/srv/salt/ceph/salt/
+	install -d -m 755 $(DESTDIR)/srv/salt/ceph/salt/crc
+	install -m 644 srv/salt/ceph/salt/crc/*.sls $(DESTDIR)/srv/salt/ceph/salt/crc/
 
 	# state files - orchestrate stage symlinks
 	ln -sf prep		$(DESTDIR)/srv/salt/ceph/stage/0

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ version:
 setup.py:
 	sed "s/DEVVERSION/"$(VERSION)"/" setup.py.in > setup.py
 
-pyc: setup.py 
+pyc: setup.py
 	#make sure to create bytecode with the correct version
 	find srv/ -name '*.py' -exec $(PYTHON) -m py_compile {} \;
 	find cli/ -name '*.py' -exec $(PYTHON) -m py_compile {} \;
@@ -531,7 +531,7 @@ copy-files:
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/remove/destroyed
 	install -m 644 srv/salt/ceph/remove/destroyed/*.sls $(DESTDIR)/srv/salt/ceph/remove/destroyed/
 	# Renamed for deprecation
-	ln -sf destroyed	$(DESTDIR)/srv/salt/ceph/remove/migrated 
+	ln -sf destroyed	$(DESTDIR)/srv/salt/ceph/remove/migrated
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/remove/mgr
 	install -m 644 srv/salt/ceph/remove/mgr/*.sls $(DESTDIR)/srv/salt/ceph/remove/mgr/
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/remove/mon
@@ -544,8 +544,8 @@ copy-files:
 	install -m 644 srv/salt/ceph/remove/storage/*.sls $(DESTDIR)/srv/salt/ceph/remove/storage/
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/remove/storage/drain
 	install -m 644 srv/salt/ceph/remove/storage/drain/*.sls $(DESTDIR)/srv/salt/ceph/remove/storage/drain
-	install -d -m 755 $(DESTDIR)/srv/salt/ceph/remove/openattic	
-	install -m 644 srv/salt/ceph/remove/openattic/*.sls $(DESTDIR)/srv/salt/ceph/remove/openattic/	
+	install -d -m 755 $(DESTDIR)/srv/salt/ceph/remove/openattic
+	install -m 644 srv/salt/ceph/remove/openattic/*.sls $(DESTDIR)/srv/salt/ceph/remove/openattic/
 	# state files - rescind
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/rescind
 	install -m 644 srv/salt/ceph/rescind/*.sls $(DESTDIR)/srv/salt/ceph/rescind/
@@ -611,9 +611,9 @@ copy-files:
 	install -m 644 srv/salt/ceph/rescind/time/ntp/*.sls $(DESTDIR)/srv/salt/ceph/rescind/time/ntp
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/rescind/tuned
 	install -m 644 srv/salt/ceph/rescind/tuned/*.sls $(DESTDIR)/srv/salt/ceph/rescind/tuned/
-	install -d -m 755 $(DESTDIR)/srv/salt/ceph/rescind/openattic	
-	install -m 644 srv/salt/ceph/rescind/openattic/*.sls $(DESTDIR)/srv/salt/ceph/rescind/openattic/	
-	install -d -m 755 $(DESTDIR)/srv/salt/ceph/rescind/openattic/keyring	
+	install -d -m 755 $(DESTDIR)/srv/salt/ceph/rescind/openattic
+	install -m 644 srv/salt/ceph/rescind/openattic/*.sls $(DESTDIR)/srv/salt/ceph/rescind/openattic/
+	install -d -m 755 $(DESTDIR)/srv/salt/ceph/rescind/openattic/keyring
 	install -m 644 srv/salt/ceph/rescind/openattic/keyring/*.sls $(DESTDIR)/srv/salt/ceph/rescind/openattic/keyring/
 	# state files - repo
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/repo
@@ -888,6 +888,9 @@ copy-files:
 	# state files - warning/noout
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/warning/noout
 	install -m 644 srv/salt/ceph/warning/noout/*.sls $(DESTDIR)/srv/salt/ceph/warning/noout/
+	# state files - salt
+	install -d -m 755 $(DESTDIR)/srv/salt/ceph/salt
+	install -m 644 srv/salt/ceph/salt/*.sls $(DESTDIR)/srv/salt/ceph/salt/
 
 	# state files - orchestrate stage symlinks
 	ln -sf prep		$(DESTDIR)/srv/salt/ceph/stage/0

--- a/deepsea.spec.in
+++ b/deepsea.spec.in
@@ -287,7 +287,7 @@ systemctl try-restart salt-api > /dev/null 2>&1 || :
 %dir /srv/salt/ceph/rescind/time/chrony
 %dir /srv/salt/ceph/rescind/time/ntp
 %dir /srv/salt/ceph/rescind/tuned
-%dir /srv/salt/ceph/rescind/openattic	
+%dir /srv/salt/ceph/rescind/openattic
 %dir /srv/salt/ceph/rescind/openattic/keyring
 %dir /srv/salt/ceph/restart
 %dir /srv/salt/ceph/restart/force
@@ -425,6 +425,7 @@ systemctl try-restart salt-api > /dev/null 2>&1 || :
 %dir /srv/salt/ceph/processes/mon
 %dir /srv/salt/ceph/processes/osd
 %dir /srv/salt/ceph/processes/rgw
+%dir /srv/salt/ceph/salt
 %{_mandir}/man7/deepsea*.7.gz
 %{_mandir}/man5/deepsea*.5.gz
 %{_mandir}/man1/deepsea*.1.gz
@@ -750,6 +751,7 @@ systemctl try-restart salt-api > /dev/null 2>&1 || :
 %config /srv/salt/ceph/processes/mon/*.sls
 %config /srv/salt/ceph/processes/osd/*.sls
 %config /srv/salt/ceph/processes/rgw/*.sls
+%config /srv/salt/ceph/salt/*.sls
 %dir %attr(-, root, root) %{_docdir}/%{name}
 %{_docdir}/%{name}/*
 

--- a/deepsea.spec.in
+++ b/deepsea.spec.in
@@ -426,6 +426,7 @@ systemctl try-restart salt-api > /dev/null 2>&1 || :
 %dir /srv/salt/ceph/processes/osd
 %dir /srv/salt/ceph/processes/rgw
 %dir /srv/salt/ceph/salt
+%dir /srv/salt/ceph/salt/crc
 %{_mandir}/man7/deepsea*.7.gz
 %{_mandir}/man5/deepsea*.5.gz
 %{_mandir}/man1/deepsea*.1.gz
@@ -752,6 +753,7 @@ systemctl try-restart salt-api > /dev/null 2>&1 || :
 %config /srv/salt/ceph/processes/osd/*.sls
 %config /srv/salt/ceph/processes/rgw/*.sls
 %config /srv/salt/ceph/salt/*.sls
+%config /srv/salt/ceph/salt/crc/*.sls
 %dir %attr(-, root, root) %{_docdir}/%{name}
 %{_docdir}/%{name}/*
 

--- a/srv/salt/ceph/salt/crc/default.sls
+++ b/srv/salt/ceph/salt/crc/default.sls
@@ -1,0 +1,4 @@
+/etc/salt/minion:
+  file.append:
+    - text:
+      - "server_id_use_crc: adler32"

--- a/srv/salt/ceph/salt/crc/init.sls
+++ b/srv/salt/ceph/salt/crc/init.sls
@@ -1,0 +1,2 @@
+include:
+  - .{{ salt['pillar.get']('server_id_use_crc_init', 'default') }}

--- a/srv/salt/ceph/salt/default.sls
+++ b/srv/salt/ceph/salt/default.sls
@@ -1,0 +1,4 @@
+/etc/salt/minion:
+  file.append:
+    - text:
+      - "server_id_use_crc: adler32"

--- a/srv/salt/ceph/salt/default.sls
+++ b/srv/salt/ceph/salt/default.sls
@@ -1,4 +1,2 @@
-/etc/salt/minion:
-  file.append:
-    - text:
-      - "server_id_use_crc: adler32"
+include:
+  - ceph.salt.crc

--- a/srv/salt/ceph/salt/init.sls
+++ b/srv/salt/ceph/salt/init.sls
@@ -1,2 +1,2 @@
 include:
-  - .{{ salt['pillar.get']('server_id_use_crc', 'default') }}
+  - .{{ salt['pillar.get']('salt_init', 'default') }}

--- a/srv/salt/ceph/salt/init.sls
+++ b/srv/salt/ceph/salt/init.sls
@@ -1,0 +1,2 @@
+include:
+  - .{{ salt['pillar.get']('server_id_use_crc', 'default') }}

--- a/srv/salt/ceph/stage/prep/minion/default-no-update-no-reboot.sls
+++ b/srv/salt/ceph/stage/prep/minion/default-no-update-no-reboot.sls
@@ -1,3 +1,9 @@
+crc_method:
+  salt.state:
+    - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
+    - tgt_type: compound
+    - sls: ceph.salt.crc
+
 repo:
   salt.state:
     - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
@@ -28,4 +34,3 @@ mines:
     - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
     - tgt_type: compound
     - sls: ceph.mines
-

--- a/srv/salt/ceph/stage/prep/minion/default-no-update-reboot.sls
+++ b/srv/salt/ceph/stage/prep/minion/default-no-update-reboot.sls
@@ -1,6 +1,10 @@
-
 {% set master = salt['master.minion']() %}
 
+crc_method:
+  salt.state:
+    - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
+    - tgt_type: compound
+    - sls: ceph.salt.crc
 repo:
   salt.state:
     - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
@@ -86,7 +90,7 @@ finished {{ host }}:
 
 {% endfor %}
 
-unset noout after final iteration: 
+unset noout after final iteration:
   salt.state:
     - sls: ceph.noout.unset
     - tgt: {{ master }}

--- a/srv/salt/ceph/stage/prep/minion/default-update-reboot.sls
+++ b/srv/salt/ceph/stage/prep/minion/default-update-reboot.sls
@@ -1,5 +1,10 @@
-
 {% set master = salt['master.minion']() %}
+
+crc_method:
+  salt.state:
+    - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
+    - tgt_type: compound
+    - sls: ceph.salt.crc
 
 repo:
   salt.state:

--- a/srv/salt/ceph/stage/prep/minion/default.sls
+++ b/srv/salt/ceph/stage/prep/minion/default.sls
@@ -1,5 +1,10 @@
-
 {% set master = salt['master.minion']() %}
+
+crc_method:
+  salt.state:
+    - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
+    - tgt_type: compound
+    - sls: ceph.salt.crc
 
 repo:
   salt.state:
@@ -86,7 +91,7 @@ finished {{ host }}:
 
 {% endfor %}
 
-unset noout after final iteration: 
+unset noout after final iteration:
   salt.state:
     - sls: ceph.noout.unset
     - tgt: {{ master }}


### PR DESCRIPTION
salt 2019 complains if there is no such setting.


bonus:
got rid of superfluous whitespaces
