### PR TITLE
dg: make error conditions consistent; don't execute a error message

### DIFF
--- a/srv/salt/_modules/dg.py
+++ b/srv/salt/_modules/dg.py
@@ -928,7 +928,7 @@ def c_v_commands(**kwargs):
         if dgo.encryption:
             cmd += " --dmcrypt"
 
-        return cmd
+        return [cmd]
 
     if dgo.format == 'bluestore':
 

--- a/srv/salt/_modules/dg.py
+++ b/srv/salt/_modules/dg.py
@@ -53,7 +53,7 @@ class UnitNotSupported(Exception):
 
 
 class ConfigError(Exception):
-    """ A critical error which encounteres when a configuration is not supported
+    """ A critical error which is encountered when a configuration is not supported
     or is invalid.
     """
     pass
@@ -822,8 +822,8 @@ class DriveGroup(object):
                 raise
 
 
-def _apply_policies(data_devices: list, wal_devices: list,
-                    db_devices: list) -> bool:
+def _apply_policies(wal_devices: list, db_devices: list) -> bool:
+    """ Apply known policies """
     if wal_devices and not db_devices:
         log.error("""
         You specified only wal_devices. If your intention was to
@@ -855,7 +855,7 @@ def list_drives(**kwargs):
     wal_devices = dgo.wal_devices
     journal_devices = dgo.journal_devices
 
-    if not _apply_policies(data_devices, wal_devices, db_devices):
+    if not _apply_policies(wal_devices, db_devices):
         raise ConfigError(
             "Detected invalid configuration. Please check the logs")
 
@@ -892,10 +892,11 @@ def c_v_commands(**kwargs):
     data_devices = dgo.data_devices
     wal_devices = dgo.wal_devices
     db_devices = dgo.db_devices
+    journal_devices = dgo.journal_devices
     if not data_devices:
         return ""
 
-    if not _apply_policies(data_devices, wal_devices, db_devices):
+    if not _apply_policies(wal_devices, db_devices):
         raise ConfigError(
             "Detected invalid configuration. Please check the logs")
 
@@ -904,16 +905,15 @@ def c_v_commands(**kwargs):
         return (seq[i::size] for i in range(size))
 
     if dgo.format == 'filestore':
-        cmd = "ceph-volume lvm batch "
+        cmd = "ceph-volume lvm batch"
 
         cmd += " {}".format(" ".join(data_devices))
 
         if dgo.journal_size:
             cmd += " --journal-size {}".format(dgo.journal_size)
 
-        if dgo.journal_devices:
-            cmd += " --journal-devices {}".format(' '.join(
-                dgo.journal_devices))
+        if journal_devices:
+            cmd += " --journal-devices {}".format(' '.join(journal_devices))
 
         cmd += " --filestore"
 

--- a/tests/unit/_modules/test_dg.py
+++ b/tests/unit/_modules/test_dg.py
@@ -1,6 +1,7 @@
 import pytest
 from mock import patch, call, Mock, PropertyMock
 from srv.salt._modules import dg
+from tests.unit.helper.fixtures import helper_specs
 
 
 class InventoryFactory(object):
@@ -897,16 +898,16 @@ class TestDriveGroup(object):
 
     def test_c_v_commands_external_wal_only(self, test_fix, inventory):
         inventory(wal_devices=2, db_devices=0)
-        ret = dg.c_v_commands(
-            filter_args={
-                'data_devices': {
-                    'rotational': '1'
-                },
-                'wal_devices': {
-                    'rotational': '0'
-                }
-            })
-        assert "You specified only wal_devices" in ret
+        with pytest.raises(dg.ConfigError):
+            dg.c_v_commands(
+                filter_args={
+                    'data_devices': {
+                        'rotational': '1'
+                    },
+                    'wal_devices': {
+                        'rotational': '0'
+                    }
+                })
 
     def test_c_v_commands_external_2_dbs_and_2_wals(self, test_fix, inventory):
         inventory(db_devices=2, wal_devices=2)
@@ -953,21 +954,97 @@ class TestDriveGroup(object):
     def test_c_v_commands_11_data_external_3_dbs_and_1_wals(
             self, test_fix, inventory):
         inventory(data_devices=11, db_devices=3, wal_devices=1)
