### PR TITLE
chrony: allow NTP access from local network

### DIFF
--- a/srv/salt/ceph/time/chrony/files/chrony.conf.j2
+++ b/srv/salt/ceph/time/chrony/files/chrony.conf.j2
@@ -20,6 +20,7 @@ rtcsync
 
 # Allow NTP client access from local network.
 #allow 192.168/16
+allow 127/8
 
 # Serve time even if not synchronized to any NTP server.
 #local stratum 10


### PR DESCRIPTION
Without an allow statement, Chrony does not listen on port 123

Fixes: https://github.com/SUSE/DeepSea/issues/1614
Signed-off-by: Nathan Cutler <ncutler@suse.com>
