### PR TITLE
[RFC][DNM] Disable certificate validation if boto

### DIFF
--- a/srv/salt/_modules/rgw.py
+++ b/srv/salt/_modules/rgw.py
@@ -281,6 +281,7 @@ def s3connect(user):
         is_secure=bool(endpoint['ssl']),
         port=int(endpoint['port']),
         calling_format=boto.s3.connection.OrdinaryCallingFormat(),
+        validate_certs=False,
     )
     return s3conn
 


### PR DESCRIPTION
rgw.py calls s3connect, which internally calls boto.connect_s3(..)

https://github.com/boto/boto/blob/8fac1878734c5ac085b781f619c70ea4b6e913c3/boto/__init__.py#L141

points to https://github.com/boto/boto/blob/develop/boto/s3/connection.py#L164

which inherits from AWSAuthConnection and accepts a 'validate_cert' parameter.

https://github.com/boto/boto/blob/develop/boto/connection.py#L466

says:

:type validate_certs: bool
:param validate_certs: Controls whether SSL certificates
    will be validated or not.  Defaults to True.

That might give the expected result

Fixes #1445 

@smithfarm can we run a rgw-ssl test on this?

Answer: yes, see the susebot command below, which runs the test using https://github.com/SUSE/ceph/pull/273