### PR TITLE
monitoring: set grafana default theme to light

### DIFF
--- a/srv/salt/ceph/monitoring/grafana/default.sls
+++ b/srv/salt/ceph/monitoring/grafana/default.sls
@@ -67,6 +67,8 @@ add mgr dashboard config section:
           enabled: true
           org_name: Main Org.
           org_role: Viewer
+        users:
+          default_theme: light
 
 grafana-server:
   service.running:


### PR DESCRIPTION
This simply looks better with the mgr dashboard.

Signed-off-by: Jan Fajerski <jfajerski@suse.com>