### PR TITLE
Change validation tag from 'openattic' to 'openattic-disabled'

### DIFF
--- a/srv/modules/runners/validate.py
+++ b/srv/modules/runners/validate.py
@@ -689,9 +689,9 @@ class Validate(Preparation):
                        "and finally remove the role-openattic line from your "
                        "policy.cfg. To enable the ceph-dashboard please follow "
                        "the documentation.")
-                self.errors.setdefault('openattic', []).append(msg)
+                self.errors.setdefault('openattic-disabled', []).append(msg)
 
-        self._set_pass_status('openattic')
+        self._set_pass_status('openattic-disabled')
 
     def saltapi(self):
         """


### PR DESCRIPTION
The previous tag is missleading and suggests that
openattic is still valid and enabled.

In SES6(nautilus) oA is being replaced with the ceph-dashboard

-----------------

**Checklist:**
~- [ ] Added unittests and or functional tests~
- [x] Adapted documentation
~- [ ] Referenced issues or internal bugtracker~
- [ ] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
