### PR TITLE
ganesha: drop nfs-ganesha-utils install

### DIFF
--- a/srv/salt/ceph/ganesha/install/default.sls
+++ b/srv/salt/ceph/ganesha/install/default.sls
@@ -17,7 +17,4 @@ install_ganesha:
         - nfs-ganesha
         - nfs-ganesha-ceph
         - nfs-ganesha-rgw
-{% if grains.get('os_family', '') == 'Suse' %}
-        - nfs-ganesha-utils
-{% endif %}
     - fire_event: True


### PR DESCRIPTION
Signed-off-by: Ricardo Dias <rdias@suse.com>


Description:

The management of nfs-ganesha through Ceph dashboard does not require the nfs-ganesha-utils package anymore.