### PR TITLE
runners/deepsea.py: fix deepsea RPM version detection

### DIFF
--- a/srv/modules/runners/deepsea.py
+++ b/srv/modules/runners/deepsea.py
@@ -17,12 +17,15 @@ def version(**kwargs):
     format_ = kwargs['format'] if 'format' in kwargs else 'plain'
 
     if format_ == 'json':
-        ver = re.findall(r'^\d\.\d\.?\d?', DEEPSEA_VERSION)
+        try:
+            ver = re.search(r'(^\d+(\.\d+)+)', DEEPSEA_VERSION).group(0)
+        except AttributeError:
+            ver = '0.0.0'
         offset = re.findall(r'\+\d+', DEEPSEA_VERSION)
         hash_ = re.findall(r'[\w]{7,8}$', DEEPSEA_VERSION)
 
         return {'full_version': DEEPSEA_VERSION,
-                'version': ver[0] if ver else '0.0.0',
+                'version': ver,
                 'git_offset': offset[0].lstrip('+') if offset else '0',
                 'git_hash': hash_[0][-7:] if hash_ else ''}
 

--- a/tests/unit/runners/test_deepsea.py
+++ b/tests/unit/runners/test_deepsea.py
@@ -1,0 +1,38 @@
+from mock import patch
+from srv.modules.runners import deepsea
+
+
+class TestVersion():
+    """
+    A class for validating how DeepSea reports its version
+    """
+
+    @patch('srv.modules.runners.deepsea.DEEPSEA_VERSION', 'something wildly unexpected')
+    def test_version_1(self):
+        result = deepsea.version(format='json')
+        assert result['full_version'] == 'something wildly unexpected'
+        assert result['version'] == '0.0.0'
+
+    @patch('srv.modules.runners.deepsea.DEEPSEA_VERSION', '0.8.10+git.0.72e3fed70')
+    def test_version_2(self):
+        result = deepsea.version(format='json')
+        assert result['full_version'] == '0.8.10+git.0.72e3fed70'
+        assert result['version'] == '0.8.10'
+
+    @patch('srv.modules.runners.deepsea.DEEPSEA_VERSION', '0.82+git.0.72e3fed70')
+    def test_version_3(self):
+        result = deepsea.version(format='json')
+        assert result['full_version'] == '0.82+git.0.72e3fed70'
+        assert result['version'] == '0.82'
+
+    @patch('srv.modules.runners.deepsea.DEEPSEA_VERSION', '1.2.3.4.5.6+git.0.72e3fed70')
+    def test_version_4(self):
+        result = deepsea.version(format='json')
+        assert result['full_version'] == '1.2.3.4.5.6+git.0.72e3fed70'
+        assert result['version'] == '1.2.3.4.5.6'
+
+    @patch('srv.modules.runners.deepsea.DEEPSEA_VERSION', '110.220.3330.44.52+git.0.72e3fed70')
+    def test_version_5(self):
+        result = deepsea.version(format='json')
+        assert result['full_version'] == '110.220.3330.44.52+git.0.72e3fed70'
+        assert result['version'] == '110.220.3330.44.52'


### PR DESCRIPTION
Fixes the following bug:

```
>>> DEEPSEA_VERSION = '0.8.10+git.0.72e3fed70'
>>> re.findall(r'^\d\.\d\.?\d?', DEEPSEA_VERSION)
['0.8.1']
```

Fixes: https://bugzilla.suse.com/show_bug.cgi?id=1134216
Signed-off-by: Nathan Cutler <ncutler@suse.com>

TO DO:

- [x] convert test.py into unit test
- [x] unit test passes in Jenkins frame
- [x] teuthology run
- [ ] merge
- [ ] cherry-pick to SES5
