### PR TITLE
scrape target partitioning, grafana config for dashboard (SES-261)

### DIFF
--- a/srv/modules/runners/populate.py
+++ b/srv/modules/runners/populate.py
@@ -747,19 +747,25 @@ class CephCluster(object):
             'rule_files': [],
             'scrape_interval': {
                 'ceph': '10s',
-                'node': '10s',
+                'node_exporter': '10s',
                 'prometheus': '10s',
                 'grafana': '10s'},
             'relabel_config': {
                 'ceph': [],
-                'node': [],
+                'node_exporter': [],
                 'prometheus': [],
                 'grafana': []},
             'metric_relabel_config': {
                 'ceph': [],
-                'node': [],
+                'node_exporter': [],
                 'prometheus': [],
-                'grafana': []}}}}
+                'grafana': []},
+            'target_partition': {
+                'cepg': '1/1',
+                'node_exporter': '1/1',
+                'prometheus': '1/1',
+                'grafana': '1/1'}
+        }}}
 
     def __init__(self, settings, writer, **kwargs):
         """

--- a/srv/salt/_modules/scrape_targets.py
+++ b/srv/salt/_modules/scrape_targets.py
@@ -1,0 +1,80 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=incompatible-py3-code
+
+"""
+Partitions prometheus scrape targets accoring to pillar data.
+This assume a minion has received all scrape_targets. This module removes
+scrape_target, that this minion is not supposed to have according to pillar
+configuration.
+Currently supported pillar data:
+    n/m: a string with two integers divided by a '/'. Partition list of scrape
+    targets into m partitions and keep partition n, delete the rest. 0/m will
+    remove all scrape targets.
+"""
+
+import logging
+import os
+
+log = logging.getLogger(__name__)
+
+
+def _partition_by_division(scrape_targets, partition_to_keep,
+                           total_partitions):
+    '''
+    :param scrape_targets: a list of which only a partition is to be kept
+    :param partition_to_keep: index of partition to keep
+    :param: total_partitions: the number of partitions
+    :returns: a set of items in scrape_targets, that does not fall in the
+      partition_to_keep
+    :raises IndexError: if partition_to_keep > total_partitions
+    '''
+    partition_length = len(scrape_targets) / total_partitions
+
+    def index(length, i):
+        '''
+        Return the rounded index of the i'th partition with length items per
+        partition
+        '''
+        return round(length * i)
+    partitions = [scrape_targets[index(partition_length, i):
+                                 index(partition_length, i + 1)]
+                  for i in range(total_partitions)]
+    return set(scrape_targets).difference(
+        set(partitions[partition_to_keep - 1]))
+
+
+def partition(exporter='node_exporter'):
+    '''
+    partition a nodes scrape targets. The partitioning specification in stored
+    in the pillar. The format is 'n/m' meaning partition all scrape targets in
+    to m partitions and keep partition number n on this node.
+    '''
+
+    pillar = 'monitoring:prometheus:target_partition:{}'.format(exporter)
+    part_pillar = __salt__['pillar.get'](pillar)
+    if part_pillar == '1/1':
+        # nothing to do
+        return True
+
+    if '/' not in part_pillar:
+        log.error('{} has the wrong format: {}'.format(pillar, part_pillar))
+        return False
+
+    # __salt__['state.apply']('ceph.monitoring.prometheus.push_scrape_configs')
+
+    local_part, all_parts = part_pillar.split('/')
+    scrape_target_path = '/etc/prometheus/SUSE/{}/'.format(exporter)
+
+    targets = sorted(os.listdir(scrape_target_path))
+    to_remove = []
+    if local_part == 0:
+        to_remove = targets
+    else:
+        to_remove = _partition_by_division(targets, local_part, all_parts)
+
+    for filename in to_remove:
+        file_ = '{}/{}'.format(scrape_target_path, filename)
+        log.info('removing scrape target {}'.format(file_))
+        os.remove(file_)
+
+    return True

--- a/srv/salt/ceph/monitoring/grafana/default.sls
+++ b/srv/salt/ceph/monitoring/grafana/default.sls
@@ -59,6 +59,15 @@ ceph grafana dashboard:
     - template: jinja
     - source: salt://ceph/monitoring/grafana/files/ses_dashboards.yaml.j2
 
+add mgr dashboard config section:
+  ini.options_present:
+    - name: /etc/grafana/grafana.ini
+    - sections:
+        auth.anonymous:
+          enabled: true
+          org_name: Main Org.
+          org_role: Viewer
+
 grafana-server:
   service.running:
     - enable: true
@@ -66,4 +75,6 @@ grafana-server:
       - pkg: grafana
     - watch:
       - file: /etc/grafana/provisioning/datasources/ses_datasource.yaml
+      - file: /etc/grafana/provisioning/dashboards/ses_dashboards.yaml
+      - ini: /etc/grafana/grafana.ini
 

--- a/srv/salt/ceph/monitoring/prometheus/push_scrape_configs.sls
+++ b/srv/salt/ceph/monitoring/prometheus/push_scrape_configs.sls
@@ -9,6 +9,10 @@
     - source: salt://ceph/monitoring/prometheus/cache/node_exporter/
     - clean: True
 
+partition node scrape configs:
+  module.run:
+    - name: scrape_targets.partition
+
 /etc/prometheus/SUSE/prometheus/:
   file.recurse:
     - user: prometheus

--- a/tests/unit/_modules/test_scrape_targets.py
+++ b/tests/unit/_modules/test_scrape_targets.py
@@ -1,0 +1,17 @@
+import pytest
+from srv.salt._modules import scrape_targets
+
+
+@pytest.mark.parametrize(
+    'targets, to_keep, total, expected',
+    [
+        ([1, 2, 3, 4, 5, 6], 1, 3, set([3, 4, 5, 6])),
+        ([1, 2, 3, 4, 5, 6], 2, 3, set([1, 2, 5, 6])),
+        ([1, 2, 3, 4, 5, 6], 3, 3, set([1, 2, 3, 4])),
+        ([1, 2, 3, 4, 5], 1, 2, set([3, 4, 5])),
+        ([1, 2, 3, 4, 5], 2, 2, set([1, 2])),
+    ])
+def test_partition_by_division(targets, to_keep, total, expected):
+    res = scrape_targets._partition_by_division(targets, to_keep, total)
+    err_report = 'unexpected partition result: {} vs {}'.format(res, expected)
+    assert res == expected, err_report


### PR DESCRIPTION
This adds scrape target partitioning to the prometheus deployment. For now partitioning is implemented for he node_exporter scrape targets. See also https://github.com/SUSE/DeepSea/wiki/New-Monitoring

Also adds Grafana configuration that the gr dashboard requires. See Step five of http://docs.ceph.com/docs/master/mgr/dashboard/#enabling-the-embedding-of-grafana-dashboards