### PR TITLE
Create rbd pool for ceph-iscsi

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -298,6 +298,8 @@ copy-files:
 	install -m 644 srv/salt/ceph/igw/auth/*.sls $(DESTDIR)/srv/salt/ceph/igw/auth/
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/igw/keyring
 	install -m 644 srv/salt/ceph/igw/keyring/*.sls $(DESTDIR)/srv/salt/ceph/igw/keyring/
+	install -d -m 755 $(DESTDIR)/srv/salt/ceph/igw/rbd
+	install -m 644 srv/salt/ceph/igw/rbd/*.sls $(DESTDIR)/srv/salt/ceph/igw/rbd/
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/igw/restart
 	install -m 644 srv/salt/ceph/igw/restart/*.sls $(DESTDIR)/srv/salt/ceph/igw/restart
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/igw/restart/force

--- a/deepsea.spec.in
+++ b/deepsea.spec.in
@@ -144,6 +144,7 @@ systemctl try-restart salt-api > /dev/null 2>&1 || :
 %dir /srv/salt/ceph/igw/key
 %dir /srv/salt/ceph/igw/auth
 %dir /srv/salt/ceph/igw/keyring
+%dir /srv/salt/ceph/igw/rbd
 %dir /srv/salt/ceph/igw/restart
 %dir /srv/salt/ceph/igw/restart/force
 %dir /srv/salt/ceph/igw/restart/reload
@@ -498,6 +499,7 @@ systemctl try-restart salt-api > /dev/null 2>&1 || :
 %config /srv/salt/ceph/igw/key/*.sls
 %config /srv/salt/ceph/igw/auth/*.sls
 %config /srv/salt/ceph/igw/keyring/*.sls
+%config /srv/salt/ceph/igw/rbd/*.sls
 %config /srv/salt/ceph/igw/restart/*.sls
 %config /srv/salt/ceph/igw/restart/force/*.sls
 %config /srv/salt/ceph/igw/restart/reload/*.sls

--- a/srv/salt/ceph/igw/rbd/default.sls
+++ b/srv/salt/ceph/igw/rbd/default.sls
@@ -1,0 +1,7 @@
+
+create rbd pool:
+  cmd.run:
+    - name: "ceph osd pool create rbd 128"
+    - unless: "ceph osd pool ls | grep -q rbd$"
+    - fire_event: True
+

--- a/srv/salt/ceph/igw/rbd/init.sls
+++ b/srv/salt/ceph/igw/rbd/init.sls
@@ -1,0 +1,3 @@
+
+include:
+  - .{{ salt['pillar.get']('igw_rbd', 'default') }}

--- a/srv/salt/ceph/stage/iscsi/core/default.sls
+++ b/srv/salt/ceph/stage/iscsi/core/default.sls
@@ -11,6 +11,12 @@ add_mine_cephimages.list_function:
     - tgt: {{ master }}
     - tgt_type: compound
 
+rbd pool:
+  salt.state:
+    - tgt: {{ master }}
+    - tgt_type: compound
+    - sls: ceph.igw.rbd
+
 igw config:
   salt.state:
     - tgt: "I@roles:igw and I@cluster:ceph"


### PR DESCRIPTION
Intentionally leaving out deletion of pool considering that rbd is the
default for other commands and may get used.

Signed-off-by: Eric Jackson <ejackson@suse.com>
bsc: 1129097

-----------------

**Checklist:**
- [ ] Added unittests and or functional tests
- [ ] Adapted documentation
- [x] Referenced issues or internal bugtracker
- [ ] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
