### PR TITLE
fix Partition GUID code in guuid_table

### DIFF
--- a/srv/salt/_modules/cephdisks.py
+++ b/srv/salt/_modules/cephdisks.py
@@ -349,8 +349,8 @@ class HardwareDetections(object):
         Search for Ceph Data and Journal partitions
         """
         log.debug("Checking partitions {} on device {}".format(ids, device))
-        guuid_table = {'data': "45B0969E-9B03-4F30-B4C6-B4B80CEFF106",
-                       'journal': "4FBD7E29-9D25-41B8-AFD0-062C0CEFF05D",
+        guuid_table = {'data': "4FBD7E29-9D25-41B8-AFD0-062C0CEFF05D",
+                       'journal': "45B0969E-9B03-4F30-B4C6-B4B80CEFF106",
                        'db': "30CD0809-C2B2-499C-8879-2D6B78529876",
                        'wal': "5CE17FCE-4087-4169-B7FF-056CC58473F9",
                        'osd_lockbox': "FB3AABF9-D25F-47CC-BF5E-721D1816496B",


### PR DESCRIPTION
This patch exchanges partition GUID code in guuid_table.
Partition GUID codes of 'data' and 'journal' are opposite.
There is no problem because key of guuid_table is not used, although.

Signed-off-by: Shingo Iwakura. iwakura.shingo@jp.fujitsu.com

Fixes #


Description:


-----------------

**Checklist:**
- [ ] Added unittests and or functional tests
- [ ] Adapted documentation
- [ ] Referenced issues or internal bugtracker
- [ ] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
