### PR TITLE
cli: automatically wrap of step lines

### DIFF
--- a/cli/common.py
+++ b/cli/common.py
@@ -81,6 +81,18 @@ def check_terminal_utf8_support():
         return False
 
 
+def get_terminal_size():
+    """
+    Returns the number of rows and columns of the current terminal
+    """
+    with os.popen('stty size', 'r') as f:
+        rows, columns = f.read().split()
+    try:
+        return int(rows), int(columns)
+    except ValueError:
+        return 80, 80
+
+
 class PrettyPrinter(object):
     """
     Helper class to pretty print


### PR DESCRIPTION
Before:

```
[12/15]   ceph.packages.common on
          hses-node1.suse.de......................................... ⏳ (34s)
            |_ pkg.installed(lsscsi, smartmontools, hwinfo, pciutils, gptfdisk, python3-boto, python3-rados, iperf, lsof, jq, tuned, libgio-2_0-0, polkit) ⏳
```

After:
```
[12/83]   ceph.packages.common on
          node3.oa.local.......................................................... ❌ (40s)
            |_ pkg.installed(lsscsi, smartmontools, hwinfo, pciutils, gptfdisk,
                python3-boto, python3-rados, iperf, lsof, jq, tuned,
                libgio-2_0-0, polkit)............................................. ❌
          node1.oa.local.......................................................... ❌ (40s)
            |_ pkg.installed(lsscsi, smartmontools, hwinfo, pciutils, gptfdisk,
                python3-boto, python3-rados, iperf, lsof, jq, tuned,
                libgio-2_0-0, polkit)............................................. ❌
          salt.oa.local........................................................... ❌ (41s)
            |_ pkg.installed(lsscsi, smartmontools, hwinfo, pciutils, gptfdisk,
                python3-boto, python3-rados, iperf, lsof, jq, tuned,
                libgio-2_0-0, polkit)............................................. ❌
          node2.oa.local.......................................................... ❌ (40s)
            |_ pkg.installed(lsscsi, smartmontools, hwinfo, pciutils, gptfdisk,
                python3-boto, python3-rados, iperf, lsof, jq, tuned,
                libgio-2_0-0, polkit)............................................. ❌
```

Signed-off-by: Ricardo Dias <rdias@suse.com>

