### PR TITLE
stage 3: wait for mgr to be available after it's initially deployed

### DIFF
--- a/srv/salt/ceph/stage/deploy/core/default.sls
+++ b/srv/salt/ceph/stage/deploy/core/default.sls
@@ -108,6 +108,19 @@ mgrs:
     - sls: ceph.mgr
     - failhard: True
 
+# Immediately after deploying ceph-mgr, it takes a few seconds for the
+# various modules to become available.  If we don't wait for this, any
+# subqeuent `ceph` commands that require mgr will fail (for example
+# `ceph mgr module enable [...]`).
+wait for mgr to be available:
+  salt.function:
+    - name: retry.cmd
+    - tgt: {{ master }}
+    - tgt_type: compound
+    - kwarg:
+        'cmd': 'test "$(ceph mgr dump | jq .available)" = "true"'
+    - failhard: True
+
 osd auth:
   salt.state:
     - tgt: {{ master }}


### PR DESCRIPTION
Immediately after deploying ceph-mgr, it takes a few seconds for the
various modules to become available.  If we don't wait for this, any
subqeuent `ceph` commands that require mgr will fail (for example
`ceph mgr module enable [...]`).

Signed-off-by: Tim Serong <tserong@suse.com>

-----------------

**Checklist:**
- [ ] Added unittests and or functional tests
- [ ] Adapted documentation
- [ ] Referenced issues or internal bugtracker
- [x] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
