### PR TITLE
rgw: use the port syntax

### DIFF
--- a/srv/salt/ceph/configuration/files/rgw-ssl.conf
+++ b/srv/salt/ceph/configuration/files/rgw-ssl.conf
@@ -1,4 +1,4 @@
 [client.{{ client }}]
-rgw frontends = "beast ssl_endpoint=[::]:443 ssl_certificate=/etc/ceph/rgw.pem"
+rgw frontends = "beast ssl_port=443 ssl_certificate=/etc/ceph/rgw.pem"
 rgw dns name = {{ fqdn }}
 rgw enable usage log = true

--- a/srv/salt/ceph/configuration/files/rgw.conf
+++ b/srv/salt/ceph/configuration/files/rgw.conf
@@ -1,4 +1,4 @@
 [client.{{ client }}]
-rgw frontends = "beast endpoint=[::]:80"
+rgw frontends = "beast port=80"
 rgw dns name = {{ fqdn }}
 rgw enable usage log = true


### PR DESCRIPTION
Beast frontend's port will bind to both v4 and v6 addresses by default. Failure
to bind if the interface doesn't support the protocol will not be treated as an
error and we warn and continue in this case unless we have no ports to bind to.

Signed-off-by: Abhishek Lekshmanan <abhishek@suse.com>

Related to: https://github.com/SUSE/ceph/pull/295

Description:


-----------------

**Checklist:**
- [ ] Added unittests and or functional tests
- [ ] Adapted documentation
- [ ] Referenced issues or internal bugtracker
- [ ] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
