### PR TITLE
monitoring: polulate alertmanager peers must run on salt master

### DIFF
--- a/srv/salt/ceph/stage/deploy/monitoring.sls
+++ b/srv/salt/ceph/stage/deploy/monitoring.sls
@@ -10,7 +10,7 @@ populate scrape configs:
 
 populate alertmanager peers:
   salt.state:
-    - tgt: 'I@roles:prometheus and I@cluster:ceph'
+    - tgt: {{ master }}
     - tgt_type: compound
     - sls: ceph.monitoring.alertmanager.populate_peers
 


### PR DESCRIPTION
Fixes: bsc#1137400

Signed-off-by: Jan Fajerski <jfajerski@suse.com>
