### PR TITLE
do no parse ceph output when no valid json

### DIFF
--- a/srv/modules/runners/disks.py
+++ b/srv/modules/runners/disks.py
@@ -210,7 +210,12 @@ def destroyed():
 
     tree = {}
     if ret:
-        tree = json.loads(list(ret.values())[0]).get('nodes')
+        try:
+            tree = json.loads(list(ret.values())[0]).get('nodes')
+        except json.decoder.JSONDecodeError:
+            log.info(
+                "No valid json in ceph osd tree. Probably no cluster deployed yet."
+            )
 
     # what is stray? # probably destroyed osds that are not listed nder
     # a certain bucket/host. This may be useful later


### PR DESCRIPTION
disks.details/deploy is used before a cluster is deployed
and no json will be returned

Signed-off-by: Joshua Schmid <jschmid@suse.de>

-----------------

**Checklist:**
- [ ] Referenced issues or internal bugtracker
- [ ] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
