### PR TITLE
Use correct config name for Dashboard SSL port

### DIFF
--- a/srv/salt/ceph/dashboard/default.sls
+++ b/srv/salt/ceph/dashboard/default.sls
@@ -13,13 +13,13 @@ disable dashboard ssl:
 
 set dashboard port:
   cmd.run:
-    - name: ceph config set mgr mgr/dashboard/server_port {{ salt['pillar.get']('dashboard_port', '8080') }}
+    - name: ceph config set mgr mgr/dashboard/server_port {{ salt['pillar.get']('dashboard_port', 8080) }}
     - failhard: true
     - fire_event: True
 {% else %}
-set dashboard port:
+set dashboard ssl port:
   cmd.run:
-    - name: ceph config set mgr mgr/dashboard/server_port {{ salt['pillar.get']('dashboard_ssl_port', '8443') }}
+    - name: ceph config set mgr mgr/dashboard/ssl_server_port {{ salt['pillar.get']('dashboard_ssl_port', 8443) }}
     - failhard: true
     - fire_event: True
 {% endif %}


### PR DESCRIPTION
Fixes: https://bugzilla.suse.com/show_bug.cgi?id=1129225

Signed-off-by: Volker Theile <vtheile@suse.com>

**Checklist:**
- [ ] Added unittests and or functional tests
- [ ] Adapted documentation
- [x] Referenced issues or internal bugtracker
- [ ] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
