### PR TITLE
srv/pillar/ceph/README should be installed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -200,6 +200,7 @@ copy-files:
 	install -m 644 srv/pillar/ceph/benchmarks/fio/*.yml $(DESTDIR)/srv/pillar/ceph/benchmarks/fio/
 	install -d -m 755 $(DESTDIR)/srv/pillar/ceph/benchmarks/templates
 	install -m 644 srv/pillar/ceph/benchmarks/templates/*.j2 $(DESTDIR)/srv/pillar/ceph/benchmarks/templates/
+	install -m 644 srv/pillar/ceph/README $(DESTDIR)/srv/pillar/ceph/
 	install -m 644 srv/pillar/ceph/init.sls $(DESTDIR)/srv/pillar/ceph/
 	install -m 644 srv/pillar/ceph/deepsea_minions.sls $(DESTDIR)/srv/pillar/ceph/
 	install -m 644 srv/pillar/ceph/blacklist.sls $(DESTDIR)/srv/pillar/ceph/

--- a/deepsea.spec.in
+++ b/deepsea.spec.in
@@ -464,6 +464,7 @@ systemctl try-restart salt-api > /dev/null 2>&1 || :
 /srv/modules/utils/*.py*
 %config %attr(-, salt, salt) /srv/pillar/top.sls
 %config %attr(-, salt, salt) /srv/pillar/ceph/init.sls
+/srv/pillar/ceph/README
 %config %attr(-, salt, salt) /srv/pillar/ceph/benchmarks/config.yml
 %config %attr(-, salt, salt) /srv/pillar/ceph/benchmarks/benchmark.cfg
 %config %attr(-, salt, salt) /srv/pillar/ceph/benchmarks/collections/*.yml


### PR DESCRIPTION
Fixes: https://github.com/SUSE/DeepSea/issues/1660

Signed-off-by: Volker Theile <vtheile@suse.com>

-----------------

**Checklist:**
- [ ] Added unittests and or functional tests
- [ ] Adapted documentation
- [x] Referenced issues or internal bugtracker
- [ ] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
