### PR TITLE
qa: disable apparmor at end of functest

### DIFF
--- a/srv/salt/ceph/functests/1node/apparmor/init.sls
+++ b/srv/salt/ceph/functests/1node/apparmor/init.sls
@@ -7,9 +7,23 @@ enforce apparmor profiles:
     - sls: ceph.apparmor.default-enforce
     - failhard: True
 
+# The below test is insufficient; as of 2019-03-27,
+# the apparmor profile for ceph-mgr won't let ceph-mgr
+# operate correctly, but you only notice this if ceph-mgr
+# is restarted.  If it's already running the cluster will
+# remain healthy.
+# TODO: restart all daemons after putting apparmor into
+# enforcing mode, *then* check the cluster health
 make sure ceph cluster is healthy:
   salt.state:
     - tgt: {{ master }}
     - tgt_type: compound
     - sls: ceph.wait
+    - failhard: True
+
+disable apparmor profiles:
+  salt.state:
+    - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
+    - tgt_type: compound
+    - sls: ceph.apparmor.default-disable
     - failhard: True


### PR DESCRIPTION
The ceph-mgr apparmor profile is currently broken, so if
apparmor is left in enforcing mode, subsequent functional
tests will fail after ceph-mgr is restarted during the
terminate tests.

Signed-off-by: Tim Serong <tserong@suse.com>

-----------------

**Checklist:**
- [ ] Added unittests and or functional tests
- [ ] Adapted documentation
- [ ] Referenced issues or internal bugtracker
- [ ] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
