### PR TITLE
Handle broken symlinks

### DIFF
--- a/srv/salt/ceph/functests/1node/symlink/init.sls
+++ b/srv/salt/ceph/functests/1node/symlink/init.sls
@@ -1,0 +1,9 @@
+
+{% set node = salt.saltutil.runner('select.first', roles='storage') %}
+
+Check split partition on symlinks:
+  salt.state:
+    - tgt: {{ node }}
+    - tgt_type: compound
+    - sls: ceph.tests.symlink
+

--- a/srv/salt/ceph/tests/symlink/init.sls
+++ b/srv/salt/ceph/tests/symlink/init.sls
@@ -1,0 +1,29 @@
+
+# Find disk of first OSD
+{% set osd_id = salt['osd.list']() %}
+{% set disk = salt['osd.device'](osd_id[0]) %}
+
+{% set working = salt['file.symlink'](disk + "1", "/tmp/working") %}
+{% set broken = salt['file.symlink'](disk + "Z", "/tmp/broken") %}
+
+{% set wdisk, wpart = salt['osd.split_partition']("/tmp/working") %}
+{% set bdisk, bpart = salt['osd.split_partition']("/tmp/broken") %}
+
+check working symlink:
+  cmd.run:
+    - name: '[ {{ wdisk }} == {{ disk }} ] && [ "1" == {{ wpart }} ]'
+
+check broken symlink:
+  cmd.run:
+    - name: '[ {{ bdisk }} == None ] && [ None == {{ bpart }} ]'
+
+Remove working symlink:
+  module.run:
+    - name: file.remove
+    - path: "/tmp/working"
+
+Remove broken symlink:
+  module.run:
+    - name: file.remove
+    - path: "/tmp/broken"
+


### PR DESCRIPTION
The split_partition function never addressed failures such as broken
symlinks.  Adding a check with an appropriate return cascades into
several other operations.

Signed-off-by: Eric Jackson <ejackson@suse.com>
bsc: 1123344
-----------------

**Checklist:**
- [x] Added unittests and or functional tests
- [ ] Adapted documentation
- [x] Referenced issues or internal bugtracker
- [ ] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
