### PR TITLE
Implement rebuild runner

### DIFF
--- a/man/deepsea-commands.7
+++ b/man/deepsea-commands.7
@@ -981,6 +981,17 @@ salt-run push.convert
 .PP
 salt-run ready.check
 .PP
+salt-run rebuild.check
+.RS
+.RE
+salt-run rebuild.identical
+.RS
+.RE
+salt-run rebuild.node
+.RS
+.RE
+salt-run rebuild.nodes
+.PP
 salt-run remove.osd
 .PP
 salt-run rescinded.ids

--- a/srv/modules/runners/disks.py
+++ b/srv/modules/runners/disks.py
@@ -112,6 +112,7 @@ class DriveGroups(object):
         self.local_client = salt.client.LocalClient()
         self.dry_run: bool = kwargs.get('dry_run', False)
         self.include_unavailable: bool = kwargs.get('include_unavailable', False)
+        self.target: str = kwargs.get('target', '')
         self.drive_groups_path: str = '/srv/salt/ceph/configuration/files/drive_groups.yml'
         self.drive_groups: dict = self._get_drive_groups()
 
@@ -141,9 +142,13 @@ class DriveGroups(object):
         for dg_name, dg_values in self.drive_groups.items():
             print("Found DriveGroup <{}>".format(dg_name))
             dgo = DriveGroup(dg_name, dg_values)
