### PR TITLE
SSL certificate deployment and management

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -725,6 +725,9 @@ copy-files:
 	# state files - shutdown
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/shutdown
 	install -m 644 srv/salt/ceph/shutdown/*.sls $(DESTDIR)/srv/salt/ceph/shutdown
+	# state files - ssl
+	install -d -m 755 $(DESTDIR)/srv/salt/ceph/ssl
+	install -m 644 srv/salt/ceph/ssl/*.sls $(DESTDIR)/srv/salt/ceph/ssl
 	# state files - startup
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/startup
 	install -m 644 srv/salt/ceph/startup/*.sls $(DESTDIR)/srv/salt/ceph/startup

--- a/deepsea.spec.in
+++ b/deepsea.spec.in
@@ -343,6 +343,7 @@ systemctl try-restart salt-api > /dev/null 2>&1 || :
 %dir /srv/salt/ceph/rgw/users
 %dir /srv/salt/ceph/rgw/users/users.d
 %dir /srv/salt/ceph/shutdown
+%dir /srv/salt/ceph/ssl
 %dir /srv/salt/ceph/startup
 %dir /srv/salt/ceph/stage
 %dir /srv/salt/ceph/stage/all
@@ -690,6 +691,7 @@ systemctl try-restart salt-api > /dev/null 2>&1 || :
 %config /srv/salt/ceph/rgw/users/*.sls
 %config /srv/salt/ceph/rgw/users/users.d/README
 %config /srv/salt/ceph/shutdown/*.sls
+%config /srv/salt/ceph/ssl/*.sls
 %config /srv/salt/ceph/startup/*.sls
 %config /srv/salt/ceph/stage/0
 %config /srv/salt/ceph/stage/1

--- a/srv/modules/runners/select.py
+++ b/srv/modules/runners/select.py
@@ -92,9 +92,8 @@ def one_minion(**kwargs):
     Some steps only need to be run once, but on any minion in a specific
     search.  Return the first matching key.
     """
-    ret = [None]
     ret = minions(**kwargs)
-    return ret[0]
+    return ret[0] if ret else None
 
 
 def first(**kwargs):

--- a/srv/salt/_modules/deepsea.py
+++ b/srv/salt/_modules/deepsea.py
@@ -74,3 +74,19 @@ def find_pool(applications, preferred_pool=None):
     if [pool for _, pool in eligible_pools if pool == preferred_pool]:
         return preferred_pool
     return eligible_pools[0][1]
+
+
+def ssl_ca_cert_cn():
+    domain = __grains__['domain']
+    if not domain:
+        raise Exception("According to the 'domain' grain, the cluster does"
+                        " not have a DNS domain configured")
+    return "deepsea.{}".format(domain)
+
+
+def ssl_cert_cn_wildcard():
+    domain = __grains__['domain']
+    if not domain:
+        raise Exception("According to the 'domain' grain, the cluster does"
+                        " not have a DNS domain configured")
+    return "*.{}".format(domain)

--- a/srv/salt/ceph/dashboard/default.sls
+++ b/srv/salt/ceph/dashboard/default.sls
@@ -44,11 +44,21 @@ set dashboard ssl key:
     - fire_event: True
 
 {% else %}
-create self signed certificate:
+
+{% set CN = salt['deepsea.ssl_cert_cn_wildcard']() %}
+
+set dashboard ssl cert:
   cmd.run:
-    - name: ceph dashboard create-self-signed-cert
+    - name: ceph config-key set mgr/dashboard/crt -i /etc/ssl/deepsea/certs/{{ CN }}.crt
     - failhard: True
     - fire_event: True
+
+set dashboard ssl key:
+  cmd.run:
+    - name: ceph config-key set mgr/dashboard/key -i /etc/ssl/deepsea/certs/{{ CN }}.key
+    - failhard: True
+    - fire_event: True
+
 {% endif %}
 {% endif %}
 
@@ -73,10 +83,10 @@ set dashboard password grain:
         - cmd: set username and password
 
 # configure grafana
-{% set grafana_addresses = salt.saltutil.runner('select.public_addresses', cluster='ceph', roles='grafana') %}
-{% if grafana_addresses %}
+{% set grafana_minion = salt.saltutil.runner('select.one_minion', cluster='ceph', roles='grafana') %}
+{% if grafana_minion %}
 set dashboard grafana url:
   cmd.run:
-    - name: ceph dashboard set-grafana-api-url https://{{ grafana_addresses[0] }}:3000
+    - name: ceph dashboard set-grafana-api-url https://{{ grafana_minion }}:3000
     - fire_event: True
 {% endif %}

--- a/srv/salt/ceph/igw/config/create_iscsi_config.sls
+++ b/srv/salt/ceph/igw/config/create_iscsi_config.sls
@@ -22,7 +22,7 @@
     - source: {{ pillar['ceph_iscsi_ssl_cert'] }}
     - user: {{ salt['deepsea.user']() }}
     - group: {{ salt['deepsea.group']() }}
-    - mode: 644
+    - mode: 600
     - makedirs: True
     - fire_event: True
 
@@ -31,16 +31,32 @@
     - source: {{ pillar['ceph_iscsi_ssl_key'] }}
     - user: {{ salt['deepsea.user']() }}
     - group: {{ salt['deepsea.group']() }}
-    - mode: 644
+    - mode: 600
     - makedirs: True
     - fire_event: True
 
 {% else %}
-generate ceph-iscsi self-signed SSL certificate:
-  module.run:
-    - name: tls.create_self_signed_cert
-    - cacert_path: /srv/salt/ceph/igw/cache
-    - CN: iscsi-gateway
+
+{% set CN = salt['deepsea.ssl_cert_cn_wildcard']() %}
+
+/srv/salt/ceph/igw/cache/tls/certs/iscsi-gateway.crt:
+  file.managed:
+    - source: /etc/ssl/deepsea/certs/{{ CN }}.crt
+    - user: {{ salt['deepsea.user']() }}
+    - group: {{ salt['deepsea.group']() }}
+    - mode: 600
+    - makedirs: True
+    - replace: True
+    - fire_event: True
+
+/srv/salt/ceph/igw/cache/tls/certs/iscsi-gateway.key:
+  file.managed:
+    - source: /etc/ssl/deepsea/certs/{{ CN }}.key
+    - user: {{ salt['deepsea.user']() }}
+    - group: {{ salt['deepsea.group']() }}
+    - mode: 600
+    - makedirs: True
+    - replace: True
     - fire_event: True
 
 {% endif %}

--- a/srv/salt/ceph/monitoring/grafana/create_configs.sls
+++ b/srv/salt/ceph/monitoring/grafana/create_configs.sls
@@ -28,11 +28,26 @@
 
 {% else %}
 
-generate grafana self-signed SSL certificate:
-  module.run:
-    - name: tls.create_self_signed_cert
-    - cacert_path: /srv/salt/ceph/monitoring/grafana/cache
-    - CN: grafana
+{% set CN = salt['deepsea.ssl_cert_cn_wildcard']() %}
+
+/srv/salt/ceph/monitoring/grafana/cache/tls/certs/grafana.crt:
+  file.managed:
+    - source: /etc/ssl/deepsea/certs/{{ CN }}.crt
+    - user: {{ salt['deepsea.user']() }}
+    - group: {{ salt['deepsea.group']() }}
+    - mode: 600
+    - makedirs: True
+    - replace: True
+    - fire_event: True
+
+/srv/salt/ceph/monitoring/grafana/cache/tls/certs/grafana.key:
+  file.managed:
+    - source: /etc/ssl/deepsea/certs/{{ CN }}.key
+    - user: {{ salt['deepsea.user']() }}
+    - group: {{ salt['deepsea.group']() }}
+    - mode: 600
+    - makedirs: True
+    - replace: True
     - fire_event: True
 
 {% endif %}

--- a/srv/salt/ceph/ssl/default.sls
+++ b/srv/salt/ceph/ssl/default.sls
@@ -1,0 +1,39 @@
+{% set CN = salt['deepsea.ssl_cert_cn_wildcard']() %}
+
+create CA:
+  module.run:
+    - name: tls.create_ca
+    - ca_name: deepsea
+    - days: 730  # 2 years
+    - CN: {{ salt['deepsea.ssl_ca_cert_cn']() }}
+    - cacert_path: /etc/ssl
+    - fire_event: True
+
+create cert request:
+  module.run:
+    - name: tls.create_csr
+    - ca_name: deepsea
+    - CN: "{{ CN }}"
+    - subjectAltName:
+      - "DNS:{{ CN }}"
+    - cacert_path: /etc/ssl
+    - fire_event: True
+
+create signed cert:
+  module.run:
+    - name: tls.create_ca_signed_cert
+    - ca_name: deepsea
+    - CN: "{{ CN }}"
+    - days: 730  # 2 years
+    - cacert_path: /etc/ssl
+    - fire_event: True
+
+/srv/salt/ceph/ssl/cache/deepsea_ca_cert.crt:
+  file.managed:
+    - source: /etc/ssl/deepsea/deepsea_ca_cert.crt
+    - user: {{ salt['deepsea.user']() }}
+    - group: {{ salt['deepsea.group']() }}
+    - mode: 600
+    - makedirs: True
+    - replace: True
+    - fire_event: True

--- a/srv/salt/ceph/ssl/distribute_ca.sls
+++ b/srv/salt/ceph/ssl/distribute_ca.sls
@@ -1,0 +1,12 @@
+/etc/pki/trust/anchors/deepsea_ca_cert.crt:
+  file.managed:
+    - source: salt://ceph/ssl/cache/deepsea_ca_cert.crt
+    - user: root
+    - group: root
+    - mode: 644
+    - fire_event: True
+
+update ca certificates:
+  cmd.run:
+    - name: update-ca-certificates
+    - fire_event: True

--- a/srv/salt/ceph/ssl/init.sls
+++ b/srv/salt/ceph/ssl/init.sls
@@ -1,0 +1,5 @@
+
+
+include:
+  - .default
+

--- a/srv/salt/ceph/stage/configure/default.sls
+++ b/srv/salt/ceph/stage/configure/default.sls
@@ -47,3 +47,15 @@ install and setup node exporters:
     - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
     - tgt_type: compound
     - sls: ceph.monitoring.prometheus.exporters.node_exporter
+
+create SSL CA and certificate:
+  salt.state:
+    - tgt: {{ master }}
+    - sls: ceph.ssl
+    - failhard: True
+
+install SSL CA in master:
+  salt.state:
+    - tgt: {{ master }}
+    - sls: ceph.ssl.distribute_ca
+    - failhard: True

--- a/srv/salt/ceph/stage/deploy/core/default.sls
+++ b/srv/salt/ceph/stage/deploy/core/default.sls
@@ -101,6 +101,13 @@ mgrs:
     - sls: ceph.mgr
     - failhard: True
 
+install ca cert in mgr minions:
+  salt.state:
+    - tgt: 'I@roles:mgr and I@cluster:ceph'
+    - tgt_type: compound
+    - sls: ceph.ssl.distribute_ca
+    - failhard: True
+
 # Immediately after deploying ceph-mgr, it takes a few seconds for the
 # various modules to become available.  If we don't wait for this, any
 # subqeuent `ceph` commands that require mgr will fail (for example


### PR DESCRIPTION
This PR adds the capability to DeepSea to management SSL certificates by using its own CA.

A CA certificate is created, and a wildcard certificate is also created and signed by the CA in stage 2. The wildcard domain corresponds to the domain of the cluster.

We then use the wildcard certificate in all services that are SSL capable like dashboard, ceph-iscsi, grafana, and radosgw.

**Edit** (removed RGW commit from the PR)
