### PR TITLE
mgr_orch: return ganesha and iscsi endpoint URLs

### DIFF
--- a/srv/modules/runners/mgr_orch.py
+++ b/srv/modules/runners/mgr_orch.py
@@ -7,12 +7,26 @@ Runner endpoints for integration specifically with the ceph-mgr orchestrator
 
 from __future__ import absolute_import
 import logging
+import ipaddress
 import os
 import sys
 # pylint: disable=import-error,3rd-party-module-not-gated,redefined-builtin
 import salt.client
 
 log = logging.getLogger(__name__)
+
+
+def _run_master_module_function(function, *args, **kwargs):
+    """
+    Used internally by this module to run master.find_pool.  Could also be
+    used to run master.minion if it turns out we need that.
+    """
+    __opts__ = salt.config.client_config('/etc/salt/master')
+    __grains__ = salt.loader.grains(__opts__)
+    __opts__['grains'] = __grains__
+    __utils__ = salt.loader.utils(__opts__)
+    __salt__ = salt.loader.minion_mods(__opts__, utils=__utils__)
+    return __salt__[function](*args, **kwargs)
 
 
 def get_inventory(nodes=None, roles=None):
@@ -87,7 +101,7 @@ def describe_service(role=None, service_id=None, node=None):
 
     search = "I@cluster:ceph"
 
-    supported_roles = ['mon', 'mgr', 'mds', 'rgw']
+    supported_roles = ['mon', 'mgr', 'mds', 'rgw', 'ganesha', 'igw']
 
     if role:
         search += " and I@roles:{}".format(role)
@@ -112,6 +126,8 @@ def describe_service(role=None, service_id=None, node=None):
 
     minion_roles = local.cmd(search, 'pillar.get', ['roles'], tgt_type="compound")
 
+    nfs_pool = None
+
     for minion, roles in minion_roles.items():
         minion_result = {}
         for minion_role in roles:
@@ -125,12 +141,36 @@ def describe_service(role=None, service_id=None, node=None):
                 # skips IDs we don't care about if one was passed in
                 continue
             # pylint: disable=fixme
-            # TODO: consider making this be a list if it's possible for DeepSea
+            # TODO: consider wrapping this in a list if it's possible for DeepSea
             # to deploy multiple services of the same type but with different IDs
             # on the same node.  Of course, DeepSea will deploy mutiple OSDs on
-            # the same node, but describe_service doesn't support quering OSDs,
+            # the same node, but describe_service doesn't support querying OSDs,
             # so that example doesn't count ;-)
-            minion_result[minion_role] = daemon_ids[minion]['host']
+            minion_result[minion_role] = {
+                'service_instance': daemon_ids[minion]['host']
+            }
+            if minion_role == 'ganesha':
+                if not nfs_pool:
+                    nfs_pool = _run_master_module_function('master.find_pool', ['cephfs', 'rgw'])
+                minion_result[minion_role]['rados_config_location'] = (
+                    'rados://{}/ganesha/conf-{}'.format(nfs_pool, daemon_ids[minion]['host']))
+            if minion_role == 'igw':
+                igw_address = local.cmd(minion, 'public.address', [])[minion]
+                if isinstance(ipaddress.ip_address(igw_address), ipaddress.IPv6Address):
+                    # IPv6 addresses need to be in square brackets in URLs
+                    igw_address = "[{}]".format(igw_address)
+                igw_username = local.cmd(minion, 'pillar.get',
+                                         ['ceph_iscsi_username'])[minion] or 'admin'
+                igw_password = local.cmd(minion, 'pillar.get',
+                                         ['ceph_iscsi_password'])[minion] or 'admin'
+                igw_port = local.cmd(minion, 'pillar.get',
+                                     ['ceph_iscsi_port'])[minion] or '5000'
+                igw_ssl = local.cmd(minion,
+                                    'pillar.get', ['ceph_iscsi_ssl'])[minion] or False
+                protocol = 'https' if igw_ssl else 'http'
+                minion_result[minion_role]['service_url'] = (
+                    '{}://{}:{}@{}:{}'.format(protocol, igw_username, igw_password,
+                                              igw_address, igw_port))
         if minion_result:
             result[minion] = minion_result
 


### PR DESCRIPTION
This changes describe_service() so it will return a dict for each
service, which includes at minimum service_instance (i.e. the daemon
ID), and also rados_config_location and service_url for ganesha
and igw instances respectively.

Signed-off-by: Tim Serong <tserong@suse.com>

-----------------

**Checklist:**
- [x] Added unittests and or functional tests
- [ ] Adapted documentation
- [ ] Referenced issues or internal bugtracker
- [ ] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
