### PR TITLE
iscsi: REST API ssl support

### DIFF
--- a/srv/salt/ceph/igw/config/apply_iscsi_config.sls
+++ b/srv/salt/ceph/igw/config/apply_iscsi_config.sls
@@ -7,7 +7,7 @@
     - mode: 600
     - fire_event: True
 
-{% if pillar.get('ceph_iscsi_ssl', True) %}
+{% if pillar.get('ceph_iscsi_ssl', False) %}
 
 /etc/ceph/iscsi-gateway.crt:
   file.managed:

--- a/srv/salt/ceph/igw/config/apply_iscsi_config.sls
+++ b/srv/salt/ceph/igw/config/apply_iscsi_config.sls
@@ -1,8 +1,30 @@
 /etc/ceph/iscsi-gateway.cfg:
   file.managed:
-    - source: 
+    - source:
       - salt://ceph/igw/cache/iscsi-gateway.{{ grains['host'] }}.cfg
     - user: root
     - group: root
     - mode: 600
     - fire_event: True
+
+{% if pillar.get('ceph_iscsi_ssl', True) %}
+
+/etc/ceph/iscsi-gateway.crt:
+  file.managed:
+    - source:
+      - salt://ceph/igw/cache/tls/certs/iscsi-gateway.crt
+    - user: root
+    - group: root
+    - mode: 600
+    - fire_event: True
+
+/etc/ceph/iscsi-gateway.key:
+  file.managed:
+    - source:
+      - salt://ceph/igw/cache/tls/certs/iscsi-gateway.key
+    - user: root
+    - group: root
+    - mode: 600
+    - fire_event: True
+
+{% endif %}

--- a/srv/salt/ceph/igw/config/create_iscsi_config.sls
+++ b/srv/salt/ceph/igw/config/create_iscsi_config.sls
@@ -14,7 +14,7 @@
         trusted_ip_list: {{ ip_addresses }}
 {% endfor %}
 
-{% if pillar.get('ceph_iscsi_ssl', True) %}
+{% if pillar.get('ceph_iscsi_ssl', False) %}
 {% if pillar.get('ceph_iscsi_ssl_cert', None) and pillar.get('ceph_iscsi_ssl_key', None) %}
 
 /srv/salt/ceph/igw/cache/tls/certs/iscsi-gateway.crt:

--- a/srv/salt/ceph/igw/files/iscsi-gateway.cfg.j2
+++ b/srv/salt/ceph/igw/files/iscsi-gateway.cfg.j2
@@ -6,7 +6,7 @@ minimum_gateways = 1
 api_port = {{ pillar.get('ceph_iscsi_port', '5000') }}
 api_user = {{ pillar.get('ceph_iscsi_username', 'admin') }}
 api_password = {{ pillar.get('ceph_iscsi_password', 'admin') }}
-{% if pillar.get('ceph_iscsi_ssl', True) %}
+{% if pillar.get('ceph_iscsi_ssl', False) %}
 api_secure = true
 {% else %}
 api_secure = false

--- a/srv/salt/ceph/igw/files/iscsi-gateway.cfg.j2
+++ b/srv/salt/ceph/igw/files/iscsi-gateway.cfg.j2
@@ -1,6 +1,13 @@
 [config]
 cluster_client_name = {{ client }}
 pool = {{ pillar['iscsi-pool'] }}
-api_secure = false
 trusted_ip_list = {{ trusted_ip_list }}
 minimum_gateways = 1
+api_port = {{ pillar.get('ceph_iscsi_port', '5000') }}
+api_user = {{ pillar.get('ceph_iscsi_username', 'admin') }}
+api_password = {{ pillar.get('ceph_iscsi_password', 'admin') }}
+{% if pillar.get('ceph_iscsi_ssl', True) %}
+api_secure = true
+{% else %}
+api_secure = false
+{% endif %}

--- a/srv/salt/ceph/stage/iscsi/core/default.sls
+++ b/srv/salt/ceph/stage/iscsi/core/default.sls
@@ -69,7 +69,7 @@ iscsi apply:
 {% set iscsi_username = pillar.get('ceph_iscsi_username', 'admin') %}
 {% set iscsi_password = pillar.get('ceph_iscsi_password', 'admin') %}
 {% set iscsi_port = pillar.get('ceph_iscsi_port', '5000') %}
-{% set iscsi_ssl = pillar.get('ceph_iscsi_ssl', True) %}
+{% set iscsi_ssl = pillar.get('ceph_iscsi_ssl', False) %}
 
 {% if iscsi_ssl %}
 disable dashboard ssl verification:


### PR DESCRIPTION
This PR adds the options to enable/disable SSL in ceph-iscsi REST API.
Currently SSL is disabled by default due to a bug in the communication between ceph-dashboard and ceph-iscsi when SSL is enabled.

Signed-off-by: Ricardo Dias <rdias@suse.com>