### PR TITLE
By default teardown apparmor

### DIFF
--- a/srv/salt/ceph/apparmor/default-teardown.sls
+++ b/srv/salt/ceph/apparmor/default-teardown.sls
@@ -1,0 +1,13 @@
+
+aa-teardown:
+  cmd.run
+
+apparmor:
+  service.dead:
+    - enable: False
+
+uninstall apparmor:
+  pkg.removed:
+    - pkgs:
+      - apparmor
+      - apparmor-utils

--- a/srv/salt/ceph/apparmor/default.sls
+++ b/srv/salt/ceph/apparmor/default.sls
@@ -1,3 +1,3 @@
 
-apparmor noop:
-  test.nop
+include:
+  - .default-teardown


### PR DESCRIPTION
SLE15 brings apparmor by default. Tear that down in a default installation.
