### PR TITLE
stage 3: configure deepsea mgr orchestrator module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,8 @@ copy-files:
 	install -m 644 srv/salt/ceph/tests/keyrings/*.sls $(DESTDIR)/srv/salt/ceph/tests/keyrings
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/tests/openstack
 	install -m 644 srv/salt/ceph/tests/openstack/*.sls $(DESTDIR)/srv/salt/ceph/tests/openstack
+	install -d -m 755 $(DESTDIR)/srv/salt/ceph/tests/orchestrator
+	install -m 644 srv/salt/ceph/tests/orchestrator/*.sls $(DESTDIR)/srv/salt/ceph/tests/orchestrator
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/tests/os_switch
 	install -m 644 srv/salt/ceph/tests/os_switch/*.sls $(DESTDIR)/srv/salt/ceph/tests/os_switch
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/tests/quiescent
@@ -133,6 +135,8 @@ copy-files:
 	install -m 644 srv/salt/ceph/functests/1node/macros/os_switch/*.sls $(DESTDIR)/srv/salt/ceph/functests/1node/macros/os_switch
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/functests/1node/openstack
 	install -m 644 srv/salt/ceph/functests/1node/openstack/*.sls $(DESTDIR)/srv/salt/ceph/functests/1node/openstack
+	install -d -m 755 $(DESTDIR)/srv/salt/ceph/functests/1node/orchestrator
+	install -m 644 srv/salt/ceph/functests/1node/orchestrator/*.sls $(DESTDIR)/srv/salt/ceph/functests/1node/orchestrator
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/functests/1node/quiescent
 	install -m 644 srv/salt/ceph/functests/1node/quiescent/*.sls $(DESTDIR)/srv/salt/ceph/functests/1node/quiescent
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/functests/1node/migrate
@@ -350,6 +354,8 @@ copy-files:
 	install -m 644 srv/salt/ceph/mgr/keyring/*.sls $(DESTDIR)/srv/salt/ceph/mgr/keyring/
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/mgr/files
 	install -m 644 srv/salt/ceph/mgr/files/*.j2 $(DESTDIR)/srv/salt/ceph/mgr/files/
+	install -d -m 755 $(DESTDIR)/srv/salt/ceph/mgr/orchestrator
+	install -m 644 srv/salt/ceph/mgr/orchestrator/*.sls $(DESTDIR)/srv/salt/ceph/mgr/orchestrator/
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/mgr/restart
 	install -m 644 srv/salt/ceph/mgr/restart/*.sls $(DESTDIR)/srv/salt/ceph/mgr/restart
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/mgr/restart/force

--- a/deepsea.spec.in
+++ b/deepsea.spec.in
@@ -165,6 +165,7 @@ systemctl try-restart salt-api > /dev/null 2>&1 || :
 %dir /srv/salt/ceph/mgr/key
 %dir /srv/salt/ceph/mgr/auth
 %dir /srv/salt/ceph/mgr/keyring
+%dir /srv/salt/ceph/mgr/orchestrator
 %dir /srv/salt/ceph/mgr/restart
 %dir /srv/salt/ceph/mgr/restart/force
 %dir /srv/salt/ceph/mgr/restart/controlled
@@ -518,6 +519,7 @@ systemctl try-restart salt-api > /dev/null 2>&1 || :
 %config /srv/salt/ceph/mgr/dashboard/*.sls
 %config /srv/salt/ceph/mgr/auth/*.sls
 %config /srv/salt/ceph/mgr/keyring/*.sls
+%config /srv/salt/ceph/mgr/orchestrator/*.sls
 %config /srv/salt/ceph/mgr/restart/*.sls
 %config /srv/salt/ceph/mgr/restart/force/*.sls
 %config /srv/salt/ceph/mgr/restart/controlled/*.sls

--- a/srv/salt/ceph/functests/1node/init.sls
+++ b/srv/salt/ceph/functests/1node/init.sls
@@ -11,3 +11,4 @@ include:
   # - .symlink
   - .tuned
   - .terminate.all
+  - .orchestrator

--- a/srv/salt/ceph/functests/1node/orchestrator/init.sls
+++ b/srv/salt/ceph/functests/1node/orchestrator/init.sls
@@ -1,0 +1,7 @@
+{% set master = salt['master.minion']() %}
+
+check orchestrator:
+  salt.state:
+    - tgt: {{ master }}
+    - tgt_type: compound
+    - sls: ceph.tests.orchestrator

--- a/srv/salt/ceph/mgr/orchestrator/default.sls
+++ b/srv/salt/ceph/mgr/orchestrator/default.sls
@@ -1,0 +1,20 @@
+ceph mgr module enable deepsea:
+  cmd.run:
+  - failhard: True
+
+ceph orchestrator set backend deepsea:
+  cmd.run:
+  - failhard: True
+
+ceph deepsea config-set salt_api_url "{{ salt['pillar.get']('salt_api_url') }}":
+  cmd.run:
+  - failhard: True
+
+ceph deepsea config-set salt_api_username "{{ salt['pillar.get']('salt_api_username') }}":
+  cmd.run:
+  - failhard: True
+
+ceph deepsea config-set salt_api_password "{{ salt['pillar.get']('salt_api_password') }}":
+  cmd.run:
+  - failhard: True
+

--- a/srv/salt/ceph/mgr/orchestrator/init.sls
+++ b/srv/salt/ceph/mgr/orchestrator/init.sls
@@ -1,0 +1,2 @@
+include:
+  - .{{ salt['pillar.get']('mgr_orchestrator', 'default') }}

--- a/srv/salt/ceph/stage/deploy/core/default.sls
+++ b/srv/salt/ceph/stage/deploy/core/default.sls
@@ -127,6 +127,17 @@ dashboard:
     - sls: ceph.dashboard
     - failhard: True
 
+mgr orchestrator module:
+  salt.state:
+    - tgt: {{ master }}
+    - tgt_type: compound
+    - sls: ceph.mgr.orchestrator
+    - pillar:
+        'salt_api_url': http://{{ master }}:8000/
+        'salt_api_username': admin
+        'salt_api_password': {{ salt.saltutil.runner('sharedsecret.show') }}
+    - failhard: True
+
 osd auth:
   salt.state:
     - tgt: {{ master }}

--- a/srv/salt/ceph/tests/orchestrator/init.sls
+++ b/srv/salt/ceph/tests/orchestrator/init.sls
@@ -1,0 +1,13 @@
+"ceph orchestrator status | grep 'Backend: deepsea'":
+  cmd.run
+
+"ceph orchestrator status | grep 'Available: True'":
+  cmd.run
+
+# This is very rough, but at least gives us the assurance that
+# `ceph orchestrator service ls` does print out at least two lines of
+# service status for mon and mgr instances, thus demonstrating that
+# the orchestrator module can talk to deepsea to find out what's running
+'test "$(ceph orchestrator service ls | grep -e ^mon -e ^mgr | wc -l)" -gt 2':
+  cmd.run
+


### PR DESCRIPTION
This enables the deepsea mgr orchestrator module, sets it as the
current orchestrator backend, and configures it to talk to the
salt-api service.

Signed-off-by: Tim Serong <tserong@suse.com>

-----------------

**Checklist:**
- [x] Added unittests and or functional tests
- [ ] Adapted documentation
- [ ] Referenced issues or internal bugtracker
- [ ] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