+            if self.target:
+                target = self.target
+            else:
+                target = dgo.target()
             ret.append(
                 self.call(
-                    dgo.target(),
+                    target,
                     dgo.filter_args(),
                     command,
                     module=module,

--- a/srv/modules/runners/rebuild.py
+++ b/srv/modules/runners/rebuild.py
@@ -1,0 +1,257 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Runner to remove and deploy OSDs
+"""
+
+from __future__ import absolute_import
+from __future__ import print_function
+import logging
+import pprint
+import time
+# pylint: disable=import-error,3rd-party-module-not-gated,redefined-builtin
+import salt.client
+import salt.runner
+
+log = logging.getLogger(__name__)
+
+
+def help_():
+    """
+    Usage
+    """
+    usage = ('salt-run rebuild.node [TARGET...]\n'
+             'salt-run rebuild.nodes [TARGET...]:\n\n'
+             '    Removes and deploys OSDs\n'
+             'salt-run rebuild.identical [TARGET...]:\n\n'
+             '    Removes and deploys OSDs with same IDs\n'
+             'salt-run rebuild.check [TARGET...]:\n\n'
+             '    Checks available space\n'
+             '\n\n'
+             'Examples:\n'
+             '    salt-run rebuild.node data1.ceph\n'
+             '    salt-run rebuild.node data1.ceph data2.ceph\n'
+             '    salt-run rebuild.node data[12].ceph\n'
+             '    salt-run rebuild.node I@roles:storage\n'
+             '    salt-run rebuild.node data*.ceph storage*.ceph\n'
+             '\n')
+    print(usage)
+    return ""
+
+
+def master_minion():
+    """
+    Load the master modules
+    """
+    __master_opts__ = salt.config.client_config("/etc/salt/master")
+    __master_utils__ = salt.loader.utils(__master_opts__)
+    __salt_master__ = salt.loader.minion_mods(
+        __master_opts__, utils=__master_utils__)
+
+    return __salt_master__["master.minion"]()
+
+
+# pylint: disable=too-many-instance-attributes
+class Rebuild(object):
+    """ Removes and deploys OSDs for a list of minions  """
+
+    def __init__(self, *args, **kwargs):
+        """ Sets clients, assigns minions """
+        self.master_minion = master_minion()
+        self.local = salt.client.LocalClient()
+        self.runner = salt.runner.RunnerClient(__opts__)
+        __master_opts__ = salt.config.client_config("/etc/salt/master")
+        __master_opts__['quiet'] = True
+        self.qrunner = salt.runner.RunnerClient(__master_opts__)
+        self.minions = self._minions(*args)
+        self.operation = kwargs.get('operation', 'osd.remove')
+        self.aggressive = kwargs.get('aggressive', False)
+        self.skipped = []
+
+    def _minions(self, *args):
+        """ Return expanded Salt target """
+        minions = set()
+        for arg in args:
+            results = self.local.cmd(arg, 'grains.get', ['id'], tgt_type="compound")
+            minions.update(results)
+        log.info("minions: {}".format(list(minions)))
+        return sorted(minions)
+
+    def _osd_list(self, minion):
+        """ Return the list of OSD IDs """
+        osd_ret = self.local.cmd(minion, 'osd.list', [], tgt_type="compound")
+        log.debug("osd.list returned: {}".format(osd_ret))
+        if minion in osd_ret:
+            return osd_ret[minion]
+        return None
+
+    def _validate_osd_df(self, osd_df):
+        """ Validate osd.df output """
+        if self.master_minion not in osd_df:
+            log.error("salt {} osd.df failed".format(self.master_minion))
+            return False
+
+        if 'nodes' not in osd_df[self.master_minion]:
+            log.error("Mangled output: missing 'nodes' from osd.df")
+            return False
+
+        if 'summary' not in osd_df[self.master_minion]:
+            log.error("Mangled output: missing 'summary' from osd.df")
+            return False
+
+        if 'total_kb_avail' not in osd_df[self.master_minion]['summary']:
+            log.error("Mangled output: missing 'total_kb_avail' from osd.df")
+            return False
+        return True
+
+    def safe(self, osds):
+        """ Check OSD used capacity does not exceed available cluster space """
+        osd_df = self.local.cmd(self.master_minion, 'osd.df', [], tgt_type="compound")
+        log.debug("osd_df: {}".format(pprint.pformat(osd_df)))
+        if not self._validate_osd_df(osd_df):
+            return False
+
+        used = 0
+        for osd in osd_df[self.master_minion]['nodes']:
+            if str(osd['id']) in osds:
+                used += osd['kb_used']
+
+        available = osd_df[self.master_minion]['summary']['total_kb_avail']
+        log.info("Used: {} KB  Available: {} KB".format(used, available))
+        if used > available:
+            log.critical("OSDs exceed available free space")
+            return False
+        return True
+
+    def _busy_wait(self):
+        """ Wait until OSDs are safe to stop """
+        delay = 3
+        while True:
+            quiescent = self.local.cmd(self.master_minion,
+                                       'osd.ceph_quiescent', [], tgt_type="compound")
+            log.debug("quiescent: {}".format(quiescent))
+            if self.master_minion in quiescent and quiescent[self.master_minion] is True:
+                break
+            print("Waiting for PGs to recover...")
+            time.sleep(delay)
+            if delay < 60:
+                delay += 3
+
+    def _disengaged(self):
+        """ Return safety setting"""
+        return self.qrunner.cmd('disengage.check')
+
+    def _check_return(self, ret, minion):
+        """ Check for failures """
+        if isinstance(ret, str) or not all(ret.values()):
+            log.error("Failed to remove OSD(s)... skipping {}".format(minion))
+            self.skipped.append(minion)
+            return True
+        return False
+
+    def _check_deploy(self, deploy_ret, minion):
+        """ Check for failures """
+        log.debug(deploy_ret)
+        for ret in deploy_ret:
+            if minion in ret:
+                if ret[minion][0] != 0:
+                    pprint.pprint(ret[minion])
+                    self.skipped.append(minion)
+
+    def _skipped_summary(self):
+        """ Print summary of skipped minions """
+        if self.skipped:
+            print("The following minions were skipped:\n{}".format("\n".join(self.skipped)),
+                  "\n\nResolve any issues and run\n",
+                  "salt-run rebuild.nodes {}".format(" ".join(self.skipped)))
+
+    def _aggressive(self, osds, minion):
+        """ Delegate list to a single call """
+        osd_ret = self.runner.cmd(self.operation, osds)
+        log.debug("osd_ret: {}".format(osd_ret))
+
+        return self._check_return(osd_ret, minion)
+
+    def _check_each(self, osds, minion):
+        """ Wait between removal of each OSD """
+        for osd in osds:
+            osd_ret = self.runner.cmd(self.operation, [osd])
+            if self._check_return(osd_ret, minion):
+                return True
+            self._busy_wait()
+        return False
+
+    def run(self, checkonly=False):
+        """
+        For each minion
+           Retrieve the list of osds
+           Verify that the storage minion is safe to rebuild
+           Remove the OSDs
+           Deploy the minion
+        """
+        if not self._disengaged() and not checkonly:
+            log.error('Safety engaged...run "salt-run disengage.safety"')
+            return ""
+
+        for minion in self.minions:
+            log.info("Processing minion: {}".format(minion))
+            osds = self._osd_list(minion)
+            if osds:
+                log.info("osds for {}: {}".format(osds, minion))
+                if not self.safe(osds):
+                    log.critical("Aborting...")
+                    return ""
+                if checkonly:
+                    print("Sufficient space to rebuild minion {}".format(minion))
+                    continue
+
+                self._busy_wait()
+                if self.aggressive:
+                    if self._aggressive(osds, minion):
+                        continue
+                else:
+                    if self._check_each(osds, minion):
+                        continue
+
+            deploy_ret = self.runner.cmd('disks.deploy', kwarg={'target': minion})
+            self._check_deploy(deploy_ret, minion)
+        self._skipped_summary()
+        return ""
+
+
+def identical(*args):
+    """ Rebuild the minions provided, keep the same OSD IDs """
+    return node(*args, operation='osd.replace')
+
+
+def aggressive(*args):
+    """ Rebuild the minions provided, may see HEALTH_ERR """
+    return node(*args, aggressive=True)
+
+
+def node(*args, **kwargs):
+    """ Rebuild the minions provided """
+    if not args:
+        help_()
+        return ""
+
+    rebuild = Rebuild(*args, **kwargs)
+    rebuild.run()
+    return ""
+
+
+def check(*args):
+    """ Check the space of the minions provided """
+    if not args:
+        help_()
+        return ""
+
+    rebuild = Rebuild(*args)
+    rebuild.run(checkonly=True)
+    return ""
+
+
+__func_alias__ = {
+                 'help_': 'help',
+                 'node': 'nodes',
+                 }

--- a/srv/salt/_modules/osd.py
+++ b/srv/salt/_modules/osd.py
@@ -203,6 +203,30 @@ def ids():
     return list()
 
 
+# pylint: disable=invalid-name
+def df(**kwargs):
+    """
+    Return osd df
+    """
+    settings = {
+        'conf': "/etc/ceph/ceph.conf",
+        'keyring': '/etc/ceph/ceph.client.admin.keyring',
+        'client': 'client.admin',
+    }
+    settings.update(kwargs)
+
+    cluster = rados.Rados(conffile=settings['conf'],
+                          conf=dict(keyring=settings['keyring']),
+                          name=settings['client'])
+
+    cluster.connect()
+    cmd = json.dumps({"prefix": "osd df", "format": "json"})
+    _, output, _ = cluster.mon_command(cmd, b'', timeout=6)
+    osd_df = json.loads(output)
+    log.debug(json.dumps(osd_df, indent=4))
+    return osd_df
+
+
 def _tree(**kwargs):
     """
     Return osd tree

--- a/tests/unit/runners/test_rebuild.py
+++ b/tests/unit/runners/test_rebuild.py
@@ -1,0 +1,435 @@
+from mock import patch, MagicMock, mock
+from srv.modules.runners import rebuild
+
+
+class TestRebuild():
+    """
+    """
+
+    @patch('srv.modules.runners.rebuild.master_minion', autospec=True)
+    @patch('salt.runner.Runner', autospec=True)
+    @patch('salt.client.LocalClient', autospec=True)
+    def test_minions(self, localclient, runner, mm):
+        rebuild.__opts__ = {}
+
+        local = localclient.return_value
+        local.cmd.return_value = {'data1.ceph': 'data1.ceph'}
+        rr = rebuild.Rebuild(['data1.ceph'])
+        assert rr.minions == ['data1.ceph']
+
+    @patch('srv.modules.runners.rebuild.master_minion', autospec=True)
+    @patch('salt.runner.Runner', autospec=True)
+    @patch('salt.client.LocalClient', autospec=True)
+    def test_minions_targets(self, localclient, runner, mm):
+        rebuild.__opts__ = {}
+
+        local = localclient.return_value
+        local.cmd.return_value = {'data1.ceph': 'data1.ceph',
+                                  'data2.ceph':'data2.ceph'}
+        rr = rebuild.Rebuild(['I@roles:storage'])
+        assert rr.minions == ['data1.ceph', 'data2.ceph']
+
+    @patch('srv.modules.runners.rebuild.master_minion', autospec=True)
+    @patch('salt.runner.Runner', autospec=True)
+    @patch('salt.client.LocalClient', autospec=True)
+    def test_minions_multiple(self, localclient, runner, mm):
+        rebuild.__opts__ = {}
+
+        local = localclient.return_value
+        local.cmd.return_value = {'data1.ceph': 'data1.ceph',
+                                  'data2.ceph':'data2.ceph'}
+        rr = rebuild.Rebuild(['data*.ceph', 'data*.ceph'])
+        assert rr.minions == ['data1.ceph', 'data2.ceph']
+
+    @patch('srv.modules.runners.rebuild.master_minion', autospec=True)
+    @patch('salt.runner.Runner', autospec=True)
+    @patch('salt.client.LocalClient', autospec=True)
+    def test_osd_list(self, localclient, runner, mm):
+        rebuild.__opts__ = {}
+
+        local = localclient.return_value
+        local.cmd.return_value = {'data1.ceph': [0, 1, 2]}
+        rr = rebuild.Rebuild(['data*.ceph'])
+        result = rr._osd_list('data1.ceph')
+        assert result == [0, 1, 2]
+
+    @patch('srv.modules.runners.rebuild.master_minion', autospec=True)
+    @patch('salt.runner.Runner', autospec=True)
+    @patch('salt.client.LocalClient', autospec=True)
+    def test_osd_list_no_match(self, localclient, runner, mm):
+        rebuild.__opts__ = {}
+
+        local = localclient.return_value
+        local.cmd.return_value = {'data1.ceph': [0, 1, 2]}
+        rr = rebuild.Rebuild(['data*.ceph'])
+        result = rr._osd_list('data2.ceph')
+        assert result == None
+
+    @patch('srv.modules.runners.rebuild.master_minion', autospec=True)
+    @patch('salt.runner.Runner', autospec=True)
+    @patch('salt.client.LocalClient', autospec=True)
+    def test_validate_osd_df(self, localclient, runner, mm):
+        rebuild.__opts__ = {}
+
+        local = localclient.return_value
+        local.cmd.return_value = {}
+        mm.return_value = 'admin'
+        rr = rebuild.Rebuild(['data*.ceph'])
+
+        osd_df = {'admin': {'nodes': '', 'summary':{'total_kb_avail': '0'}}}
+        result = rr._validate_osd_df(osd_df)
+        assert result == True
+
+    @patch('srv.modules.runners.rebuild.master_minion', autospec=True)
+    @patch('salt.runner.Runner', autospec=True)
+    @patch('salt.client.LocalClient', autospec=True)
+    def test_validate_osd_df_missing_mm(self, localclient, runner, mm):
+        rebuild.__opts__ = {}
+
+        local = localclient.return_value
+        local.cmd.return_value = {}
+        mm.return_value = 'admin'
+        rr = rebuild.Rebuild(['data*.ceph'])
+
+        osd_df = {'': {'nodes': '', 'summary':{'total_kb_avail': '0'}}}
+        result = rr._validate_osd_df(osd_df)
+        assert result == False
+
+    @patch('srv.modules.runners.rebuild.master_minion', autospec=True)
+    @patch('salt.runner.Runner', autospec=True)
+    @patch('salt.client.LocalClient', autospec=True)
+    def test_validate_osd_df_missing_nodes(self, localclient, runner, mm):
+        rebuild.__opts__ = {}
+
+        local = localclient.return_value
+        local.cmd.return_value = {}
+        mm.return_value = 'admin'
+        rr = rebuild.Rebuild(['data*.ceph'])
+
+        osd_df = {'admin': {'': '', 'summary':{'total_kb_avail': '0'}}}
+        result = rr._validate_osd_df(osd_df)
+        assert result == False
+
+    @patch('srv.modules.runners.rebuild.master_minion', autospec=True)
+    @patch('salt.runner.Runner', autospec=True)
+    @patch('salt.client.LocalClient', autospec=True)
+    def test_validate_osd_df_missing_summary(self, localclient, runner, mm):
+        rebuild.__opts__ = {}
+
+        local = localclient.return_value
+        local.cmd.return_value = {}
+        mm.return_value = 'admin'
+        rr = rebuild.Rebuild(['data*.ceph'])
+
+        osd_df = {'admin': {'nodes': '', '':{'total_kb_avail': '0'}}}
+        result = rr._validate_osd_df(osd_df)
+        assert result == False
+
+    @patch('srv.modules.runners.rebuild.master_minion', autospec=True)
+    @patch('salt.runner.Runner', autospec=True)
+    @patch('salt.client.LocalClient', autospec=True)
+    def test_validate_osd_df_missing_total(self, localclient, runner, mm):
+        rebuild.__opts__ = {}
+
+        local = localclient.return_value
+        local.cmd.return_value = {}
+        mm.return_value = 'admin'
+        rr = rebuild.Rebuild(['data*.ceph'])
+
+        osd_df = {'admin': {'nodes': '', 'summary':{'': '0'}}}
+        result = rr._validate_osd_df(osd_df)
+        assert result == False
+
+    @patch('srv.modules.runners.rebuild.master_minion', autospec=True)
+    @patch('salt.runner.Runner', autospec=True)
+    @patch('salt.client.LocalClient', autospec=True)
+    def test_safe(self, localclient, runner, mm):
+        rebuild.__opts__ = {}
+
+        local = localclient.return_value
+        local.cmd.return_value = {'admin': {'nodes': [
+                                             {'id': 0, 'kb_used': 10},
+                                             {'id': 1, 'kb_used': 10}
+                                             ],
+                                            'summary':{'total_kb_avail': 30}}}
+        mm.return_value = 'admin'
+        rr = rebuild.Rebuild(['data*.ceph'])
+
+        result = rr.safe(['0', '1'])
+        assert result == True
+
+    @patch('srv.modules.runners.rebuild.master_minion', autospec=True)
+    @patch('salt.runner.Runner', autospec=True)
+    @patch('salt.client.LocalClient', autospec=True)
+    def test_safe_fails(self, localclient, runner, mm):
+        rebuild.__opts__ = {}
+
+        local = localclient.return_value
+        local.cmd.return_value = {'admin': {'nodes': [
+                                             {'id': 0, 'kb_used': 10},
+                                             {'id': 1, 'kb_used': 10}
+                                             ],
+                                            'summary':{'total_kb_avail': 10}}}
+        mm.return_value = 'admin'
+        rr = rebuild.Rebuild(['data*.ceph'])
+
+        result = rr.safe(['0', '1'])
+        assert result == False
+
+    @patch('srv.modules.runners.rebuild.master_minion', autospec=True)
+    @patch('salt.runner.Runner', autospec=True)
+    @patch('salt.client.LocalClient', autospec=True)
+    def test_safe_fails_validation(self, localclient, runner, mm):
+        rebuild.__opts__ = {}
+
+        local = localclient.return_value
+        local.cmd.return_value = {'': {'nodes': [
+                                             {'id': 0, 'kb_used': 10},
+                                             {'id': 1, 'kb_used': 10}
+                                             ],
+                                            'summary':{'total_kb_avail': 10}}}
+        mm.return_value = 'admin'
+        rr = rebuild.Rebuild(['data*.ceph'])
+
+        result = rr.safe(['0', '1'])
+        assert result == False
+
+    @patch('srv.modules.runners.rebuild.master_minion', autospec=True)
+    @patch('salt.runner.Runner', autospec=True)
+    @patch('salt.client.LocalClient', autospec=True)
+    def test_check_return(self, localclient, runner, mm):
+        rebuild.__opts__ = {}
+
+        rr = rebuild.Rebuild(['data*.ceph'])
+
+        ret = {0: True, 1:True}
+        result = rr._check_return(ret, 'data1.ceph')
+        assert result == False
+        assert rr.skipped == []
+
+    @patch('srv.modules.runners.rebuild.master_minion', autospec=True)
+    @patch('salt.runner.Runner', autospec=True)
+    @patch('salt.client.LocalClient', autospec=True)
+    def test_check_return_finds_failure(self, localclient, runner, mm):
+        rebuild.__opts__ = {}
+
+        rr = rebuild.Rebuild(['data*.ceph'])
+
+        ret = {0: False, 1:True}
+        result = rr._check_return(ret, 'data1.ceph')
+        assert result == True
+        assert rr.skipped == ['data1.ceph']
+
+    @patch('srv.modules.runners.rebuild.master_minion', autospec=True)
+    @patch('salt.runner.Runner', autospec=True)
+    @patch('salt.client.LocalClient', autospec=True)
+    def test_check_return_finds_error(self, localclient, runner, mm):
+        rebuild.__opts__ = {}
+
+        rr = rebuild.Rebuild(['data*.ceph'])
+
+        ret = "An error message"
+        result = rr._check_return(ret, 'data1.ceph')
+        assert result == True
+        assert rr.skipped == ['data1.ceph']
+
+    @patch('srv.modules.runners.rebuild.master_minion', autospec=True)
+    @patch('salt.runner.Runner', autospec=True)
+    @patch('salt.client.LocalClient', autospec=True)
+    def test_run(self, localclient, runner, mm):
+        rebuild.__opts__ = {}
+
+        rr = rebuild.Rebuild(['data*.ceph'])
+        rr._disengaged = mock.Mock()
+        rr._disengaged.return_value = True
+        rr.minions = ['data1.ceph']
+        rr._osd_list = mock.Mock()
+        rr._osd_list.return_value = [0, 1]
+        rr.safe = mock.Mock()
+        rr.safe.return_value = True
+        rr._busy_wait = mock.Mock()
+        rr.runner.cmd = mock.Mock()
+        rr.runner.cmd.return_value = {}
+        rr._check_return = mock.Mock()
+        rr._check_return.return_value = False
+        rr._skipped_summary = mock.Mock()
+
+        result = rr.run()
+        assert result == ""
+        assert rr._osd_list.called
+        assert rr.safe.called
+        assert rr.runner.cmd.called
+        assert rr._check_return.called
+        assert rr._skipped_summary.called
+
+    @patch('srv.modules.runners.rebuild.master_minion', autospec=True)
+    @patch('salt.runner.Runner', autospec=True)
+    @patch('salt.client.LocalClient', autospec=True)
+    def test_run_multiple(self, localclient, runner, mm):
+        rebuild.__opts__ = {}
+
+        rr = rebuild.Rebuild(['data*.ceph'])
+        rr._disengaged = mock.Mock()
+        rr._disengaged.return_value = True
+        rr.minions = ['data1.ceph', 'data2.ceph']
+        rr._osd_list = mock.Mock()
+        rr._osd_list.return_value = [0, 1]
+        rr.safe = mock.Mock()
+        rr.safe.return_value = True
+        rr._busy_wait = mock.Mock()
+        rr.runner.cmd = mock.Mock()
+        rr.runner.cmd.return_value = {}
+        rr._check_return = mock.Mock()
+        rr._check_return.return_value = False
+        rr._skipped_summary = mock.Mock()
+
+        result = rr.run()
+        assert result == ""
+        assert rr._osd_list.call_count == 2
+        assert rr.safe.call_count == 2
+        assert rr.runner.cmd.call_count == 6
+        assert rr._check_return.call_count == 4
+        assert rr._skipped_summary.called
+
+    @patch('srv.modules.runners.rebuild.master_minion', autospec=True)
+    @patch('salt.runner.Runner', autospec=True)
+    @patch('salt.client.LocalClient', autospec=True)
+    def test_run_check_only(self, localclient, runner, mm):
+        rebuild.__opts__ = {}
+
+        rr = rebuild.Rebuild(['data*.ceph'])
+        rr._disengaged = mock.Mock()
+        rr._disengaged.return_value = True
+        rr.minions = ['data1.ceph']
+        rr._osd_list = mock.Mock()
+        rr._osd_list.return_value = [0, 1]
+        rr.safe = mock.Mock()
+        rr.safe.return_value = True
+        rr.runner.cmd = mock.Mock()
+        rr.runner.cmd.return_value = {}
+        rr._check_return = mock.Mock()
+        rr._check_return.return_value = False
+        rr._skipped_summary = mock.Mock()
+
+        result = rr.run(checkonly=True)
+        assert result == ""
+        assert rr._osd_list.called
+        assert rr.safe.called
+        assert rr.runner.cmd.called is False
+        assert rr._check_return.called is False
+        assert rr._skipped_summary.called
+
+    @patch('srv.modules.runners.rebuild.master_minion', autospec=True)
+    @patch('salt.runner.Runner', autospec=True)
+    @patch('salt.client.LocalClient', autospec=True)
+    def test_run_safety_engaged(self, localclient, runner, mm):
+        rebuild.__opts__ = {}
+
+        rr = rebuild.Rebuild(['data*.ceph'])
+        rr._disengaged = mock.Mock()
+        rr._disengaged.return_value = False
+        rr.minions = ['data1.ceph']
+        rr._osd_list = mock.Mock()
+        rr._osd_list.return_value = [0, 1]
+        rr.safe = mock.Mock()
+        rr.safe.return_value = True
+        rr.runner.cmd = mock.Mock()
+        rr.runner.cmd.return_value = {}
+        rr._check_return = mock.Mock()
+        rr._check_return.return_value = False
+        rr._skipped_summary = mock.Mock()
+
+        result = rr.run()
+        assert result == ""
+        assert rr._osd_list.called is False
+        assert rr.safe.called is False
+        assert rr.runner.cmd.called is False
+        assert rr._check_return.called is False
+        assert rr._skipped_summary.called is False
+
+    @patch('srv.modules.runners.rebuild.master_minion', autospec=True)
+    @patch('salt.runner.Runner', autospec=True)
+    @patch('salt.client.LocalClient', autospec=True)
+    def test_run_no_remove(self, localclient, runner, mm):
+        rebuild.__opts__ = {}
+
+        rr = rebuild.Rebuild(['data*.ceph'])
+        rr._disengaged = mock.Mock()
+        rr._disengaged.return_value = True
+        rr.minions = ['data1.ceph']
+        rr._osd_list = mock.Mock()
+        rr._osd_list.return_value = []
+        rr.safe = mock.Mock()
+        rr.safe.return_value = True
+        rr.runner.cmd = mock.Mock()
+        rr.runner.cmd.return_value = {}
+        rr._check_return = mock.Mock()
+        rr._check_return.return_value = False
+        rr._skipped_summary = mock.Mock()
+
+        result = rr.run()
+        assert result == ""
+        assert rr._osd_list.called
+        assert rr.safe.called is False
+        assert rr.runner.cmd.called
+        assert rr._check_return.called is False
+        assert rr._skipped_summary.called
+
+    @patch('srv.modules.runners.rebuild.master_minion', autospec=True)
+    @patch('salt.runner.Runner', autospec=True)
+    @patch('salt.client.LocalClient', autospec=True)
+    def test_run_not_safe(self, localclient, runner, mm):
+        rebuild.__opts__ = {}
+
+        rr = rebuild.Rebuild(['data*.ceph'])
+        rr._disengaged = mock.Mock()
+        rr._disengaged.return_value = True
+        rr.minions = ['data1.ceph']
+        rr._osd_list = mock.Mock()
+        rr._osd_list.return_value = [0, 1]
+        rr.safe = mock.Mock()
+        rr.safe.return_value = False
+        rr.runner.cmd = mock.Mock()
+        rr.runner.cmd.return_value = {}
+        rr._check_return = mock.Mock()
+        rr._check_return.return_value = False
+        rr._skipped_summary = mock.Mock()
+
+        result = rr.run()
+        assert result == ""
+        assert rr._osd_list.called
+        assert rr.safe.called
+        assert rr.runner.cmd.called is False
+        assert rr._check_return.called is False
+        assert rr._skipped_summary.called is False
+
+    @patch('srv.modules.runners.rebuild.master_minion', autospec=True)
+    @patch('salt.runner.Runner', autospec=True)
+    @patch('salt.client.LocalClient', autospec=True)
+    def test_run_remove_failed(self, localclient, runner, mm):
+        rebuild.__opts__ = {}
+
+        rr = rebuild.Rebuild(['data*.ceph'])
+        rr._disengaged = mock.Mock()
+        rr._disengaged.return_value = True
+        rr.minions = ['data1.ceph']
+        rr._osd_list = mock.Mock()
+        rr._osd_list.return_value = [0, 1]
+        rr.safe = mock.Mock()
+        rr.safe.return_value = True
+        rr._busy_wait = mock.Mock()
+        rr.runner.cmd = mock.Mock()
+        rr.runner.cmd.return_value = {}
+        rr._check_return = mock.Mock()
+        rr._check_return.return_value = True
+        rr._skipped_summary = mock.Mock()
+
+        result = rr.run()
+        assert result == ""
+        assert rr._osd_list.called
+        assert rr.safe.called
+        assert rr.runner.cmd.called
+        assert rr._check_return.called
+        assert rr._skipped_summary.called
+
+


### PR DESCRIPTION
Signed-off-by: Eric Jackson <swiftgist@gmail.com>

Description:
Serially removes and redeploys OSDs.

```
salt-run rebuild.node TARGET...
salt-run rebuild.aggressive TARGET...
salt-run rebuild.identical TARGET...
```
The difference betwen `node` and `aggressive` is an `active+clean` is performed for each OSD with node and is only performed between the nodes with aggressive.  The Ceph cluster must recover in either case before the rebuild proceeds.

One caveat is that the Ceph cluster will reach HEALTH_ERR and recover.  That is still under investigation, but no data loss occurs.



-----------------

**Checklist:**
- [x] Added unittests and or functional tests
- [ ] Adapted documentation
- [ ] Referenced issues or internal bugtracker
- [ ] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
