### PR TITLE
apparmor: ignore aa-disabled return code

### DIFF
--- a/srv/salt/ceph/apparmor/default-disable.sls
+++ b/srv/salt/ceph/apparmor/default-disable.sls
@@ -3,17 +3,17 @@ include:
   - .install
   - .profiles
 
-aa-disable /etc/apparmor.d/usr.bin.ceph-mds:
+"aa-disable /etc/apparmor.d/usr.bin.ceph-mds || true":
   cmd.run
 
-aa-disable /etc/apparmor.d/usr.bin.ceph-mgr:
+"aa-disable /etc/apparmor.d/usr.bin.ceph-mgr || true":
   cmd.run
 
-aa-disable /etc/apparmor.d/usr.bin.ceph-mon:
+"aa-disable /etc/apparmor.d/usr.bin.ceph-mon || true":
   cmd.run
 
-aa-disable /etc/apparmor.d/usr.bin.ceph-osd:
+"aa-disable /etc/apparmor.d/usr.bin.ceph-osd || true":
   cmd.run
 
-aa-disable /etc/apparmor.d/usr.bin.radosgw:
+"aa-disable /etc/apparmor.d/usr.bin.radosgw || true":
   cmd.run


### PR DESCRIPTION
The reasoning behind this is that aa-disable fails if the profiles in
question was not in either complain or enforce mode before. For thsi
state it doesn't matter if its disabled or never was enabled.

Fixes: bsc#1130930

Signed-off-by: Jan Fajerski <jfajerski@suse.com>

Not 100% if this might not mask other failure modes of aa-disable, just couldn't think of any.