### PR TITLE
rescind/ntp: remove the correct RPM

### DIFF
--- a/srv/salt/ceph/rescind/time/ntp/default.sls
+++ b/srv/salt/ceph/rescind/time/ntp/default.sls
@@ -9,9 +9,9 @@ stop ntpd:
     - enable: False
     - fire_event: True
 
-uninstall ntpd:
+uninstall ntp:
   pkg.removed:
-    - name: ntpd
+    - name: ntp
 {% endif %}
 
 prevent empty ntp:


### PR DESCRIPTION
On SUSE distros, at least, the correct package name is "ntp",
not "ntpd".

Signed-off-by: Nathan Cutler <ncutler@suse.com>
