### PR TITLE
install ceph in packages.common

### DIFF
--- a/srv/salt/ceph/packages/common/default.sls
+++ b/srv/salt/ceph/packages/common/default.sls
@@ -29,6 +29,7 @@ stage prep dependencies suse:
       - polkit
       - libstoragemgmt
       - curl
+      - ceph
     - fire_event: True
     - refresh: True
 
@@ -47,6 +48,7 @@ stage prep dependencies ubuntu:
       - iperf
       - jq
       - curl
+      - ceph
     - fire_event: True
     - refresh: True
 
@@ -77,6 +79,7 @@ stage prep dependencies CentOS:
       - jq
       - libstoragemgmt
       - curl
+      - ceph
     - fire_event: True
     - refresh: True
 

--- a/srv/salt/ceph/stage/deploy/core/default.sls
+++ b/srv/salt/ceph/stage/deploy/core/default.sls
@@ -37,13 +37,6 @@ time:
     - sls: ceph.time
 {% endif %}
 
-packages:
-  salt.state:
-    - tgt: 'I@cluster:ceph'
-    - tgt_type: compound
-    - sls: ceph.packages
-    - failhard: True
-
 configuration check:
   salt.state:
     - tgt: {{ master }}


### PR DESCRIPTION
ceph-volume needs to be present before stage.3
in earlier version we installed ceph separately in stage.3

Adding it to the list of basic requirements (installed in stage.0)



-----------------

**Checklist:**
- [ ] Added unittests and or functional tests
- [ ] Adapted documentation
- [ ] Referenced issues or internal bugtracker
- [ ] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
