### PR TITLE
[SES5] metapackage: add test.nop stanza

### DIFF
--- a/srv/salt/ceph/metapackage/default.sls
+++ b/srv/salt/ceph/metapackage/default.sls
@@ -1,4 +1,7 @@
 
+metapackage install nop:
+  test.nop
+
 {% if grains.get('osfullname', '') == 'SLES' %}
 metapackage for salt versioning:
   pkg.installed:


### PR DESCRIPTION
Without this, DeepSea fails in openSUSE because the osfullname grain contains
the string "Leap". As a result, the Jinja conditional evaluates to false and
the file becomes empty, causing Salt to generate a bizarre error.

(This is not cherry-picked from master because the fix for this issue in master
is too complicated.)

Signed-off-by: Nathan Cutler <ncutler@suse.com>

Fixes #


Description:


-----------------

**Checklist:**
- [ ] Added unittests and or functional tests
- [ ] Adapted documentation
- [ ] Referenced issues or internal bugtracker
- [x] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
