### PR TITLE
core: add include_unavailable flag for disks.py

### DIFF
--- a/srv/modules/runners/disks.py
+++ b/srv/modules/runners/disks.py
@@ -111,6 +111,7 @@ class DriveGroups(object):
     def __init__(self, **kwargs: dict) -> None:
         self.local_client = salt.client.LocalClient()
         self.dry_run: bool = kwargs.get('dry_run', False)
+        self.include_unavailable: bool = kwargs.get('include_unavailable', False)
         self.drive_groups_path: str = '/srv/salt/ceph/configuration/files/drive_groups.yml'
         self.drive_groups: dict = self._get_drive_groups()
 
@@ -171,6 +172,7 @@ class DriveGroups(object):
             kwarg={
                 'filter_args': filter_args,
                 'dry_run': self.dry_run,
+                'include_unavailable': self.include_unavailable,
                 'destroyed_osds': destroyed()
             },
             expr_form='compound')

--- a/tests/unit/runners/test_disks.py
+++ b/tests/unit/runners/test_disks.py
@@ -141,6 +141,7 @@ class TestDriveGroup_Disks(object):
             kwarg={
                 'filter_args': {'args'},
                 'dry_run': False,
+                'include_unavailable': False,
                 'destroyed_osds': {
                     'data1': [1, 2, 3]
                 }
@@ -158,6 +159,26 @@ class TestDriveGroup_Disks(object):
             kwarg={
                 'filter_args': {'args'},
                 'dry_run': True,
+                'include_unavailable': False,
+                'destroyed_osds': {
+                    'data1': [1, 2, 3]
+                }
+            })
+
+    @patch('srv.modules.runners.disks.destroyed')
+    def test_call_include_unavailable(self, destroyed_mock,
+                                      drive_groups_fixture):
+        dgo = drive_groups_fixture(include_unavailable=True)
+        destroyed_mock.return_value = {'data1': [1, 2, 3]}
+        dgo.call('target*', {'args'}, 'test_command')
+        dgo.local_client.cmd.assert_called_with(
+            'target*',
+            'dg.test_command',
+            expr_form='compound',
+            kwarg={
+                'filter_args': {'args'},
+                'dry_run': False,
+                'include_unavailable': True,
                 'destroyed_osds': {
                     'data1': [1, 2, 3]
                 }


### PR DESCRIPTION
This serves mainly the purpose of allowing to show matching disks
in a already deployed cluster.
There needs to be such a functionality in order to make migration
from profile-based to drive-group-based deployments easier.

Docs will point people towards:

`salt-run disks.list include_unavailable`

-----------------

**Checklist:**
- [x] Added unittests and or functional tests
- [ ] Adapted documentation #TODO
~- [ ] Referenced issues or internal bugtracker~
- [ ] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
