### PR TITLE
crc_method: deepsea_minions can be a compound target

### DIFF
--- a/srv/salt/ceph/stage/prep/minion/default-no-update-no-reboot.sls
+++ b/srv/salt/ceph/stage/prep/minion/default-no-update-no-reboot.sls
@@ -1,6 +1,7 @@
 crc_method minion:
   salt.state:
     - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
+    - tgt_type: compound
     - sls: ceph.salt.crc.minion
 
 repo:

--- a/srv/salt/ceph/stage/prep/minion/default-no-update-reboot.sls
+++ b/srv/salt/ceph/stage/prep/minion/default-no-update-reboot.sls
@@ -3,6 +3,7 @@
 crc_method minion:
   salt.state:
     - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
+    - tgt_type: compound
     - sls: ceph.salt.crc.minion
 
 repo:

--- a/srv/salt/ceph/stage/prep/minion/default-update-reboot.sls
+++ b/srv/salt/ceph/stage/prep/minion/default-update-reboot.sls
@@ -3,6 +3,7 @@
 crc_method minion:
   salt.state:
     - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
+    - tgt_type: compound
     - sls: ceph.salt.crc.minion
 
 

--- a/srv/salt/ceph/stage/prep/minion/default.sls
+++ b/srv/salt/ceph/stage/prep/minion/default.sls
@@ -3,6 +3,7 @@
 crc_method minion:
   salt.state:
     - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
+    - tgt_type: compound
     - sls: ceph.salt.crc.minion
 
 repo:


### PR DESCRIPTION
If deepsea_minions is compound target (e.g. G@deepsea:*) stage 0 will only succeed if salt is told about the compound target type.

Signed-off-by: Jan Fajerski <jfajerski@suse.com>