### PR TITLE
Move crc_method to master.d/crc_method

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -915,7 +915,11 @@ copy-files:
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/salt
 	install -m 644 srv/salt/ceph/salt/*.sls $(DESTDIR)/srv/salt/ceph/salt/
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/salt/crc
-	install -m 644 srv/salt/ceph/salt/crc/*.sls $(DESTDIR)/srv/salt/ceph/salt/crc/
+	install -m 644 srv/salt/ceph/salt/crc/*.conf $(DESTDIR)/srv/salt/ceph/salt/crc/
+	install -d -m 755 $(DESTDIR)/srv/salt/ceph/salt/crc/minion
+	install -m 644 srv/salt/ceph/salt/crc/minion/*.sls $(DESTDIR)/srv/salt/ceph/salt/crc/minion/
+	install -d -m 755 $(DESTDIR)/srv/salt/ceph/salt/crc/master
+	install -m 644 srv/salt/ceph/salt/crc/master/*.sls $(DESTDIR)/srv/salt/ceph/salt/crc/master/
 
 	# state files - orchestrate stage symlinks
 	ln -sf prep		$(DESTDIR)/srv/salt/ceph/stage/0

--- a/deepsea.spec.in
+++ b/deepsea.spec.in
@@ -432,6 +432,8 @@ systemctl try-restart salt-api > /dev/null 2>&1 || :
 %dir /srv/salt/ceph/processes/rgw
 %dir /srv/salt/ceph/salt
 %dir /srv/salt/ceph/salt/crc
+%dir /srv/salt/ceph/salt/crc/master
+%dir /srv/salt/ceph/salt/crc/minion
 %{_mandir}/man7/deepsea*.7.gz
 %{_mandir}/man5/deepsea*.5.gz
 %{_mandir}/man1/deepsea*.1.gz
@@ -765,7 +767,9 @@ systemctl try-restart salt-api > /dev/null 2>&1 || :
 %config /srv/salt/ceph/processes/osd/*.sls
 %config /srv/salt/ceph/processes/rgw/*.sls
 %config /srv/salt/ceph/salt/*.sls
-%config /srv/salt/ceph/salt/crc/*.sls
+%config /srv/salt/ceph/salt/crc/*.conf
+%config /srv/salt/ceph/salt/crc/master/*.sls
+%config /srv/salt/ceph/salt/crc/minion/*.sls
 %dir %attr(-, root, root) %{_docdir}/%{name}
 %{_docdir}/%{name}/*
 

--- a/srv/salt/ceph/salt/crc/crc_method.conf
+++ b/srv/salt/ceph/salt/crc/crc_method.conf
@@ -1,0 +1,1 @@
+server_id_use_crc: adler32

--- a/srv/salt/ceph/salt/crc/default.sls
+++ b/srv/salt/ceph/salt/crc/default.sls
@@ -1,4 +1,0 @@
-/etc/salt/minion:
-  file.append:
-    - text:
-      - "server_id_use_crc: adler32"

--- a/srv/salt/ceph/salt/crc/init.sls
+++ b/srv/salt/ceph/salt/crc/init.sls
@@ -1,2 +1,0 @@
-include:
-  - .{{ salt['pillar.get']('server_id_use_crc_init', 'default') }}

--- a/srv/salt/ceph/salt/crc/master/default.sls
+++ b/srv/salt/ceph/salt/crc/master/default.sls
@@ -1,0 +1,4 @@
+/etc/salt/master.d/crc_method.conf:
+  file.managed:
+    - source:
+      - salt://ceph/salt/crc/crc_method.conf

--- a/srv/salt/ceph/salt/crc/master/init.sls
+++ b/srv/salt/ceph/salt/crc/master/init.sls
@@ -1,0 +1,2 @@
+include:
+  - .{{ salt['pillar.get']('server_id_use_crc_master_init', 'default') }}

--- a/srv/salt/ceph/salt/crc/minion/default.sls
+++ b/srv/salt/ceph/salt/crc/minion/default.sls
@@ -1,0 +1,4 @@
+/etc/salt/minion.d/crc_method.conf:
+  file.managed:
+    - source:
+      - salt://ceph/salt/crc/crc_method.conf

--- a/srv/salt/ceph/salt/crc/minion/init.sls
+++ b/srv/salt/ceph/salt/crc/minion/init.sls
@@ -1,0 +1,2 @@
+include:
+  - .{{ salt['pillar.get']('server_id_use_crc_minion_init', 'default') }}

--- a/srv/salt/ceph/stage/prep/master/default-no-update-no-reboot.sls
+++ b/srv/salt/ceph/stage/prep/master/default-no-update-no-reboot.sls
@@ -1,4 +1,3 @@
-
 {% set master = salt['master.minion']() %}
 
 {% if salt['saltutil.runner']('validate.setup') == False %}
@@ -10,6 +9,11 @@ validate failed:
     - failhard: True
 
 {% endif %}
+
+crc_method:
+  salt.state:
+    - tgt: {{ master }}
+    - sls: ceph.salt.crc.master
 
 sync master:
   salt.state:
@@ -52,7 +56,3 @@ ready:
   salt.runner:
     - name: minions.ready
     - timeout: {{ salt['pillar.get']('ready_timeout', 300) }}
-
-
-
-

--- a/srv/salt/ceph/stage/prep/master/default-no-update-reboot.sls
+++ b/srv/salt/ceph/stage/prep/master/default-no-update-reboot.sls
@@ -1,4 +1,3 @@
-
 {% set master = salt['master.minion']() %}
 
 {% if salt['saltutil.runner']('validate.setup') == False %}
@@ -10,6 +9,11 @@ validate failed:
     - failhard: True
 
 {% endif %}
+
+crc_method:
+  salt.state:
+    - tgt: {{ master }}
+    - sls: ceph.salt.crc.master
 
 sync master:
   salt.state:
@@ -57,7 +61,3 @@ ready:
   salt.runner:
     - name: minions.ready
     - timeout: {{ salt['pillar.get']('ready_timeout', 300) }}
-
-
-
-

--- a/srv/salt/ceph/stage/prep/master/default-update-reboot.sls
+++ b/srv/salt/ceph/stage/prep/master/default-update-reboot.sls
@@ -10,6 +10,10 @@ validate failed:
 
 {% endif %}
 
+crc_method:
+  salt.state:
+    - tgt: {{ master }}
+    - sls: ceph.salt.crc.master
 
 sync master:
   salt.state:
@@ -64,7 +68,3 @@ ready:
   salt.runner:
     - name: minions.ready
     - timeout: {{ salt['pillar.get']('ready_timeout', 300) }}
-
-
-
-

--- a/srv/salt/ceph/stage/prep/master/default.sls
+++ b/srv/salt/ceph/stage/prep/master/default.sls
@@ -1,4 +1,3 @@
-
 {% set master = salt['master.minion']() %}
 
 {% if salt['saltutil.runner']('validate.setup') == False %}
@@ -11,6 +10,10 @@ validate failed:
 
 {% endif %}
 
+crc_method master:
+  salt.state:
+    - tgt: {{ master }}
+    - sls: ceph.salt.crc.master
 
 sync master:
   salt.state:
@@ -58,7 +61,3 @@ ready:
   salt.runner:
     - name: minions.ready
     - timeout: {{ salt['pillar.get']('ready_timeout', 300) }}
-
-
-
-

--- a/srv/salt/ceph/stage/prep/minion/default-no-update-no-reboot.sls
+++ b/srv/salt/ceph/stage/prep/minion/default-no-update-no-reboot.sls
@@ -1,8 +1,7 @@
-crc_method:
+crc_method minion:
   salt.state:
     - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
-    - tgt_type: compound
-    - sls: ceph.salt.crc
+    - sls: ceph.salt.crc.minion
 
 repo:
   salt.state:

--- a/srv/salt/ceph/stage/prep/minion/default-no-update-reboot.sls
+++ b/srv/salt/ceph/stage/prep/minion/default-no-update-reboot.sls
@@ -1,10 +1,10 @@
 {% set master = salt['master.minion']() %}
 
-crc_method:
+crc_method minion:
   salt.state:
     - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
-    - tgt_type: compound
-    - sls: ceph.salt.crc
+    - sls: ceph.salt.crc.minion
+
 repo:
   salt.state:
     - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'

--- a/srv/salt/ceph/stage/prep/minion/default-update-reboot.sls
+++ b/srv/salt/ceph/stage/prep/minion/default-update-reboot.sls
@@ -1,10 +1,10 @@
 {% set master = salt['master.minion']() %}
 
-crc_method:
+crc_method minion:
   salt.state:
     - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
-    - tgt_type: compound
-    - sls: ceph.salt.crc
+    - sls: ceph.salt.crc.minion
+
 
 repo:
   salt.state:

--- a/srv/salt/ceph/stage/prep/minion/default.sls
+++ b/srv/salt/ceph/stage/prep/minion/default.sls
@@ -1,10 +1,9 @@
 {% set master = salt['master.minion']() %}
 
-crc_method:
+crc_method minion:
   salt.state:
     - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
-    - tgt_type: compound
-    - sls: ceph.salt.crc
+    - sls: ceph.salt.crc.minion
 
 repo:
   salt.state:


### PR DESCRIPTION
Fixes #1593 
Fixes: aa40d37501600d1dd9c6c2bf650e61e49058c74a


~For me it seems to now suffice to have this entry *only* in the master conf.~

nope, see https://github.com/SUSE/DeepSea/pull/1594#issuecomment-477898215

This PR will add the 'crc_method' to `/etc/salt/minion.d/crc_method.conf` and `/etc/salt/master.d/crc_method.conf` respectively.

resolves: SES-351

-----------------

*Checklist:**
- [x] Referenced issues or internal bugtracker
- [x] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