-        ret = dg.c_v_commands(
-            filter_args={
-                'data_devices': {
-                    'rotational': '1'
-                },
-                'db_devices': {
-                    'rotational': '0',
-                    'limit': 3
-                },
-                'wal_devices': {
-                    'rotational': '0',
-                    'limit': 1
-                }
-            })
-        assert "This doesn't work right now" in ret
+        with pytest.raises(dg.ConfigError):
+            dg.c_v_commands(
+                filter_args={
+                    'data_devices': {
+                        'rotational': '1'
+                    },
+                    'db_devices': {
+                        'rotational': '0',
+                        'limit': 3
+                    },
+                    'wal_devices': {
+                        'rotational': '0',
+                        'limit': 1
+                    }
+                })
+
+    @patch("srv.salt._modules.dg.c_v_commands", autospec=True)
+    def test_deploy(self, c_v_commands):
+        """
+        No ceph-volume commands
+        No errors
+        No old profiles in the pillar
+        """
+        c_v_commands.return_value = []
+        dg.__pillar__ = {}
+        dg.__salt__ = {}
+        dg.__salt__['helper.run'] = Mock()
+        ret = dg.deploy()
+        dg.__salt__['helper.run'].assert_not_called
+        assert ret == []
+
+    @patch("srv.salt._modules.dg.c_v_commands", autospec=True)
+    def test_deploy_1(self, c_v_commands):
+        """
+        No ceph-volume commands
+        No errors
+        Old profiles in the pillar
+        """
+        c_v_commands.return_value = []
+        dg.__pillar__ = {'ceph': {'storage': {'something'}}}
+        dg.__salt__ = {}
+        dg.__salt__['helper.run'] = Mock()
+        ret = dg.deploy()
+        dg.__salt__['helper.run'].assert_not_called()
+        assert "You seem to have configured" in ret
+
+    @patch("srv.salt._modules.dg.c_v_commands", autospec=True)
+    def test_deploy_2(self, c_v_commands):
+        """
+        ceph-volume commands
+        No errors
+        No old profiles in the pillar
+        """
+        c_v_commands.return_value = ['ceph-volume foo bar baz']
+        dg.__pillar__ = {}
+        dg.__salt__ = {}
+        dg.__salt__['helper.run'] = Mock()
+        ret = dg.deploy()
+        dg.__salt__['helper.run'].assert_called_once_with(
+            'ceph-volume foo bar baz')
+        assert len(ret) == len(c_v_commands.return_value)
+
+    @patch("srv.salt._modules.dg.c_v_commands", autospec=True)
+    def test_deploy_3(self, c_v_commands):
+        """
+        No ceph-volume commands
+        One error
+        No old profiles in the pillar
+        """
+        c_v_commands.return_value = ['An error message']
+        dg.__pillar__ = {}
+        dg.__salt__ = {}
+        dg.__salt__['helper.run'] = Mock()
+        ret = dg.deploy()
+        dg.__salt__['helper.run'].assert_not_called()
+        assert len(ret) == 0
+
+    @patch("srv.salt._modules.dg.c_v_commands", autospec=True)
+    def test_deploy_4(self, c_v_commands):
+        """
+        No ceph-volume commands
+        One error
+        No old profiles in the pillar
+        """
+        c_v_commands.return_value = ['']
+        dg.__pillar__ = {}
+        dg.__salt__ = {}
+        dg.__salt__['helper.run'] = Mock()
+        ret = dg.deploy()
+        dg.__salt__['helper.run'].assert_not_called()
+        assert len(ret) == 0
 
 
 class TestFilter(object):

--- a/tests/unit/_modules/test_dg.py
+++ b/tests/unit/_modules/test_dg.py
@@ -475,15 +475,15 @@ class TestDriveGroup(object):
                 'target': 'data*',
                 'format': 'filestore',
                 'data_devices': {
-                    'size': '10G:29G',
+                    'size': '30G:50G',
                     'model': 'foo',
                     'vendor': '1x',
                     'limit': data_limit
                 },
                 'journal_devices': {
-                    'size': ':90G'
+                    'size': ':20G'
                 },
-                'journal_size': '500M',
+                'journal_size': '500',
                 'encryption': True,
             }
             if disk_format == 'filestore':
@@ -586,7 +586,7 @@ class TestDriveGroup(object):
     def test_journal_device_prop(self, test_fix):
         test_fix = test_fix(disk_format='filestore')
         assert test_fix.journal_device_attrs == {
-            'size': ':90G',
+            'size': ':20G',
         }
 
     def test_wal_device_prop_empty(self, test_fix):
@@ -624,7 +624,7 @@ class TestDriveGroup(object):
     def test_journal_devices(self, filter_mock, test_fix):
         test_fix = test_fix(disk_format='filestore')
         test_fix.journal_devices
-        filter_mock.assert_called_once_with({'size': ':90G'})
+        filter_mock.assert_called_once_with({'size': ':20G'})
 
     def test_filestore_format_prop(self, test_fix):
         test_fix = test_fix(disk_format='filestore')
@@ -640,7 +640,7 @@ class TestDriveGroup(object):
 
     def test_journal_size(self, test_fix):
         test_fix = test_fix(disk_format='filestore')
-        assert test_fix.journal_size == '500M'
+        assert test_fix.journal_size == '500'
 
     def test_journal_size_empty(self, test_fix):
         test_fix = test_fix(empty=True)
@@ -879,6 +879,14 @@ class TestDriveGroup(object):
         ret = dg.c_v_commands(filter_args=test_fix.filter_args)
         assert ret == [
             'ceph-volume lvm batch --no-auto /dev/vdb /dev/vdc /dev/vdd /dev/vde /dev/vdf /dev/vdg /dev/vdh /dev/vdi /dev/vdj /dev/vdk /dev/vdl /dev/vdm --yes --dmcrypt --block-wal-size 500 --block-db-size 500'
+        ]
+
+    def test_c_v_commands_filestore(self, test_fix, inventory):
+        inventory()
+        test_fix = test_fix(disk_format='filestore')
+        ret = dg.c_v_commands(filter_args=test_fix.filter_args)
+        assert ret == [
+            'ceph-volume lvm batch /dev/vdb /dev/vdc /dev/vdd /dev/vde /dev/vdf /dev/vdg /dev/vdh /dev/vdi /dev/vdj /dev/vdk --journal-size 500 --journal-devices /dev/vdl /dev/vdm --filestore --yes --dmcrypt'
         ]
 
     def test_c_v_commands_external_db(self, test_fix, inventory):


### PR DESCRIPTION
1) Error messages should not be executed.

2) Unify error messages in case `wal` and no `db`

3) Fix filestore deployment

-----------------

**Checklist:**
- [x] Added unittests and or functional tests
- [ ] Referenced issues or internal bugtracker
- [ ] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
