### PR TITLE
Extract short hostname from salt grains to feed ceph c_v properly 

### DIFF
--- a/srv/salt/_modules/dg.py
+++ b/srv/salt/_modules/dg.py
@@ -789,8 +789,7 @@ def c_v_commands(**kwargs):
     dgo = DriveGroup(filter_args)
 
     destroyed_osds_map = kwargs.get('destroyed_osds', {})
-    my_destroyed_osds = destroyed_osds_map.get(
-        __grains__.get('id', ''), list())
+    my_destroyed_osds = destroyed_osds_map.get(__grains__.get('host', ''), list())
 
     appendix = ""
     if my_destroyed_osds:


### PR DESCRIPTION
Salt grains reported FQDN while ceph volume was expecting only short hostname.

Signed-off-by: Shyukri Shyukriev <shshyukriev@suse.com>


-----------------

**Checklist:**
- [ ] Added unittests and or functional tests
- [ ] Adapted documentation
- [ ] Referenced issues or internal bugtracker
- [x] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
