### PR TITLE
core: do not skip disks that are not used by ceph

### DIFF
--- a/srv/salt/_modules/cephdisks.py
+++ b/srv/salt/_modules/cephdisks.py
@@ -26,14 +26,14 @@ class Inventory(object):
     @property
     def available_filter(self) -> bool:
         """ The available filter """
-        return self.kwargs.get('available', None)
+        return self.kwargs.get('available', False)
 
     @property
     def used_by_ceph_filter(self) -> bool:
         """ The used_by_ceph filter """
         # This also returns disks that are marked as
         # 'destroyed' is that valid?
-        return self.kwargs.get('used_by_ceph', True)
+        return self.kwargs.get('used_by_ceph', False)
 
     def osd_list(self) -> list:
         """
@@ -59,11 +59,11 @@ class Inventory(object):
         for dev in self.devices.devices:
             # Apply known filters
             if self.available_filter:
-                if dev.available is self.available_filter:
+                if dev.available:
                     devs.append(dev)
                     continue
             elif self.used_by_ceph_filter:
-                if dev.used_by_ceph is self.used_by_ceph_filter:
+                if dev.used_by_ceph:
                     devs.append(dev)
                     continue
             else:


### PR DESCRIPTION
This affects disks.details and disks.report/deploy
We have a function that explicitly asks for disks
that are used by ceph. The default should be 'None'.

bsc:1131161

-----------------

**Checklist:**
- [x] Referenced issues or internal bugtracker
- [ ] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
