### PR TITLE
Address removal of dmcrypt partitions

### DIFF
--- a/srv/salt/_modules/osd.py
+++ b/srv/salt/_modules/osd.py
@@ -1522,7 +1522,7 @@ class OSDRemove(object):
                 log.error(msg)
                 return msg
 
-        for func in [self.unmount, self.wipe, self.destroy]:
+        for func in [self.record_dmcrypt, self.unmount, self.wipe, self.destroy]:
             msg = func()
             if msg:
                 log.error(msg)
@@ -1564,6 +1564,17 @@ class OSDRemove(object):
         if _rc == 0:
             return "Failed to terminate OSD {} - pid {}".format(self.osd_id, _stdout)
         return ""
+
+    def record_dmcrypt(self):
+        """
+        Record separate dmcrypt partitions prior to unmounting the OSD.  These
+        are not recorded elsewhere.
+        """
+        for attr in ['block.wal', 'block.db']:
+            device_path = "/var/lib/ceph/osd/ceph-{}/{}_dmcrypt".format(self.osd_id, attr)
+            if os.path.exists(device_path):
+                log.debug("recording {}_dmcrypt".format(attr))
+                self.partitions["{}_dmcrypt".format(attr)] = readlink(device_path)
 
     def unmount(self):
         """

--- a/tests/unit/_modules/test_osd.py
+++ b/tests/unit/_modules/test_osd.py
@@ -2690,6 +2690,35 @@ class TestOSDRemove():
     f_os = fake_fs.FakeOsModule(fs)
     f_open = fake_fs.FakeFileOpen(fs)
 
+    @patch('os.path.exists', new=f_os.path.exists)
+    def test_record_dmcrypt_does_nothing(self):
+        partitions = {'osd': '/dev/sda1'}
+        mock_device = mock.Mock()
+        mock_device.partitions.return_value = partitions
+
+        osdr = osd.OSDRemove(1, mock_device, None, None)
+        osdr.record_dmcrypt()
+
+        assert 'block.wal_dmcrypt' not in partitions
+        assert 'block.db_dmcrypt' not in partitions
+
+    @patch('os.path.exists', new=f_os.path.exists)
+    def test_record_dmcrypt_assigns_attrs(self):
+        TestOSDRemove.fs.CreateFile('/var/lib/ceph/osd/ceph-1/block.wal_dmcrypt')
+        TestOSDRemove.fs.CreateFile('/var/lib/ceph/osd/ceph-1/block.db_dmcrypt')
+        partitions = {'osd': '/dev/sda1'}
+        mock_device = mock.Mock()
+        mock_device.partitions.return_value = partitions
+
+        osdr = osd.OSDRemove(1, mock_device, None, None)
+        osdr.record_dmcrypt()
+
+        TestOSDRemove.fs.RemoveFile('/var/lib/ceph/osd/ceph-1/block.wal_dmcrypt')
+        TestOSDRemove.fs.RemoveFile('/var/lib/ceph/osd/ceph-1/block.db_dmcrypt')
+
+        assert 'block.wal_dmcrypt' in partitions
+        assert 'block.db_dmcrypt' in partitions
+
     @patch('srv.salt._modules.osd._run')
     @patch('os.rmdir')
     @patch('__builtin__.open', new=f_open)
@@ -2763,7 +2792,7 @@ class TestOSDRemove():
         mock_rl.return_value = '/dev/sda1'
         result = osdr._mounted()
         assert '/dev/sda1' in result
-        
+
     @patch('srv.salt._modules.osd.readlink')
     def test_mounted_lockbox(self, mock_rl):
         partitions = {'lockbox': '/dev/sda1'}
@@ -2774,7 +2803,7 @@ class TestOSDRemove():
         mock_rl.return_value = '/dev/sda1'
         result = osdr._mounted()
         assert '/dev/sda1' in result
-        
+
     def test_mounted_none(self):
         partitions = {}
         mock_device = mock.Mock()


### PR DESCRIPTION
Only the device mapper entries were unmapped.  Now, the partitions on separate media are also removed.

Signed-off-by: Eric Jackson <ejackson@suse.com>
bsc: 1122326
-----------------

**Checklist:**
- [x] Added unittests and or functional tests
- [ ] Adapted documentation
- [x] Referenced issues or internal bugtracker
- [ ] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
