### PR TITLE
Add dashboard orchestration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -310,6 +310,9 @@ copy-files:
 	# state files - macros
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/macros
 	install -m 644 srv/salt/ceph/macros/*.sls $(DESTDIR)/srv/salt/ceph/macros/
+	# state files - dashboard
+	install -d -m 755 $(DESTDIR)/srv/salt/ceph/dashboard
+	install -m 644 srv/salt/ceph/dashboard/*.sls $(DESTDIR)/srv/salt/ceph/dashboard/
 	# state files - mds
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/mds
 	install -m 644 srv/salt/ceph/mds/*.sls $(DESTDIR)/srv/salt/ceph/mds/

--- a/deepsea.spec.in
+++ b/deepsea.spec.in
@@ -116,6 +116,7 @@ systemctl try-restart salt-api > /dev/null 2>&1 || :
 %dir /srv/salt/ceph/cephfs/benchmarks
 %dir /srv/salt/ceph/cephfs/benchmarks/files
 %dir /srv/salt/ceph/metapackage
+%dir /srv/salt/ceph/dashboard
 %dir /srv/salt/ceph/salt-api
 %dir /srv/salt/ceph/salt-api/files
 %dir /srv/salt/ceph/configuration
@@ -467,6 +468,7 @@ systemctl try-restart salt-api > /dev/null 2>&1 || :
 %config /srv/salt/ceph/cephfs/benchmarks/*.sls
 %config /srv/salt/ceph/cephfs/benchmarks/files/keyring.j2
 %config /srv/salt/ceph/metapackage/*.sls
+%config /srv/salt/ceph/dashboard/*.sls
 %config /srv/salt/ceph/salt-api/*.sls
 %config /srv/salt/ceph/salt-api/files/*.conf*
 %config /srv/salt/ceph/tools/benchmarks/*.sls

--- a/srv/salt/ceph/dashboard/default.sls
+++ b/srv/salt/ceph/dashboard/default.sls
@@ -1,0 +1,32 @@
+{% set dashboard_user = salt['pillar.get']('dashboard_user', 'admin') %}
+{% set dashboard_pw = salt['pillar.get']('dashboard_password', salt['grains.get']('dashboard_creds:' ~ dashboard_user , salt['random.get_str'](10))) %}
+
+enable ceph dashboard:
+  cmd.run:
+    - name: ceph mgr module enable dashboard
+    - failhard: True
+
+create self signed certificate:
+  cmd.run:
+    - name: ceph dashboard create-self-signed-cert
+    - failhard: True
+
+dashboard user exists:
+  cmd.run:
+    - name: /bin/true
+    - unless: ceph dashboard ac-user-show -f json | jq -e 'index("{{ dashboard_user }}")'
+
+set username and password:
+  cmd.run:
+    # This command is printed although the 'onchange' statement evaluates as true. This might cause confusion.
+    - name: ceph dashboard ac-user-create {{ dashboard_user }} {{ dashboard_pw }} administrator
+    - onchanges:
+        - cmd: dashboard user exists
+
+set dashboard password grain:
+  module.run:
+    - name: grains.set
+    - key: dashboard_creds:{{ dashboard_user }}
+    - val: {{ dashboard_pw }}
+    - onchanges:
+        - cmd: set username and password

--- a/srv/salt/ceph/dashboard/init.sls
+++ b/srv/salt/ceph/dashboard/init.sls
@@ -1,0 +1,2 @@
+include:
+  - .{{ salt['pillar.get']('dashboard_init', 'default') }}

--- a/srv/salt/ceph/stage/deploy/core/default.sls
+++ b/srv/salt/ceph/stage/deploy/core/default.sls
@@ -119,6 +119,12 @@ wait for mgr to be available:
     - tgt_type: compound
     - kwarg:
         'cmd': 'test "$(ceph mgr dump | jq .available)" = "true"'
+
+dashboard:
+  salt.state:
+    - tgt: {{ master }}
+    - tgt_type: compound
+    - sls: ceph.dashboard
     - failhard: True
 
 osd auth:


### PR DESCRIPTION
I adapted the logic as follows:

* Username will default to 'admin' if not defined in the pillar (which takes precedence)
* Password will be generated with a salt internal function (`random.get_str(10)`) unless defined in the pillar (which takes precedence)

Since only `ceph mgr module enable dashboard` and `ceph dashboard create-self-signed-cert` are idempotent, there needs to be a check for the presence of the `dashboard_user` before actually creating the user.

After a user is created, the password will be stored in a grain structure looking like this:

``` yaml
dasboard_creds:
  username_1:
      password_1
  username_2:
      password_2
```

This structure will not allow to add multiple users at once (maybe we should?) but it will guarantee that switching to a new user, by changing the value in the pillar, will not overwrite the existing user's password.

If a user is present. There will be no action.

Due to how salt works, the password(respective) will be printed to the screen. This (may) be avoided using jinja conditionals, which I'd like to avoid..

Storing the passwords in the master's grain is maybe not the best technique security wise, but better than storing it in the pillar (which we do when specifying the password) as it doesn't leave the node.

The passwords can be queried with:

```
admin:~ # salt -I roles:master grains.get dashboard_creds
admin:
    ----------
    foo:
        ltfCTW33Ak
    bar:
        oVOhYBromI
    baz:
        askdJskaMas
```

Theoretically we can also implement a password changing mechanism controlled via the pillar with ` ceph dashboard ac-user-set-password <username> <password>`

Comments, notes, concerns?

----------------

- [ ] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
