### PR TITLE
Remove obsolete includes

### DIFF
--- a/srv/salt/ceph/monitoring/default.sls
+++ b/srv/salt/ceph/monitoring/default.sls
@@ -1,7 +1,5 @@
 include:
   - .prometheus
-  - .prometheus.update_service_discovery
-  - .prometheus.alertmanager
   - .grafana
 
 fix salt job cache permissions:


### PR DESCRIPTION
The includes prometheus.update_service_discovery and prometheus.alertmanager do not exist anymore.

Signed-off-by: Volker Theile <vtheile@suse.com>

**Checklist:**
- [ ] Added unittests and or functional tests
- [ ] Adapted documentation
- [ ] Referenced issues or internal bugtracker
- [ ] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
