### PR TITLE
dg: Add parameter to bypass the pillar_check of dg.py

### DIFF
--- a/srv/modules/runners/disks.py
+++ b/srv/modules/runners/disks.py
@@ -111,7 +111,9 @@ class DriveGroups(object):
     def __init__(self, **kwargs: dict) -> None:
         self.local_client = salt.client.LocalClient()
         self.dry_run: bool = kwargs.get('dry_run', False)
-        self.include_unavailable: bool = kwargs.get('include_unavailable', False)
+        self.include_unavailable: bool = kwargs.get('include_unavailable',
+                                                    False)
+        self.bypass_pillar: bool = kwargs.get('bypass_pillar', False)
         self.target: str = kwargs.get('target', '')
         self.drive_groups_path: str = '/srv/salt/ceph/configuration/files/drive_groups.yml'
         self.drive_groups: dict = self._get_drive_groups()
@@ -177,6 +179,7 @@ class DriveGroups(object):
             kwarg={
                 'filter_args': filter_args,
                 'dry_run': self.dry_run,
+                'bypass_pillar': self.bypass_pillar,
                 'include_unavailable': self.include_unavailable,
                 'destroyed_osds': destroyed()
             },
@@ -232,8 +235,10 @@ def destroyed():
     for item in tree:
         # only looking for type host
         if item.get('type', '') == 'host':
-            report_map.update({item.get('name', ''): item.get('children',
-                                                              list())})
+            report_map.update({
+                item.get('name', ''):
+                item.get('children', list())
+            })
 
     return report_map
 

--- a/srv/salt/_modules/dg.py
+++ b/srv/salt/_modules/dg.py
@@ -961,7 +961,8 @@ def deploy(**kwargs):
     # do not run this when there is still ceph:storage in the pillar
     # this indicates that we are in a post-upgrade scenario and
     # the drive assignment was not ported to drive-groups yet.
-    if __pillar__.get('ceph', {}).get('storage'):
+    if not kwargs.get('bypass_pillar', False) and ('storage' in __pillar__.get(
+            'ceph', {})):
         return ("You seem to have configured old-style profiles."
                 "Will not deploy using Drive-Groups."
                 "Please consult <insert doc/man> for guidance"

--- a/tests/unit/runners/test_disks.py
+++ b/tests/unit/runners/test_disks.py
@@ -142,6 +142,7 @@ class TestDriveGroup_Disks(object):
                 'filter_args': {'args'},
                 'dry_run': False,
                 'include_unavailable': False,
+                'bypass_pillar': False,
                 'destroyed_osds': {
                     'data1': [1, 2, 3]
                 }
@@ -160,6 +161,7 @@ class TestDriveGroup_Disks(object):
                 'filter_args': {'args'},
                 'dry_run': True,
                 'include_unavailable': False,
+                'bypass_pillar': False,
                 'destroyed_osds': {
                     'data1': [1, 2, 3]
                 }
@@ -179,6 +181,27 @@ class TestDriveGroup_Disks(object):
                 'filter_args': {'args'},
                 'dry_run': False,
                 'include_unavailable': True,
+                'bypass_pillar': False,
+                'destroyed_osds': {
+                    'data1': [1, 2, 3]
+                }
+            })
+
+    @patch('srv.modules.runners.disks.destroyed')
+    def test_call_bypass_pillar(self, destroyed_mock,
+                                      drive_groups_fixture):
+        dgo = drive_groups_fixture(include_unavailable=True, bypass_pillar=True)
+        destroyed_mock.return_value = {'data1': [1, 2, 3]}
+        dgo.call('target*', {'args'}, 'test_command')
+        dgo.local_client.cmd.assert_called_with(
+            'target*',
+            'dg.test_command',
+            tgt_type='compound',
+            kwarg={
+                'filter_args': {'args'},
+                'dry_run': False,
+                'include_unavailable': True,
+                'bypass_pillar': True,
                 'destroyed_osds': {
                     'data1': [1, 2, 3]
                 }


### PR DESCRIPTION
This parameter is useful for using disks.report and a forceful
disks.deploy.

The command is already mentioned in https://bugzilla.suse.com/show_bug.cgi?id=1135340

-----------------

**Checklist:**
- [x] Added unittests and or functional tests
- [x] Adapted documentation
- [x] Referenced issues or internal bugtracker
- [x] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
