### PR TITLE
ceph.conf: disable msgr2

### DIFF
--- a/srv/salt/ceph/configuration/files/ceph.conf.j2
+++ b/srv/salt/ceph/configuration/files/ceph.conf.j2
@@ -10,6 +10,7 @@ auth_service_required = cephx
 auth_client_required = cephx
 public_network = {{ salt['pillar.get']('public_network') }}
 cluster_network = {{ salt['pillar.get']('cluster_network') }}
+ms_bind_msgr2 = false
 
 # enable old ceph health format in the json output. This fixes the
 # ceph_exporter. This option will only stay until the prometheus plugin takes


### PR DESCRIPTION
Not having this causes a newly deployed Nautilus cluster to come
up in HEALTH_WARN:

```
  cluster:
    id:     6c4a1148-a9ac-3dab-982f-0cb9d2ec1ada
    health: HEALTH_WARN
            4 monitors have not enabled msgr2
```

Fixes: bsc#1128964
Signed-off-by: Nathan Cutler <ncutler@suse.com>

-----------------

**Checklist:**
- [ ] adapt ceph.maintenance.upgrade
- [x] Referenced issues or internal bugtracker
- [ ] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
