### PR TITLE
Revert "orchestrator: disable orchestrator for now"

### DIFF
--- a/srv/salt/ceph/functests/1node/init.sls
+++ b/srv/salt/ceph/functests/1node/init.sls
@@ -11,4 +11,4 @@ include:
   # - .symlink
   - .tuned
   - .terminate.all
-  # - .orchestrator
+  - .orchestrator

--- a/srv/salt/ceph/stage/deploy/core/default.sls
+++ b/srv/salt/ceph/stage/deploy/core/default.sls
@@ -127,17 +127,16 @@ dashboard:
     - sls: ceph.dashboard
     - failhard: True
 
-## disabled for now
-# mgr orchestrator module:
-#   salt.state:
-#     - tgt: {{ master }}
-#     - tgt_type: compound
-#     - sls: ceph.mgr.orchestrator
-#     - pillar:
-#         'salt_api_url': http://{{ master }}:8000/
-#         'salt_api_username': admin
-#         'salt_api_password': {{ salt.saltutil.runner('sharedsecret.show') }}
-#     - failhard: True
+mgr orchestrator module:
+  salt.state:
+    - tgt: {{ master }}
+    - tgt_type: compound
+    - sls: ceph.mgr.orchestrator
+    - pillar:
+        'salt_api_url': http://{{ master }}:8000/
+        'salt_api_username': admin
+        'salt_api_password': {{ salt.saltutil.runner('sharedsecret.show') }}
+    - failhard: True
 
 osd auth:
   salt.state:


### PR DESCRIPTION
This reverts commit 9d0baa4ce142e554c6a35ea109337b10eb3be8d3.

Signed-off-by: Nathan Cutler <ncutler@suse.com>

Fixes #


Description:


-----------------

**Checklist:**
- [ ] Added unittests and or functional tests
- [ ] Adapted documentation
- [ ] Referenced issues or internal bugtracker
- [ ] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
