### PR TITLE
Avoid running drivegroup based osd deployment post-upgrade

### DIFF
--- a/srv/salt/_modules/dg.py
+++ b/srv/salt/_modules/dg.py
@@ -823,6 +823,14 @@ def c_v_commands(**kwargs):
 
 def deploy(**kwargs):
     """ Execute the generated ceph-volume commands """
+    # do not run this when there is still ceph:storage in the pillar
+    # this indicates that we are in a post-upgrade scenario and
+    # the drive assignment was not ported to drive-groups yet.
+    if __pillar__.get('ceph', {}).get('storage'):
+        return ("You seem to have configured old-style profiles."
+                "Will not deploy using Drive-Groups."
+                "Please consult <insert doc/man> for guidance"
+                "on how to migrate to Drive-Groups")
     return __salt__['helper.run'](c_v_commands(**kwargs))
 
 


### PR DESCRIPTION
In a post-upgrade scenario the user still has old-style profiles defined in the
pillar.

Since we don't force the user to move to the new drive-group implementation
right after the upgrade, we have to detect that they are running in 'legacy'
mode and stop.

Fixes #


Description:


-----------------

**Checklist:**
- [ ] Added unittests and or functional tests
- [ ] Adapted documentation
- [ ] Referenced issues or internal bugtracker
- [ ] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
