### PR TITLE
tox: use python3 instead of python3.6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -988,7 +988,7 @@ tarball:
 	rm -r $(TEMPDIR)
 
 test: setup.py
-	tox -e py36
+	tox -e py3
 
 lint: setup.py
 	tox -e lint

--- a/tox.ini
+++ b/tox.ini
@@ -4,15 +4,15 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py36,lint
+envlist = py3,lint
 
 [base]
 deps =
     ipaddress
     salt<2018.10.13
 
-[testenv:py36]
-basepython = python3.6
+[testenv:py3]
+basepython = python3
 commands =
     py.test --cov=. --tb=line -v --ignore=cli/ --junitxml=junit-{envname}.xml {posargs}
 


### PR DESCRIPTION
Explicitly specifying python3.6 means we can't run unit tests on
openSUSE Tumbleweed, which has python3.7, so let's just make it
use python3, which means whatever 3-series python happens to be
installed.

Signed-off-by: Tim Serong <tserong@suse.com>