### PR TITLE
Handle broken symlinks

### DIFF
--- a/srv/salt/ceph/functests/1node/init.sls
+++ b/srv/salt/ceph/functests/1node/init.sls
@@ -8,5 +8,6 @@ include:
   - .restart.rgw
   - .apparmor
   - .openstack
+  - .symlink
   - .tuned
   - .terminate.all

--- a/srv/salt/ceph/functests/1node/symlink/init.sls
+++ b/srv/salt/ceph/functests/1node/symlink/init.sls
@@ -1,0 +1,9 @@
+
+{% set node = salt.saltutil.runner('select.first', roles='storage') %}
+
+Check split partition on symlinks:
+  salt.state:
+    - tgt: {{ node }}
+    - tgt_type: compound
+    - sls: ceph.tests.symlink
+

--- a/srv/salt/ceph/tests/symlink/init.sls
+++ b/srv/salt/ceph/tests/symlink/init.sls
@@ -1,0 +1,29 @@
+
+# Find disk of first OSD
+{% set osd_id = salt['osd.list']() %}
+{% set disk = salt['osd.device'](osd_id[0]) %}
+
+{% set working = salt['file.symlink'](disk + "1", "/tmp/working") %}
+{% set broken = salt['file.symlink'](disk + "Z", "/tmp/broken") %}
+
+{% set wdisk, wpart = salt['osd.split_partition']("/tmp/working") %}
+{% set bdisk, bpart = salt['osd.split_partition']("/tmp/broken") %}
+
+check working symlink:
+  cmd.run:
+    - name: '[ {{ wdisk }} == {{ disk }} ] && [ "1" == {{ wpart }} ]'
+
+check broken symlink:
+  cmd.run:
+    - name: '[ {{ bdisk }} == None ] && [ None == {{ bpart }} ]'
+
+Remove working symlink:
+  module.run:
+    - name: file.remove
+    - path: "/tmp/working"
+
+Remove broken symlink:
+  module.run:
+    - name: file.remove
+    - path: "/tmp/broken"
+

--- a/tests/unit/_modules/test_osd.py
+++ b/tests/unit/_modules/test_osd.py
@@ -2234,25 +2234,31 @@ class TestOSDCommands():
 
 class Testsplit_partition():
 
+    @patch('os.path.exists')
     @patch('srv.salt._modules.osd.readlink')
-    def test_split_partition(self, readlink):
+    def test_split_partition(self, readlink, exists):
+        exists.return_value = True
         readlink.return_value = "/dev/sda1"
         disk, part = osd.split_partition("/dev/sda1")
         assert disk == "/dev/sda"
         assert part == "1"
 
+    @patch('os.path.exists')
     @patch('srv.salt._modules.osd.readlink')
-    def test_split_partition_on_nvme(self, readlink):
+    def test_split_partition_on_nvme(self, readlink, exists):
+        exists.return_value = True
         readlink.return_value = "/dev/nvme0n1p1"
         disk, part = osd.split_partition("/dev/nvme0n1p1")
         assert disk == "/dev/nvme0n1"
         assert part == "1"
 
+    @patch('os.path.exists')
     @patch('srv.salt._modules.osd.readlink')
-    def test_split_partition_on_sdp(self, readlink):
+    def test_split_partition_on_sdp(self, readlink, exists):
         """
         Verify that the 'p' never gets truncated with /dev/sdp
         """
+        exists.return_value = True
         readlink.return_value = "/dev/sdp1"
         disk, part = osd.split_partition("/dev/sdp1")
         assert disk == "/dev/sdp"
@@ -2941,6 +2947,16 @@ class TestOSDDestroyed():
     fs = fake_fs.FakeFilesystem()
     f_os = fake_fs.FakeOsModule(fs)
     f_open = fake_fs.FakeFileOpen(fs)
+
+    def test_update_fails(self):
+        """
+        Device is in content
+        force is False
+        expected return -> ""
+        """
+        osdd = osd.OSDDestroyed()
+        result = osdd.update(None, 0)
+        assert "No device provided" in result
 
     @patch('os.path.exists', new=f_os.path.exists)
     @patch('builtins.open', new=f_open)


### PR DESCRIPTION
The split_partition function never addressed failures such as broken
symlinks.  Adding a check with an appropriate return cascades into
several other operations.

Signed-off-by: Eric Jackson <ejackson@suse.com>
ForwardPort: #1531 
-----------------

**Checklist:**
- [ ] Added unittests and or functional tests
- [ ] Adapted documentation
- [ ] Referenced issues or internal bugtracker
- [ ] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
