### PR TITLE
monitoring: defer deployment to stage 3

### DIFF
--- a/srv/salt/ceph/stage/configure/default.sls
+++ b/srv/salt/ceph/stage/configure/default.sls
@@ -35,28 +35,6 @@ show networks:
 
 {% endfor %}
 
-{% if (salt.saltutil.runner('select.minions', cluster='ceph', roles='prometheus') != []) %}
-
-populate scrape configs:
-  salt.state:
-    - tgt: {{ master }}
-    - tgt_type: compound
-    - sls: ceph.monitoring.prometheus.populate_scrape_configs
-
-install prometheus:
-  salt.state:
-    - tgt: 'I@roles:prometheus and I@cluster:ceph'
-    - tgt_type: compound
-    - sls: ceph.monitoring.prometheus.install
-
-push scrape configs:
-  salt.state:
-    - tgt: 'I@roles:prometheus and I@cluster:ceph'
-    - tgt_type: compound
-    - sls: ceph.monitoring.prometheus.push_scrape_configs
-
-{% endif %}
-
 install and setup node exporters:
   salt.state:
     - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
@@ -66,19 +44,3 @@ install and setup node exporters:
 advise OSDs:
   salt.runner:
     - name: advise.osds
-
-{% if (salt.saltutil.runner('select.minions', cluster='ceph', roles='grafana') != []) %}
-
-populate grafana datasources:
-  salt.state:
-    - tgt: {{ master }}
-    - tgt_type: compound
-    - sls: ceph.monitoring.grafana.populate_datasources
-
-install grafana:
-  salt.state:
-    - tgt: 'I@roles:grafana and I@cluster:ceph'
-    - tgt_type: compound
-    - sls: ceph.monitoring.grafana
-
-{% endif %}

--- a/srv/salt/ceph/stage/deploy/default.sls
+++ b/srv/salt/ceph/stage/deploy/default.sls
@@ -1,6 +1,7 @@
 {% set master = salt['master.minion']() %}
 
 include:
+  - .monitoring
   - .core
   - ...restart.mon.lax
   - ...restart.mgr.lax
@@ -11,6 +12,8 @@ enable prometheus module:
     - tgt: {{ master }}
     - tgt_type: compound
     - sls: ceph.monitoring.prometheus.exporters.mgr_exporter
+    - require:
+      - salt: mgrs # from .core/default.sls
 
 {% if (salt.saltutil.runner('select.minions', cluster='ceph', roles='prometheus') != []) %}
 
@@ -19,6 +22,8 @@ populate mgr scrape configs:
     - tgt: {{ master }}
     - tgt_type: compound
     - sls: ceph.monitoring.prometheus.populate_mgr_scrape_configs
+    - require:
+      - salt: enable prometheus module
 
 distribute mgr scrape configs:
   salt.state:

--- a/srv/salt/ceph/stage/deploy/monitoring.sls
+++ b/srv/salt/ceph/stage/deploy/monitoring.sls
@@ -1,0 +1,39 @@
+{% set master = salt['master.minion']() %}
+
+{% if (salt.saltutil.runner('select.minions', cluster='ceph', roles='prometheus') != []) %}
+
+populate scrape configs:
+  salt.state:
+    - tgt: {{ master }}
+    - tgt_type: compound
+    - sls: ceph.monitoring.prometheus.populate_scrape_configs
+
+install prometheus:
+  salt.state:
+    - tgt: 'I@roles:prometheus and I@cluster:ceph'
+    - tgt_type: compound
+    - sls: ceph.monitoring.prometheus.install
+
+push scrape configs:
+  salt.state:
+    - tgt: 'I@roles:prometheus and I@cluster:ceph'
+    - tgt_type: compound
+    - sls: ceph.monitoring.prometheus.push_scrape_configs
+
+{% endif %}
+
+{% if (salt.saltutil.runner('select.minions', cluster='ceph', roles='grafana') != []) %}
+
+populate grafana datasources:
+  salt.state:
+    - tgt: {{ master }}
+    - tgt_type: compound
+    - sls: ceph.monitoring.grafana.populate_datasources
+
+install grafana:
+  salt.state:
+    - tgt: 'I@roles:grafana and I@cluster:ceph'
+    - tgt_type: compound
+    - sls: ceph.monitoring.grafana
+
+{% endif %}


### PR DESCRIPTION
Otherwise role assignments are not accessible since jinja is evaluated
before anything is run, including push.proposals and pillar sync (and thus
role-based switches get evaluated before roles are in the pillar).

Signed-off-by: Jan Fajerski <jfajerski@suse.com>