### PR TITLE
rgw.py: tolerate a certain number of S3 connection failures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -839,6 +839,8 @@ copy-files:
 	install -m 644 srv/salt/ceph/stage/radosgw/*.sls $(DESTDIR)/srv/salt/ceph/stage/radosgw/
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/stage/radosgw/core
 	install -m 644 srv/salt/ceph/stage/radosgw/core/*.sls $(DESTDIR)/srv/salt/ceph/stage/radosgw/core
+	install -d -m 755 $(DESTDIR)/srv/salt/ceph/stage/radosgw/buckets
+	install -m 644 srv/salt/ceph/stage/radosgw/buckets/*.sls $(DESTDIR)/srv/salt/ceph/stage/radosgw/buckets
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/stage/services
 	install -m 644 srv/salt/ceph/stage/services/*.sls $(DESTDIR)/srv/salt/ceph/stage/services/
 	# state files - orchestrate shared

--- a/deepsea.spec.in
+++ b/deepsea.spec.in
@@ -347,6 +347,7 @@ systemctl try-restart salt-api > /dev/null 2>&1 || :
 %dir /srv/salt/ceph/stage/prep/minion
 %dir /srv/salt/ceph/stage/radosgw
 %dir /srv/salt/ceph/stage/radosgw/core
+%dir /srv/salt/ceph/stage/radosgw/buckets
 %dir /srv/salt/ceph/stage/removal
 %dir /srv/salt/ceph/stage/services
 %dir /srv/salt/ceph/stage/validate
@@ -697,6 +698,7 @@ systemctl try-restart salt-api > /dev/null 2>&1 || :
 %config /srv/salt/ceph/stage/prep/minion/*.sls
 %config /srv/salt/ceph/stage/radosgw/*.sls
 %config /srv/salt/ceph/stage/radosgw/core/*.sls
+%config /srv/salt/ceph/stage/radosgw/buckets/*.sls
 %config /srv/salt/ceph/stage/removal/*.sls
 %config /srv/salt/ceph/stage/services/*.sls
 %config /srv/salt/ceph/stage/validate/*.sls

--- a/srv/salt/_modules/rgw.py
+++ b/srv/salt/_modules/rgw.py
@@ -296,6 +296,10 @@ def create_bucket(**kwargs):
         s3conn.create_bucket(kwargs['bucket_name'])
     except boto.exception.S3CreateError:
         return False
+    except Exception as err:
+        log.exception("Other boto exception")
+        print('Other boto exception: ', err)
+        raise
     return True
 
 

--- a/srv/salt/ceph/stage/radosgw/buckets/default.sls
+++ b/srv/salt/ceph/stage/radosgw/buckets/default.sls
@@ -1,0 +1,12 @@
+
+{% set master = salt['master.minion']() %}
+
+{% if salt.saltutil.runner('select.minions', cluster='ceph', roles='rgw') or salt.saltutil.runner('select.minions', cluster='ceph', rgw_configurations='*') %}
+
+rgw demo buckets:
+  salt.state:
+    - tgt: {{ master }}
+    - tgt_type: compound
+    - sls: ceph.rgw.buckets
+
+{% endif %}

--- a/srv/salt/ceph/stage/radosgw/buckets/default.sls
+++ b/srv/salt/ceph/stage/radosgw/buckets/default.sls
@@ -8,5 +8,6 @@ rgw demo buckets:
     - tgt: {{ master }}
     - tgt_type: compound
     - sls: ceph.rgw.buckets
+    - failhard: True
 
 {% endif %}

--- a/srv/salt/ceph/stage/radosgw/buckets/init.sls
+++ b/srv/salt/ceph/stage/radosgw/buckets/init.sls
@@ -1,0 +1,4 @@
+
+include:
+  - .{{ salt['pillar.get']('stage_radosgw_core', 'default') }}
+

--- a/srv/salt/ceph/stage/radosgw/core/default.sls
+++ b/srv/salt/ceph/stage/radosgw/core/default.sls
@@ -31,10 +31,4 @@ setup prometheus rgw exporter:
     - tgt_type: compound
     - sls: ceph.monitoring.prometheus.exporters.ceph_rgw_exporter
 
-rgw demo buckets:
-  salt.state:
-    - tgt: {{ master }}
-    - tgt_type: compound
-    - sls: ceph.rgw.buckets
-
 {% endif %}

--- a/srv/salt/ceph/stage/radosgw/default.sls
+++ b/srv/salt/ceph/stage/radosgw/default.sls
@@ -2,3 +2,4 @@
 include:
   - .core
   - ...restart.rgw.lax
+  - .buckets


### PR DESCRIPTION
This commit implements a try-wait loop around the S3 connection
in create_buckets().

Fixes: https://github.com/SUSE/DeepSea/issues/1580
Signed-off-by: Nathan Cutler <ncutler@suse.com>
