### PR TITLE
Fix typo: URL reference to Drive-Groups wiki

### DIFF
--- a/srv/modules/runners/proposal.py
+++ b/srv/modules/runners/proposal.py
@@ -8,7 +8,7 @@ def deprecation_message():
     """ General depracation message """
     print(
         """This runner is deprecated. Please use the new Drive Group approach.
-        Information can be found here: https://github.com/SUSE/DeepSea/wiki/Drive-Group"""
+        Information can be found here: https://github.com/SUSE/DeepSea/wiki/Drive-Groups"""
     )
 
 


### PR DESCRIPTION
Fix typo in URL that references Drive-Groups wiki.  Should be "https://github.com/SUSE/DeepSea/wiki/Drive-Groups"

Description: Fixes misinformation when users try to use deprecated "proposal.populate", pointing them to the Drive-Groups wiki on github.


-----------------

**Checklist:**
- [ ] Added unittests and or functional tests
- [ ] Adapted documentation
- [ ] Referenced issues or internal bugtracker
- [ ] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
