### PR TITLE
spec: add explicit prometheus, grafana runtime deps

### DIFF
--- a/deepsea.spec.in
+++ b/deepsea.spec.in
@@ -32,6 +32,12 @@ Url:            https://github.com/suse/deepsea
 Source0:        %{name}-%{version}.tar.bz2
 
 BuildRequires:  salt-master
+Requires:       ceph-grafana-dashboards
+%if 0%{?suse_version}
+Requires:       ceph-prometheus-alerts
+Requires:       golang-github-prometheus-alertmanager
+Requires:       golang-github-prometheus-prometheus
+%endif
 Requires:       curl
 Requires:       gptfdisk
 Requires:       hwinfo


### PR DESCRIPTION
We are now explicitly declaring all packages (with the exception of core Ceph itself) that deepsea might insist on installing as part of a Ceph deployment.