### PR TITLE
 cephprocesses: do not exit on missing pillar struct 

### DIFF
--- a/srv/salt/_modules/cephprocesses.py
+++ b/srv/salt/_modules/cephprocesses.py
@@ -344,8 +344,7 @@ def check(results=False, **kwargs):
     res = MetaCheck(**kwargs)
 
     if 'roles' not in __pillar__:
-        log.error("Did not find _roles_ in pillar. Aborting")
-        return False
+        return {'up': {}, 'down': {}} if results else True
     for role in kwargs.get('roles', __pillar__['roles']):
         for running_proc in psutil.process_iter():
             res.add(ProcInfo(running_proc), role)

--- a/tests/unit/_modules/test_cephprocesses.py
+++ b/tests/unit/_modules/test_cephprocesses.py
@@ -403,20 +403,20 @@ class TestInstanceMethods():
 
     def test_check(self):
         """
-        Exit if there is no pillar data
+        Pass if there is no pillar data
         """
         cephprocesses.__pillar__ = {}
-        assert cephprocesses.check() == False
+        assert cephprocesses.check() == True
 
     @mock.patch('srv.salt._modules.cephprocesses.psutil')
     @mock.patch('srv.salt._modules.cephprocesses.MetaCheck')
     @mock.patch('srv.salt._modules.cephprocesses.ProcInfo')
     def test_check_1(self, proc_mock, meta_mock, psutil_mock):
         """
-        Exit if there is pillar data but no roles in it
+        Pass if there is pillar data but no roles in it
         """
         cephprocesses.__pillar__ = {'NOroles': ['dummy']}
-        assert cephprocesses.check() == False
+        assert cephprocesses.check() == True
 
     @pytest.mark.parametrize("test_input,expected", [
         ("mgr", 'mgr'),


### PR DESCRIPTION
bsc#1136818

do not exit if there is a missing pillar struct. This is the case in a new node addition

-----------------

**Checklist:**
- [x] Added unittests and or functional tests
~- [ ] Adapted documentation~
- [x] Referenced issues or internal bugtracker
- [x] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
