### PR TITLE
ceph.packages: Install ceph-mgr-dashboard package

### DIFF
--- a/srv/salt/ceph/packages/default.sls
+++ b/srv/salt/ceph/packages/default.sls
@@ -3,5 +3,6 @@ ceph:
   pkg.installed:
     - pkgs:
       - ceph
+      - ceph-mgr-dashboard
     - refresh: True
     - fire_event: True


### PR DESCRIPTION
Along with the rest of the ceph server packages in Stage 3.

Fixes: https://github.com/SUSE/DeepSea/issues/1550
Signed-off-by: Nathan Cutler <ncutler@suse.com>
