### PR TITLE
rgw: start making beast as a default frontend

### DIFF
--- a/srv/salt/ceph/configuration/files/rgw-ssl.conf
+++ b/srv/salt/ceph/configuration/files/rgw-ssl.conf
@@ -1,4 +1,4 @@
 [client.{{ client }}]
-rgw frontends = "civetweb port=443s ssl_certificate=/etc/ceph/rgw.pem"
+rgw frontends = "beast ssl_port=443 ssl_certificate=/etc/ceph/rgw.pem"
 rgw dns name = {{ fqdn }}
 rgw enable usage log = true

--- a/srv/salt/ceph/configuration/files/rgw.conf
+++ b/srv/salt/ceph/configuration/files/rgw.conf
@@ -1,4 +1,4 @@
 [client.{{ client }}]
-rgw frontends = "civetweb port=80"
+rgw frontends = "beast port=80"
 rgw dns name = {{ fqdn }}
 rgw enable usage log = true


### PR DESCRIPTION
Fixes: https://github.com/SUSE/DeepSea/issues/1028





Description:

It is recommended to default to beast as the rgw frontend from mimic release onwards. Support this as the new default. I'd love some opinions on how to handle the upgrade scenarios. 

-----------------

**Checklist:**
- [ ] Added unittests and or functional tests
- [ ] Adapted documentation
- [ ] Referenced issues or internal bugtracker
- [ ] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
