### PR TITLE
dg: adapt default drive group to only match 'roles:storage'

### DIFF
--- a/srv/salt/ceph/configuration/files/drive_groups.yml
+++ b/srv/salt/ceph/configuration/files/drive_groups.yml
@@ -13,7 +13,9 @@
 #     size: 50G
 #     rotational: 0
 
+# This is the default configuration and
+# will create an OSD on all available drives
 default:
-  target: '*'
+  target: 'I@roles:storage'
   data_devices:
     all: true


### PR DESCRIPTION
Also add a few lines explaining what this does


-----------------

**Checklist:**
- [ ] Added unittests and or functional tests
- [ ] Adapted documentation
- [ ] Referenced issues or internal bugtracker
- [ ] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
