### PR TITLE
qa: ensure mgr is available prior to orchestrator tests

### DIFF
--- a/srv/salt/ceph/tests/orchestrator/init.sls
+++ b/srv/salt/ceph/tests/orchestrator/init.sls
@@ -1,13 +1,23 @@
+ensure mgr is available:
+  module.run:
+    - name: retry.cmd
+    - kwargs:
+        'cmd': 'test "$(ceph mgr dump | jq .available)" = "true"'
+    - failhard: True
+
 "ceph orchestrator status | grep 'Backend: deepsea'":
-  cmd.run
+  cmd.run:
+    - failhard: True
 
 "ceph orchestrator status | grep 'Available: True'":
-  cmd.run
+  cmd.run:
+    - failhard: True
 
 # This is very rough, but at least gives us the assurance that
 # `ceph orchestrator service ls` does print out at least two lines of
 # service status for mon and mgr instances, thus demonstrating that
 # the orchestrator module can talk to deepsea to find out what's running
 'test "$(ceph orchestrator service ls | grep -e ^mon -e ^mgr | wc -l)" -gt 2':
-  cmd.run
+  cmd.run:
+    - failhard: True
 

--- a/srv/salt/ceph/tests/orchestrator/init.sls
+++ b/srv/salt/ceph/tests/orchestrator/init.sls
@@ -1,3 +1,10 @@
+# Force the orchestrator test to fail at this point, before doing
+# anything at all, and dump out the current cluster status
+"ceph status 2>&1 ; false":
+  cmd.run:
+    - failhard: True
+
+# This is unlikely to actually be necessary
 ensure mgr is available:
   module.run:
     - name: retry.cmd


### PR DESCRIPTION
The orchestrator functests are run immediately after the
terminate functests.  It's possible mgr hasn't quite finished
re-loading at this point, which will cause the orchestrator
functests to fail.

Signed-off-by: Tim Serong <tserong@suse.com>