### PR TITLE
Deploy Prometheus Alertmanager SNMP receiver

### DIFF
--- a/doc/pillar/alertmanager_receiver_snmp.yml
+++ b/doc/pillar/alertmanager_receiver_snmp.yml
@@ -1,0 +1,9 @@
+monitoring:
+  alertmanager_receiver_snmp:
+    enabled: True
+    config:
+      host: localhost
+      port: 9099
+      snmp_host: snmp.foo-bar.com
+      snmp_community: private
+      metrics: True

--- a/srv/salt/ceph/monitoring/alertmanager/default.sls
+++ b/srv/salt/ceph/monitoring/alertmanager/default.sls
@@ -4,8 +4,43 @@ install alertmanager:
     - fire_event: True
     - refresh: True
 
+{% set receiver_snmp_enabled = salt['pillar.get']('monitoring:alertmanager_receiver_snmp:enabled', False) %}
+{% if receiver_snmp_enabled | to_bool %}
+
+prometheus_webhook_snmp_install:
+  pkg.installed:
+    - name: prometheus-webhook-snmp
+    - fire_event: True
+    - refresh: True
+
+prometheus_webhook_snmp_configure:
+  file.managed:
+    - name: "/etc/prometheus-webhook-snmp.conf"
+    - contents: |
+        {{ salt['pillar.get']('monitoring:alertmanager_receiver_snmp:config', {}) | yaml(False) | indent(8) }}
+    - user: root
+    - group: root
+    - mode: 644
+    - fire_event: True
+
+prometheus_webhook_snmp_start:
+  service.running:
+    - name: prometheus-webhook-snmp
+    - enable: True
+    - restart: True
+
+{% else %}
+
+prometheus_webhook_snmp_stop:
+  service.dead:
+    - name: prometheus-webhook-snmp
+    - enable: False
+
+{% endif %}
+
 {% set alertmanager_config = salt['pillar.get']('monitoring:alertmanager:config', '') %}
 {% if alertmanager_config == '' %}
+
 /etc/prometheus/alertmanager.yml:
   file.exists
 

--- a/srv/salt/ceph/rescind/alertmanager/default.sls
+++ b/srv/salt/ceph/rescind/alertmanager/default.sls
@@ -18,5 +18,14 @@ golang-github-prometheus-alertmanager:
 
 /etc/sysconfig/prometheus-alertmanager:
   file.absent
-{% endif %}
 
+prometheus_webhook_snmp_stop:
+  service.dead:
+    - name: prometheus-webhook-snmp
+    - enable: False
+
+prometheus_webhook_snmp_uninstall:
+  pkg.removed:
+    - name: prometheus-webhook-snmp
+    - fire_event: True
+{% endif %}


### PR DESCRIPTION
Install the prometheus-webhook-snmp Prometheus Alertmanager reveiver if pillar ``monitoring:alertmanager:receiver:snmp:enabled`` is set to True.

To enable and configure the Prometheus Alertmanager SNMP receiver the pillar data might look like:

```
monitoring:
  alertmanager:
    receiver:
      snmp:
        enabled: True
        config:
          host: localhost
          port: 9099
          snmp_host: snmp.foo-bar.com
          snmp_community: private
          metrics: True
```

Signed-off-by: Volker Theile <vtheile@suse.com>

-----------------

**Checklist:**
- [ ] Added unittests and or functional tests
- [ ] Adapted documentation
- [ ] Referenced issues or internal bugtracker
- [x] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
