### PR TITLE
Makefile: install symlink tests and functests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,6 +100,7 @@ copy-files:
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/tests/restart/rgw/nochange
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/tests/tuned
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/tests/tuned/off
+	install -d -m 755 $(DESTDIR)/srv/salt/ceph/tests/symlink
 	install -m 644 srv/salt/ceph/tests/restart/*.sls $(DESTDIR)/srv/salt/ceph/tests/restart
 	install -m 644 srv/salt/ceph/tests/restart/mon/*.sls $(DESTDIR)/srv/salt/ceph/tests/restart/mon
 	install -m 644 srv/salt/ceph/tests/restart/mon/change/*.sls $(DESTDIR)/srv/salt/ceph/tests/restart/mon/change
@@ -119,6 +120,7 @@ copy-files:
 	install -m 644 srv/salt/ceph/tests/restart/rgw/nochange/*.sls $(DESTDIR)/srv/salt/ceph/tests/restart/rgw/nochange
 	install -m 644 srv/salt/ceph/tests/tuned/*.sls $(DESTDIR)/srv/salt/ceph/tests/tuned
 	install -m 644 srv/salt/ceph/tests/tuned/off/*.sls $(DESTDIR)/srv/salt/ceph/tests/tuned/off
+	install -m 644 srv/salt/ceph/tests/symlink/*.sls $(DESTDIR)/srv/salt/ceph/tests/symlink
 	# functests/1node
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/functests/1node
 	install -m 644 srv/salt/ceph/functests/1node/*.sls $(DESTDIR)/srv/salt/ceph/functests/1node
@@ -156,6 +158,8 @@ copy-files:
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/functests/1node/tuned/off
 	install -m 644 srv/salt/ceph/functests/1node/tuned/*.sls $(DESTDIR)/srv/salt/ceph/functests/1node/tuned
 	install -m 644 srv/salt/ceph/functests/1node/tuned/off/*.sls $(DESTDIR)/srv/salt/ceph/functests/1node/tuned/off
+	install -d -m 755 $(DESTDIR)/srv/salt/ceph/functests/1node/symlink
+	install -m 644 srv/salt/ceph/functests/1node/symlink/*.sls $(DESTDIR)/srv/salt/ceph/functests/1node/symlink
 	# docs
 	install -d -m 755 $(DESTDIR)$(DOCDIR)/deepsea
 	install -m 644 LICENSE $(DESTDIR)$(DOCDIR)/deepsea/

--- a/srv/salt/ceph/functests/1node/init.sls
+++ b/srv/salt/ceph/functests/1node/init.sls
@@ -8,6 +8,6 @@ include:
   - .restart.rgw
   - .apparmor
   - .openstack
-  - .symlink
+  # - .symlink
   - .tuned
   - .terminate.all


### PR DESCRIPTION
This fixes a regression introduced by 9ce9f95cab1f1e24afa4bb405dd82b4e6ce0f06c
which was found by the CI.

The commit in question added the following directories:

srv/salt/ceph/functests/1node/symlink/
srv/salt/ceph/tests/symlink/

each containing a single file called "init.sls". However, since the commit did
not add the respective lines to Makefile, the new directories and files did not
make it into the deepsea-qa RPM, nor are they created when DeepSea is installed
via the "make install" method.

Signed-off-by: Nathan Cutler <ncutler@suse.com>
