### PR TITLE
MyPy static checking via tox

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,7 @@
+[mypy]
+strict_optional = True
+no_implicit_optional = True
+ignore_missing_imports = True
+warn_incomplete_stub = True
+check_untyped_defs = True
+show_error_context = True

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py3,lint
+envlist = py3,lint,mypy
 
 [base]
 deps =
@@ -36,3 +36,9 @@ deps =
     {[base]deps}
     pylint<2.0
     saltpylint<2018.10.13
+
+[testenv:mypy]
+basepython = python3
+commands = mypy --config-file mypy.ini srv/modules srv/salt/_modules
+deps =
+    mypy


### PR DESCRIPTION
Fixes #


Description:
mypy.ini inherited from https://github.com/ceph/ceph/blob/6d1cfe47d530670aa58f8fe3dc52c517a23757a0/src/mypy.ini

-----------------

**Checklist:**
- [ ] Added unittests and or functional tests
- [ ] Adapted documentation
- [ ] Referenced issues or internal bugtracker
- [ ] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)

<details><summary>tox -e mypy</summary>
<p>

```

GLOB sdist-make: /home/shyukri/work/suse/DeepSea/setup.py
mypy inst-nodeps: /home/shyukri/work/suse/DeepSea/.tox/.tmp/package/1/deepsea-0.9.18+5.gac5e53c6.zip
mypy installed: deepsea==0.9.18+5.gac5e53c6,mypy==0.701,mypy-extensions==0.4.1,typed-ast==1.3.5
mypy run-test-pre: PYTHONHASHSEED='3125237554'
mypy run-test: commands[0] | mypy --config-file mypy.ini srv/modules srv/salt/_modules
srv/salt/_modules/deepsea.py: note: In function "show_low_sls":
srv/salt/_modules/deepsea.py:15: error: Name '__salt__' is not defined
srv/salt/_modules/deepsea.py:18: error: Name '__salt__' is not defined
srv/salt/_modules/deepsea.py: note: In function "user":
srv/salt/_modules/deepsea.py:26: error: Name '__grains__' is not defined
srv/salt/_modules/deepsea.py: note: In function "group":
srv/salt/_modules/deepsea.py:35: error: Name '__grains__' is not defined
srv/salt/_modules/deepsea.py: note: In function "ssl_ca_cert_cn":
srv/salt/_modules/deepsea.py:80: error: Name '__grains__' is not defined
srv/salt/_modules/deepsea.py: note: In function "ssl_cert_cn_wildcard":
srv/salt/_modules/deepsea.py:88: error: Name '__grains__' is not defined
srv/salt/_modules/cephimages.py: note: In function "list_":
srv/salt/_modules/cephimages.py:15: error: Need type annotation for 'images'
srv/salt/_modules/cephimages.py:18: error: Name '__salt__' is not defined
srv/salt/_modules/cephimages.py:23: error: Name '__salt__' is not defined
srv/modules/runners/status.py: note: In function "report":
srv/modules/runners/status.py:54: error: Need type annotation for 'unsynced_nodes'
srv/modules/runners/status.py:55: error: Need type annotation for 'common_keys'
srv/modules/runners/orderednodes.py: note: In function "_preserve_order_sorted":
srv/modules/runners/orderednodes.py:38: error: Need type annotation for 'seen'
srv/modules/runners/orderednodes.py:39: error: "add" of "set" does not return a value
srv/modules/runners/orderednodes.py: note: In function "unique":
srv/modules/runners/orderednodes.py:48: error: Need type annotation for 'all_clients'
srv/modules/runners/orderednodes.py:50: error: Name '__opts__' is not defined
srv/salt/_modules/zypper_locks.py: note: In function "ready":
srv/salt/_modules/zypper_locks.py:38: error: Name '__salt__' is not defined
srv/salt/_modules/zypper_locks.py:41: error: Name '__salt__' is not defined
srv/salt/_modules/scrape_targets.py: note: In function "partition":
srv/salt/_modules/scrape_targets.py:54: error: Name '__salt__' is not defined
srv/salt/_modules/scrape_targets.py:69: error: Need type annotation for 'to_remove'
srv/salt/_modules/rgw.py: note: In function "configurations":
srv/salt/_modules/rgw.py:26: error: Name '__pillar__' is not defined
srv/salt/_modules/rgw.py:27: error: Name '__pillar__' is not defined
srv/salt/_modules/rgw.py:28: error: Name '__pillar__' is not defined
srv/salt/_modules/rgw.py:29: error: Name '__pillar__' is not defined
srv/salt/_modules/rgw.py:30: error: Name '__pillar__' is not defined
srv/salt/_modules/rgw.py:32: error: Name '__pillar__' is not defined
srv/salt/_modules/rgw.py: note: In function "configuration":
srv/salt/_modules/rgw.py:44: error: Name '__pillar__' is not defined
srv/salt/_modules/rgw.py:45: error: Name '__pillar__' is not defined
srv/salt/_modules/rgw.py:46: error: Name '__pillar__' is not defined
srv/salt/_modules/rgw.py: note: In function "users":
srv/salt/_modules/rgw.py:57: error: Name '__salt__' is not defined
srv/salt/_modules/rgw.py: note: In function "add_users":
srv/salt/_modules/rgw.py:69: error: Name '__salt__' is not defined
srv/salt/_modules/rgw.py:107: error: Name '__salt__' is not defined
srv/salt/_modules/rgw.py:110: error: Name '__salt__' is not defined
srv/salt/_modules/rgw.py:116: error: Name '__salt__' is not defined
srv/salt/_modules/rgw.py:120: error: Name '__salt__' is not defined
srv/salt/_modules/rgw.py:129: error: Incompatible types in assignment (expression has type "List[str]", variable has type "str")
srv/salt/_modules/rgw.py:130: error: "str" has no attribute "extend"
srv/salt/_modules/rgw.py:131: error: "str" has no attribute "extend"
srv/salt/_modules/rgw.py:135: error: Name '__salt__' is not defined
srv/salt/_modules/rgw.py:138: error: Name '__salt__' is not defined
srv/salt/_modules/retry.py: note: In function "cmd":
srv/salt/_modules/retry.py:35: error: Argument 1 to "Popen" has incompatible type "int"; expected "Union[bytes, str, Sequence[Union[bytes, str, _PathLike[Any]]]]"
srv/salt/_modules/retry.py:38: error: Name '__salt__' is not defined
srv/salt/_modules/retry.py:41: error: Name '__salt__' is not defined
srv/salt/_modules/public.py: note: In function "address":
srv/salt/_modules/public.py:22: error: Name '__pillar__' is not defined
srv/salt/_modules/public.py:25: error: Name '__pillar__' is not defined
srv/salt/_modules/public.py:26: error: Name '__pillar__' is not defined
srv/salt/_modules/public.py:27: error: Name '__pillar__' is not defined
srv/salt/_modules/public.py:29: error: Name '__pillar__' is not defined
srv/salt/_modules/public.py:34: error: Name '__salt__' is not defined
srv/salt/_modules/public.py: note: In function "_ipnetwork":
srv/salt/_modules/public.py:75: error: Name '__pillar__' is not defined
srv/salt/_modules/public.py:77: error: Name '__pillar__' is not defined
srv/salt/_modules/public.py:78: error: Name '__pillar__' is not defined
srv/salt/_modules/public.py:79: error: Name '__pillar__' is not defined
srv/salt/_modules/public.py:81: error: Name '__pillar__' is not defined
srv/salt/_modules/keyring.py: note: In function "gen_secret":
srv/salt/_modules/keyring.py:40: error: Name '__salt__' is not defined
srv/salt/_modules/kernel.py: note: In function "replace":
srv/salt/_modules/kernel.py:50: error: Name '__grains__' is not defined
srv/salt/_modules/kernel.py:51: error: Name '__grains__' is not defined
srv/salt/_modules/kernel.py:52: error: Name '__grains__' is not defined
srv/salt/_modules/kernel.py:53: error: Name '__grains__' is not defined
srv/salt/_modules/kernel.py: note: In function "_kernel_pkg":
srv/salt/_modules/kernel.py:85: error: Name '__salt__' is not defined
srv/salt/_modules/kernel.py: note: In function "installed_kernel_version":
srv/salt/_modules/kernel.py:125: error: Name '__grains__' is not defined
srv/salt/_modules/kernel.py:133: error: Name '__salt__' is not defined
srv/salt/_modules/ganesha.py: note: In function "configurations":
srv/salt/_modules/ganesha.py:29: error: Name '__pillar__' is not defined
srv/salt/_modules/ganesha.py:30: error: Name '__pillar__' is not defined
srv/salt/_modules/ganesha.py:31: error: Name '__pillar__' is not defined
srv/salt/_modules/ganesha.py:32: error: Name '__pillar__' is not defined
srv/salt/_modules/ganesha.py:33: error: Name '__pillar__' is not defined
srv/salt/_modules/ganesha.py: note: In function "validate_ganesha_daemon":
srv/salt/_modules/ganesha.py:88: error: Name '__salt__' is not defined
srv/salt/_modules/fs.py: note: In function "_systemctl_cmd_target":
srv/salt/_modules/fs.py:41: error: Name '__salt__' is not defined
srv/salt/_modules/fs.py:43: error: Name '__salt__' is not defined
srv/salt/_modules/fs.py: note: In function "_ceph_is_down":
srv/salt/_modules/fs.py:116: error: Name '__salt__' is not defined
srv/salt/_modules/fs.py: note: In function "_ceph_is_up":
srv/salt/_modules/fs.py:143: error: Name '__salt__' is not defined
srv/salt/_modules/fs.py:149: error: Name '__salt__' is not defined
srv/salt/_modules/fs.py: note: In function "_mv_contents":
srv/salt/_modules/fs.py:188: error: Name '__salt__' is not defined
srv/salt/_modules/fs.py: note: In function "btrfs_get_default_subvol":
srv/salt/_modules/fs.py:281: error: Name '__salt__' is not defined
srv/salt/_modules/fs.py: note: In function "btrfs_subvol_exists":
srv/salt/_modules/fs.py:309: error: Name '__salt__' is not defined
srv/salt/_modules/fs.py: note: In function "btrfs_create_subvol":
srv/salt/_modules/fs.py:371: error: Name '__salt__' is not defined
srv/salt/_modules/fs.py:379: error: Name '__salt__' is not defined
srv/salt/_modules/fs.py:387: error: Name '__salt__' is not defined
srv/salt/_modules/fs.py: note: In function "btrfs_mount_subvol":
srv/salt/_modules/fs.py:483: error: Name '__salt__' is not defined
srv/salt/_modules/fs.py: note: In function "get_attrs":
srv/salt/_modules/fs.py:535: error: Name '__salt__' is not defined
srv/salt/_modules/fs.py: note: In function "_call_chattr":
srv/salt/_modules/fs.py:553: error: Name '__salt__' is not defined
srv/salt/_modules/fs.py: note: In function "get_uuid":
srv/salt/_modules/fs.py:780: error: Name '__salt__' is not defined
srv/salt/_modules/fs.py: note: In function "get_device_info":
srv/salt/_modules/fs.py:839: error: Incompatible types in assignment (expression has type "str", target has type "None")
srv/salt/_modules/fs.py:841: error: Incompatible types in assignment (expression has type "str", target has type "None")
srv/salt/_modules/fs.py:843: error: Incompatible types in assignment (expression has type "str", target has type "None")
srv/salt/_modules/fs.py: note: In function "_unmount_osd":
srv/salt/_modules/fs.py:932: error: Name '__salt__' is not defined
srv/salt/_modules/fs.py: note: In function "_mount_osd":
srv/salt/_modules/fs.py:944: error: Name '__salt__' is not defined
srv/salt/_modules/fs.py: note: In function "migrate_path_to_btrfs_subvolume":
srv/salt/_modules/fs.py:1032: error: Name '__salt__' is not defined
srv/salt/_modules/fs.py: note: In function "inspect_path":
srv/salt/_modules/fs.py:1170: error: Incompatible types in assignment (expression has type "str", target has type "Optional[bool]")
srv/salt/_modules/fs.py:1181: error: Value of type "Optional[bool]" is not indexable
srv/salt/_modules/dg.py: note: In member "raw" of class "Inventory":
srv/salt/_modules/dg.py:144: error: Name '__salt__' is not defined
srv/salt/_modules/dg.py: note: In member "disks" of class "Inventory":
srv/salt/_modules/dg.py:161: error: Incompatible return value type (got "Dict[Any, Any]", expected "List[Any]")
srv/salt/_modules/dg.py: note: In member "_virtual" of class "Matcher":
srv/salt/_modules/dg.py:195: error: Name '__grains__' is not defined
srv/salt/_modules/dg.py: note: In member "_reduce_inventory" of class "DriveGroup":
srv/salt/_modules/dg.py:794: error: Missing return statement
srv/salt/_modules/dg.py:821: error: Exception type must be derived from BaseException
srv/salt/_modules/dg.py: note: In function "c_v_commands":
srv/salt/_modules/dg.py:885: error: Name '__grains__' is not defined
srv/salt/_modules/dg.py: note: In function "deploy":
srv/salt/_modules/dg.py:984: error: Name '__pillar__' is not defined
srv/salt/_modules/dg.py:998: error: Name '__salt__' is not defined
srv/salt/_modules/cephprocesses.py: note: In member "_service_names" of class "SystemdUnit":
srv/salt/_modules/cephprocesses.py:101: error: Need type annotation for 'service_names'
srv/salt/_modules/cephprocesses.py:105: error: Name '__grains__' is not defined
srv/salt/_modules/cephprocesses.py:107: error: Name '__grains__' is not defined
srv/salt/_modules/cephprocesses.py: note: In member "__init__" of class "MetaCheck":
srv/salt/_modules/cephprocesses.py:176: error: Need type annotation for 'up'
srv/salt/_modules/cephprocesses.py:177: error: Need type annotation for 'down'
srv/salt/_modules/cephprocesses.py: note: In function "blacklist":
srv/salt/_modules/cephprocesses.py:193: error: Name '__salt__' is not defined
srv/salt/_modules/cephprocesses.py: note: In member "expected_osds" of class "MetaCheck":
srv/salt/_modules/cephprocesses.py:207: error: Need type annotation for 'blacklisted_osds'
srv/salt/_modules/cephprocesses.py:213: error: Name '__salt__' is not defined
srv/salt/_modules/cephprocesses.py: note: In member "add" of class "MetaCheck":
srv/salt/_modules/cephprocesses.py:226: error: Unsupported right operand type for in ("object")
srv/salt/_modules/cephprocesses.py: note: In member "check_absents" of class "MetaCheck":
srv/salt/_modules/cephprocesses.py:248: error: "object" has no attribute "__iter__"; maybe "__str__" or "__dir__"? (not iterable)
srv/salt/_modules/cephprocesses.py: note: In member "report" of class "MetaCheck":
srv/salt/_modules/cephprocesses.py:306: error: Need type annotation for 'res'
srv/salt/_modules/cephprocesses.py: note: In function "_extend_processes":
srv/salt/_modules/cephprocesses.py:330: error: Name '__pillar__' is not defined
srv/salt/_modules/cephprocesses.py:331: error: Name '__pillar__' is not defined
srv/salt/_modules/cephprocesses.py: note: In function "check":
srv/salt/_modules/cephprocesses.py:342: error: Name '__pillar__' is not defined
srv/salt/_modules/cephprocesses.py:346: error: Name '__pillar__' is not defined
srv/salt/_modules/cephprocesses.py:349: error: Name '__pillar__' is not defined
srv/salt/_modules/cephprocesses.py: note: In function "_process_map":
srv/salt/_modules/cephprocesses.py:405: error: Name '__salt__' is not defined
srv/salt/_modules/cephprocesses.py: note: In function "zypper_ps":
srv/salt/_modules/cephprocesses.py:426: error: Name '__salt__' is not defined
srv/salt/_modules/cephprocesses.py:434: error: Name '__pillar__' is not defined
srv/salt/_modules/cephprocesses.py:438: error: Unsupported right operand type for in ("object")
srv/salt/_modules/cephprocesses.py: note: In function "need_restart_lsof":
srv/salt/_modules/cephprocesses.py:451: error: Unsupported right operand type for in ("object")
srv/salt/_modules/cephprocesses.py: note: In function "need_restart_config_change":
srv/salt/_modules/cephprocesses.py:464: error: Name '__grains__' is not defined
srv/salt/_modules/cephprocesses.py: note: In function "_timeout":
srv/salt/_modules/cephprocesses.py:488: error: Name '__grains__' is not defined
srv/modules/utils/ready.py: note: In member "__init__" of class "Checks":
srv/modules/utils/ready.py:47: error: Need type annotation for 'passed'
srv/modules/utils/ready.py:48: error: Need type annotation for 'warnings'
srv/modules/utils/ready.py: note: In function "check":
srv/modules/utils/ready.py:160: error: Cannot determine type of 'warnings'
srv/modules/runners/smoketests.py: note: In member "__init__" of class "SmoketestPillar":
srv/modules/runners/smoketests.py:23: error: Need type annotation for 'base'
srv/modules/runners/select.py: note: In function "from_":
srv/modules/runners/select.py:209: error: Incompatible types in assignment (expression has type "List[Any]", variable has type "Tuple[Any, ...]")
srv/modules/runners/rescinded.py: note: In function "ids":
srv/modules/runners/rescinded.py:51: error: Need type annotation for '_ids'
srv/modules/runners/rescinded.py: note: In function "osds":
srv/modules/runners/rescinded.py:68: error: Need type annotation for '_ids'
srv/modules/runners/rebuild.py: note: In member "__init__" of class "Rebuild":
srv/modules/runners/rebuild.py:62: error: Name '__opts__' is not defined
srv/modules/runners/rebuild.py:69: error: Need type annotation for 'skipped'
srv/modules/runners/rebuild.py: note: In member "_minions" of class "Rebuild":
srv/modules/runners/rebuild.py:73: error: Need type annotation for 'minions'
srv/modules/runners/ready.py: note: In member "__init__" of class "Checks":
srv/modules/runners/ready.py:47: error: Need type annotation for 'passed'
srv/modules/runners/ready.py:48: error: Need type annotation for 'warnings'
srv/modules/runners/ready.py: note: In function "check":
srv/modules/runners/ready.py:160: error: Cannot determine type of 'warnings'
srv/modules/runners/osd.py: note: In function "_target_lookup":
srv/modules/runners/osd.py:434: error: Need type annotation for 'osd_list'
srv/modules/runners/openstack.py:16: error: Name 'configparser' already defined (by an import)
srv/modules/runners/minions.py: note: In function "ready":
srv/modules/runners/minions.py:50: error: Need type annotation for 'ret'
srv/modules/runners/minions.py:54: error: Unsupported operand types for + ("float" and "None")
srv/modules/runners/minions.py:54: note: Right operand is of type "Optional[int]"
srv/modules/runners/minions.py:63: error: Name '__opts__' is not defined
srv/modules/runners/minions.py:66: error: Name '__opts__' is not defined
srv/modules/runners/minions.py:78: error: Name '__opts__' is not defined
srv/modules/runners/minions.py:83: error: Name '__opts__' is not defined
srv/modules/runners/minions.py:98: error: Argument 1 to "sleep" has incompatible type "Optional[int]"; expected "float"
srv/modules/runners/filequeue.py: note: In member "_fire_event" of class "FileQueue":
srv/modules/runners/filequeue.py:191: error: Name '__opts__' is not defined
srv/modules/runners/deepsea.py: note: In function "version":
srv/modules/runners/deepsea.py:21: error: Item "None" of "Optional[Match[str]]" has no attribute "group"
srv/modules/runners/changed.py: note: In member "rgw_configurations" of class "Role":
srv/modules/runners/changed.py:103: error: Need type annotation for 'roles'
srv/modules/runners/changed.py: note: In function "requires_conf_change":
srv/modules/runners/changed.py:229: error: Item "None" of "Optional[Any]" has no attribute "dependencies"
srv/modules/runners/changed.py:231: error: Item "None" of "Optional[Any]" has no attribute "dependencies"
srv/modules/runners/cephprocesses.py: note: In function "_cached_roles":
srv/modules/runners/cephprocesses.py:187: error: Name '__opts__' is not defined
srv/modules/runners/cephprocesses.py:190: error: Need type annotation for 'roles'
srv/modules/runners/cephprocesses.py: note: In function "wait":
srv/modules/runners/cephprocesses.py:214: error: Need type annotation for 'status'
srv/salt/_modules/purge.py: note: In function "roles":
srv/salt/_modules/purge.py:36: error: Cannot assign to a method
srv/salt/_modules/purge.py: note: In function "default":
srv/salt/_modules/purge.py:70: error: Cannot assign to a method
srv/salt/_modules/packagemanager.py: note: In member "__init__" of class "PackageManager":
srv/salt/_modules/packagemanager.py:31: error: Name '__grains__' is not defined
srv/salt/_modules/packagemanager.py: note: In member "_reboot" of class "PackageManager":
srv/salt/_modules/packagemanager.py:52: error: Name '__salt__' is not defined
srv/salt/_modules/packagemanager.py: note: In member "_updates_needed" of class "Apt":
srv/salt/_modules/packagemanager.py:89: error: Name '__salt__' is not defined
srv/salt/_modules/packagemanager.py: note: In member "_refresh" of class "Zypper":
srv/salt/_modules/packagemanager.py:183: error: Need type annotation for 'cmd'
srv/salt/_modules/packagemanager.py: note: In member "list_updates" of class "Zypper":
srv/salt/_modules/packagemanager.py:245: error: Name '__salt__' is not defined
srv/salt/_modules/packagemanager.py:248: error: "object" has no attribute "__iter__"; maybe "__str__" or "__dir__"? (not iterable)
srv/salt/_modules/packagemanager.py: note: In member "_patches_needed" of class "Zypper":
srv/salt/_modules/packagemanager.py:258: error: Need type annotation for 'cmd'
srv/salt/_modules/packagemanager.py: note: In member "_handle" of class "Zypper":
srv/salt/_modules/packagemanager.py:301: error: Need type annotation for 'cmd'
srv/salt/_modules/packagemanager.py: note: In member "_migrate" of class "Zypper":
srv/salt/_modules/packagemanager.py:342: error: Need type annotation for 'cmd'
srv/salt/_modules/osd.py: note: In member "_is_mounted" of class "OSD":
srv/salt/_modules/osd.py:74: error: Argument 1 to "ismount" has incompatible type "List[Any]"; expected "Union[bytes, str, _PathLike[Any]]"
srv/salt/_modules/osd.py: note: In function "pairs":
srv/salt/_modules/osd.py:273: error: Item "None" of "Optional[Match[str]]" has no attribute "group"
srv/salt/_modules/osd.py: note: In function "part_pairs":
srv/salt/_modules/osd.py:292: error: Item "None" of "Optional[Match[str]]" has no attribute "group"
srv/salt/_modules/osd.py: note: In function "configured":
srv/salt/_modules/osd.py:315: error: Need type annotation for '_devices'
srv/salt/_modules/osd.py:319: error: Name '__pillar__' is not defined
srv/salt/_modules/osd.py:320: error: Name '__pillar__' is not defined
srv/salt/_modules/osd.py:321: error: Name '__pillar__' is not defined
srv/salt/_modules/osd.py:324: error: Name '__pillar__' is not defined
srv/salt/_modules/osd.py:325: error: Name '__pillar__' is not defined
srv/salt/_modules/osd.py:326: error: Name '__pillar__' is not defined
srv/salt/_modules/osd.py:327: error: Name '__pillar__' is not defined
srv/salt/_modules/osd.py:331: error: Name '__pillar__' is not defined
srv/salt/_modules/osd.py:332: error: Name '__pillar__' is not defined
srv/salt/_modules/osd.py:333: error: Name '__pillar__' is not defined
srv/salt/_modules/osd.py:334: error: Name '__pillar__' is not defined
srv/salt/_modules/osd.py: note: In function "list_":
srv/salt/_modules/osd.py:351: error: Name '__grains__' is not defined
srv/salt/_modules/osd.py:352: error: Name '__grains__' is not defined
srv/salt/_modules/osd.py: note: In function "_children":
srv/salt/_modules/osd.py:380: error: Need type annotation for 'entries'
srv/salt/_modules/osd.py:382: error: Name '__grains__' is not defined
srv/salt/_modules/osd.py: note: In member "update_weight" of class "OSDWeight":
srv/salt/_modules/osd.py:528: error: Name '__salt__' is not defined
srv/salt/_modules/osd.py: note: In member "update_reweight" of class "OSDWeight":
srv/salt/_modules/osd.py:537: error: Name '__salt__' is not defined
srv/salt/_modules/osd.py: note: In member "quiescent" of class "CephPGs":
srv/salt/_modules/osd.py:636: error: Need type annotation for 'last'
srv/salt/_modules/osd.py: note: In function "_settings":
srv/salt/_modules/osd.py:690: error: Need type annotation for 'settings'
srv/salt/_modules/osd.py: note: In function "readlink":
srv/salt/_modules/osd.py:763: error: Name '__salt__' is not defined
srv/salt/_modules/osd.py: note: In member "_uuid_device" of class "OSDDevices":
srv/salt/_modules/osd.py:905: error: Name '__salt__' is not defined
srv/salt/_modules/osd.py: note: In member "delete" of class "OSDGrains":
srv/salt/_modules/osd.py:933: error: Need type annotation for 'content'
srv/salt/_modules/osd.py: note: In member "_grains" of class "OSDGrains":
srv/salt/_modules/osd.py:949: error: Need type annotation for 'content'
srv/salt/_modules/osd.py: note: In member "_update_grains" of class "OSDGrains":
srv/salt/_modules/osd.py:968: error: Cannot assign to a method
srv/salt/_modules/osd.py:975: error: Name '__salt__' is not defined
srv/salt/_modules/osd.py: note: In function "_partition":
srv/salt/_modules/osd.py:982: error: Name '__grains__' is not defined
srv/salt/_modules/osd.py:983: error: Name '__grains__' is not defined
srv/salt/_modules/osd.py:984: error: Name '__grains__' is not defined
srv/salt/_modules/osd.py: note: In function "_fsck":
srv/salt/_modules/osd.py:999: error: Name '__salt__' is not defined
srv/salt/_modules/osd.py: note: In function "terminate":
srv/salt/_modules/osd.py:1032: error: Name '__salt__' is not defined
srv/salt/_modules/osd.py:1035: error: Name '__salt__' is not defined
srv/salt/_modules/osd.py:1037: error: Name '__salt__' is not defined
srv/salt/_modules/osd.py:1040: error: Name '__salt__' is not defined
srv/salt/_modules/osd.py:1043: error: Name '__salt__' is not defined
srv/salt/_modules/osd.py: note: In function "takeover":
srv/salt/_modules/osd.py:1052: error: Name '__salt__' is not defined
srv/salt/_modules/osd.py:1058: error: Name '__salt__' is not defined
srv/salt/_modules/osd.py:1063: error: Need type annotation for 'osd_files'
srv/salt/_modules/osd.py:1072: error: Name '__salt__' is not defined
srv/salt/_modules/multi.py:21: error: Module 'distutils.spawn' has no attribute 'which'
srv/salt/_modules/multi.py: note: In function "_summarize_iperf":
srv/salt/_modules/multi.py:73: error: Item "None" of "Optional[Match[Any]]" has no attribute "group"
srv/salt/_modules/multi.py: note: In function "_summarize_ping":
srv/salt/_modules/multi.py:118: error: Unsupported operand types for / ("None" and "int")
srv/salt/_modules/multi.py:118: note: Left operand is of type "Union[Any, None, int]"
srv/salt/_modules/multi.py:121: error: Unsupported operand types for < ("float" and "None")
srv/salt/_modules/multi.py:121: note: Both left and right operands are unions
srv/salt/_modules/multi.py:131: error: Incompatible types in assignment (expression has type "str", target has type "int")
srv/salt/_modules/multi.py:133: error: Incompatible types in assignment (expression has type "str", target has type "int")
srv/salt/_modules/multi.py:135: error: Incompatible types in assignment (expression has type "str", target has type "int")
srv/salt/_modules/multi.py:135: error: Argument 1 to "join" of "str" has incompatible type "List[Optional[Any]]"; expected "Iterable[str]"
srv/salt/_modules/multi.py:136: error: Incompatible types in assignment (expression has type "Union[Any, float]", target has type "int")
srv/salt/_modules/multi.py: note: In function "iperf_client_cmd":
srv/salt/_modules/multi.py:170: error: Name '__salt__' is not defined
srv/salt/_modules/multi.py:171: error: Incompatible types in assignment (expression has type "Tuple[Any, Any, Any, Any]", variable has type "List[object]")
srv/salt/_modules/multi.py: note: In function "ping_cmd":
srv/salt/_modules/multi.py:226: error: Name '__salt__' is not defined
srv/salt/_modules/multi.py: note: In function "jumbo_ping_cmd":
srv/salt/_modules/multi.py:254: error: Name '__salt__' is not defined
srv/modules/runners/validate.py: note: In member "__init__" of class "JsonPrinter":
srv/modules/runners/validate.py:117: error: Need type annotation for 'result'
srv/modules/runners/validate.py: note: In member "__init__" of class "Preparation":
srv/modules/runners/validate.py:152: error: Name '__utils__' is not defined
srv/modules/runners/validate.py:153: error: Name '__utils__' is not defined
srv/modules/runners/validate.py: note: In member "_clusters" of class "ClusterAssignment":
srv/modules/runners/validate.py:193: error: Need type annotation for 'clusters'
srv/modules/runners/validate.py: note: In member "__init__" of class "Validate":
srv/modules/runners/validate.py:242: error: Need type annotation for 'skipped'
srv/modules/runners/validate.py:243: error: Need type annotation for 'passed'
srv/modules/runners/validate.py:244: error: Need type annotation for 'errors'
srv/modules/runners/validate.py:245: error: Need type annotation for 'warnings'
srv/modules/runners/validate.py:246: error: Need type annotation for 'ipversion'
srv/modules/runners/validate.py:252: error: Need type annotation for 'uninstalled'
srv/modules/runners/validate.py: note: In member "storage" of class "Validate":
srv/modules/runners/validate.py:416: error: Need type annotation for 'missing'
srv/modules/runners/validate.py: note: In member "ganesha" of class "Validate":
srv/modules/runners/validate.py:483: error: Need type annotation for 'ganesha_roles'
srv/modules/runners/validate.py: note: In member "master_minion" of class "Validate":
srv/modules/runners/validate.py:790: error: Name '__pillar__' is not defined
srv/modules/runners/validate.py: note: In member "_check_installed" of class "Validate":
srv/modules/runners/validate.py:810: error: Name '__utils__' is not defined
srv/modules/runners/validate.py: note: In member "lint_yaml_files" of class "Validate":
srv/modules/runners/validate.py:954: error: "YAMLError" has no attribute "problem_mark"
srv/modules/runners/validate.py: note: In member "__init__" of class "ConfigCheck":
srv/modules/runners/validate.py:1136: error: Need type annotation for 'issues'
srv/modules/runners/validate.py: note: In function "discovery":
srv/modules/runners/validate.py:1315: error: Name '__pillar__' is not defined
srv/modules/runners/validate.py:1316: error: Name '__pillar__' is not defined
srv/modules/runners/validate.py:1320: error: Incompatible types in assignment (expression has type "None", variable has type "str")
srv/modules/runners/validate.py:1329: error: Cannot determine type of 'errors'
srv/modules/runners/validate.py: note: In function "config_check":
srv/modules/runners/validate.py:1351: error: Cannot determine type of 'errors'
srv/modules/runners/validate.py: note: In function "pillar":
srv/modules/runners/validate.py:1393: error: Cannot determine type of 'errors'
srv/modules/runners/validate.py: note: In function "deploy":
srv/modules/runners/validate.py:1411: error: Cannot determine type of 'errors'
srv/modules/runners/validate.py: note: In function "saltapi":
srv/modules/runners/validate.py:1426: error: Cannot determine type of 'errors'
srv/modules/runners/validate.py: note: In function "setup":
srv/modules/runners/validate.py:1448: error: Name '__salt__' is not defined
srv/modules/runners/validate.py:1468: error: Cannot determine type of 'errors'
srv/modules/runners/push.py: note: In member "organize" of class "PillarData":
srv/modules/runners/push.py:212: error: Need type annotation for 'common'
srv/modules/runners/push.py: note: In function "_merge":
srv/modules/runners/push.py:275: error: Need type annotation for 'merged'
srv/modules/runners/iscsi_upgrade.py: note: In function "_check_if_migration_needed":
srv/modules/runners/iscsi_upgrade.py:29: error: Name '__context__' is not defined
srv/modules/runners/iscsi_upgrade.py:36: error: Name '__context__' is not defined
srv/modules/runners/iscsi_upgrade.py: note: In function "validate":
srv/modules/runners/iscsi_upgrade.py:68: error: Name '__context__' is not defined
srv/modules/runners/iscsi_upgrade.py:79: error: Name '__context__' is not defined
srv/modules/runners/iscsi_upgrade.py:83: error: Name '__context__' is not defined
srv/modules/runners/iscsi_upgrade.py:91: error: Name '__context__' is not defined
srv/modules/runners/iscsi_upgrade.py:95: error: Name '__context__' is not defined
srv/modules/runners/iscsi_upgrade.py: note: In function "upgrade":
srv/modules/runners/iscsi_upgrade.py:123: error: Name '__context__' is not defined
srv/modules/runners/iscsi_upgrade.py:127: error: Need type annotation for 'minions'
srv/modules/runners/iscsi_upgrade.py:130: error: Name '__context__' is not defined
srv/modules/runners/iscsi_upgrade.py:135: error: Name '__context__' is not defined
srv/modules/runners/iscsi_upgrade.py:141: error: Name '__context__' is not defined
srv/modules/runners/iscsi_upgrade.py:149: error: Name '__context__' is not defined
srv/modules/runners/iscsi_upgrade.py:152: error: Name '__context__' is not defined
srv/modules/runners/iscsi_upgrade.py:155: error: Name '__context__' is not defined
srv/modules/runners/iscsi_upgrade.py:163: error: Name '__context__' is not defined
srv/modules/runners/iscsi_upgrade.py:171: error: Name '__context__' is not defined
srv/modules/runners/iscsi_upgrade.py:179: error: Name '__context__' is not defined
srv/modules/runners/iscsi_upgrade.py:183: error: Name '__context__' is not defined
srv/modules/runners/iscsi_upgrade.py:190: error: Name '__context__' is not defined
srv/modules/runners/iscsi_upgrade.py:194: error: Name '__context__' is not defined
srv/modules/runners/iscsi_upgrade.py: note: In function "set_igw_service_daemon":
srv/modules/runners/iscsi_upgrade.py:212: error: Need type annotation for 'contents'
srv/modules/runners/iscsi_upgrade.py:219: error: Cannot assign to a method
srv/modules/runners/ganesha_upgrade.py: note: In function "validate":
srv/modules/runners/ganesha_upgrade.py:256: error: Name '__context__' is not defined
srv/modules/runners/ganesha_upgrade.py:263: error: Name '__context__' is not defined
srv/modules/runners/ganesha_upgrade.py:273: error: Name '__context__' is not defined
srv/modules/runners/ganesha_upgrade.py:276: error: Name '__context__' is not defined
srv/modules/runners/ganesha_upgrade.py:283: error: Need type annotation for 'minions'
srv/modules/runners/ganesha_upgrade.py:291: error: Name '__context__' is not defined
srv/modules/runners/ganesha_upgrade.py:303: error: Name '__context__' is not defined
srv/modules/runners/ganesha_upgrade.py:308: error: Name '__context__' is not defined
srv/modules/runners/ganesha_upgrade.py:318: error: Name '__context__' is not defined
srv/modules/runners/ganesha_upgrade.py: note: In function "upgrade":
srv/modules/runners/ganesha_upgrade.py:352: error: Name '__context__' is not defined
srv/modules/runners/ganesha_upgrade.py:360: error: Need type annotation for 'raw_configs'
srv/modules/runners/ganesha_upgrade.py:378: error: Need type annotation for 'unique_export_blocks'
srv/modules/runners/ganesha_upgrade.py:385: error: Name '__context__' is not defined
srv/modules/runners/ganesha_upgrade.py:403: error: Name '__context__' is not defined
srv/modules/runners/ganesha_upgrade.py:407: error: Name '__context__' is not defined
srv/modules/runners/ganesha_upgrade.py:411: error: Name '__context__' is not defined
srv/modules/runners/ganesha_upgrade.py:417: error: Need type annotation for 'exports_per_daemon'
srv/modules/runners/ganesha_upgrade.py:437: error: Name '__context__' is not defined
srv/modules/runners/ganesha_upgrade.py:441: error: Name '__context__' is not defined
srv/modules/runners/ganesha_upgrade.py:445: error: Name '__context__' is not defined
srv/modules/runners/ganesha_upgrade.py:451: error: Need type annotation for 'contents'
srv/modules/runners/ganesha_upgrade.py:459: error: Cannot assign to a method
srv/modules/runners/ganesha_upgrade.py:474: error: Name '__context__' is not defined
srv/modules/runners/ganesha_upgrade.py:478: error: Name '__context__' is not defined
srv/modules/runners/ganesha_upgrade.py:490: error: Name '__context__' is not defined
srv/modules/runners/ganesha_upgrade.py:494: error: Name '__context__' is not defined
srv/modules/runners/ganesha_upgrade.py:507: error: Name '__context__' is not defined
srv/modules/runners/ganesha_upgrade.py:511: error: Name '__context__' is not defined
srv/modules/runners/disks.py: note: In member "__init__" of class "DriveGroups":
srv/modules/runners/disks.py:113: error: Incompatible types in assignment (expression has type "Union[Dict[Any, Any], bool]", variable has type "bool")
srv/modules/runners/disks.py:114: error: Incompatible types in assignment (expression has type "Union[Dict[Any, Any], bool]", variable has type "bool")
srv/modules/runners/disks.py:116: error: Incompatible types in assignment (expression has type "Union[Dict[Any, Any], bool]", variable has type "bool")
srv/modules/runners/disks.py:117: error: Incompatible types in assignment (expression has type "Union[Dict[Any, Any], str]", variable has type "str")
srv/modules/runners/disks.py: note: In member "call_out" of class "DriveGroups":
srv/modules/runners/disks.py:140: error: Incompatible default for argument "alias" (default has type "None", argument has type "str")
srv/modules/runners/disks.py: note: In member "call" of class "DriveGroups":
srv/modules/runners/disks.py:162: error: Incompatible default for argument "alias" (default has type "None", argument has type "str")
srv/modules/runners/disks.py: note: In function "destroyed":
srv/modules/runners/disks.py:221: error: Need type annotation for 'tree'
srv/modules/runners/disks.py:224: error: "str" has no attribute "values"
srv/salt/_modules/iscsi.py: note: In member "check_read_write_perms" of class "RadosConn":
srv/salt/_modules/iscsi.py:80: error: Name '__salt__' is not defined
srv/salt/_modules/iscsi.py: note: In member "__init__" of class "CephCluster":
srv/salt/_modules/iscsi.py:99: error: Name '__salt__' is not defined
srv/salt/_modules/iscsi.py: note: In class "CephIscsiConfig":
srv/salt/_modules/iscsi.py:155: error: Need type annotation for 'errors'
srv/salt/_modules/iscsi.py: note: In member "_get_controls" of class "CephIscsiConfig":
srv/salt/_modules/iscsi.py:213: error: Need type annotation for 'controls_overrides'
srv/salt/_modules/iscsi.py: note: In member "get_target_controls" of class "CephIscsiConfig":
srv/salt/_modules/iscsi.py:236: error: Need type annotation for 'controls_overrides'
srv/salt/_modules/iscsi.py: note: In function "validate":
srv/salt/_modules/iscsi.py:426: error: Need type annotation for 'targets_by_disk'
srv/salt/_modules/iscsi.py: note: In function "validate_rados_rw":
srv/salt/_modules/iscsi.py:528: error: Name '__salt__' is not defined
srv/salt/_modules/iscsi.py: note: In function "is_pkg_installed":
srv/salt/_modules/iscsi.py:541: error: Name '__salt__' is not defined
srv/salt/_modules/iscsi.py:545: error: Name '__context__' is not defined
srv/salt/_modules/iscsi.py: note: In function "wait_for_gateway":
srv/salt/_modules/iscsi.py:565: error: Name '__pillar__' is not defined
srv/salt/_modules/iscsi.py:566: error: Name '__pillar__' is not defined
srv/salt/_modules/iscsi.py:567: error: Name '__pillar__' is not defined
srv/salt/_modules/iscsi.py:568: error: Name '__pillar__' is not defined
srv/salt/_modules/iscsi.py:569: error: Name '__salt__' is not defined
srv/salt/_modules/iscsi.py:580: error: Name '__salt__' is not defined
srv/modules/runners/populate.py:59: error: Name 'configparser' already defined (by an import)
srv/modules/runners/populate.py: note: In member "__init__" of class "HardwareProfile":
srv/modules/runners/populate.py:170: error: Need type annotation for 'profiles'
srv/modules/runners/populate.py:171: error: Need type annotation for 'servers'
srv/modules/runners/populate.py:172: error: Need type annotation for 'rotates'
srv/modules/runners/populate.py:173: error: Need type annotation for 'nvme'
srv/modules/runners/populate.py: note: In member "add" of class "HardwareProfile":
srv/modules/runners/populate.py:179: error: Need type annotation for 'model'
srv/modules/runners/populate.py: note: In member "_model_sort" of class "HardwareProfile":
srv/modules/runners/populate.py:262: error: Item "None" of "Optional[Match[Any]]" has no attribute "group"
srv/modules/runners/populate.py:264: error: Item "None" of "Optional[Match[Any]]" has no attribute "group"
srv/modules/runners/populate.py:267: error: Item "None" of "Optional[Match[Any]]" has no attribute "group"
srv/modules/runners/populate.py: note: In member "__init__" of class "CephRoles":
srv/modules/runners/populate.py:285: error: Name '__utils__' is not defined
srv/modules/runners/populate.py: note: In member "_networks" of class "CephRoles":
srv/modules/runners/populate.py:454: error: Need type annotation for 'networks'
srv/modules/runners/populate.py: note: In member "__init__" of class "CephCluster":
srv/modules/runners/populate.py:625: error: Name '__utils__' is not defined
srv/modules/runners/populate.py: note: In function "show":
srv/modules/runners/populate.py:700: error: Name '__utils__' is not defined
srv/modules/runners/populate.py:713: error: Name 'DiskConfiguration' is not defined
srv/modules/runners/populate.py: note: In function "proposals":
srv/modules/runners/populate.py:744: error: Name '__utils__' is not defined
srv/modules/runners/net.py: note: In function "iperf":
srv/modules/runners/net.py:100: error: Need type annotation for 'addresses'
srv/modules/runners/net.py:126: error: Need type annotation for 'public_addresses'
srv/modules/runners/net.py:127: error: Need type annotation for 'cluster_addresses'
srv/modules/runners/net.py:163: error: Name '__utils__' is not defined
srv/modules/runners/net.py:180: error: "List[Any]" has no attribute "values"
srv/modules/runners/net.py: note: In function "_create_client":
srv/modules/runners/net.py:240: error: Need type annotation for 'results'
srv/modules/runners/net.py:277: error: Name '__salt__' is not defined
srv/modules/runners/net.py:283: error: Name '__salt__' is not defined
srv/modules/runners/net.py: note: In function "ping":
srv/modules/runners/net.py:367: error: Need type annotation for 'addresses'
srv/modules/runners/net.py:377: error: Name '__utils__' is not defined
srv/modules/runners/net.py:395: error: "List[Any]" has no attribute "values"
srv/modules/runners/net.py: note: In function "_summarize_iperf":
srv/modules/runners/net.py:569: error: Need type annotation for 'server_results'
srv/modules/runners/net.py:597: error: Incompatible types in assignment (expression has type "float", variable has type "int")
srv/modules/runners/net.py:599: error: Incompatible types in assignment (expression has type "int", target has type "str")
srv/modules/runners/fs.py: note: In function "_analyze_ceph_statedirs":
srv/modules/runners/fs.py:114: error: Need type annotation for 'results'
srv/modules/runners/fs.py: note: In function "_inspect_ceph_statedir":
srv/modules/runners/fs.py:327: error: Name '__utils__' is not defined
srv/modules/runners/benchmark.py: note: In member "_get_job_parameters" of class "Fio":
srv/modules/runners/benchmark.py:131: error: Name 'YAMLError' is not defined
srv/modules/runners/benchmark.py: note: In function "__parse_collection":
srv/modules/runners/benchmark.py:180: error: Name 'YAMLError' is not defined
ERROR: InvocationError for command /home/shyukri/work/suse/DeepSea/.tox/mypy/bin/mypy --config-file mypy.ini srv/modules srv/salt/_modules (exited with code 1)
___________________________________ summary ____________________________________
ERROR:   mypy: commands failed
```
</p>

</details>