### PR TITLE
SES5: fix mds numerical names

### DIFF
--- a/srv/salt/_modules/mds.py
+++ b/srv/salt/_modules/mds.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+
+"""
+This module adds some MDS specific functions. Determining the name is its
+original use.
+"""
+
+import logging
+# pylint: disable=incompatible-py3-code
+log = logging.getLogger(__name__)
+
+
+def get_name(host):
+    """
+    In most cases we use the hostname of the machine as the MDS name. However
+    MDS names must not start with a digit, so filter those out and prefix them
+    with "mds.".
+    """
+    if host[0].isdigit():
+        return 'mds.{}'.format(host)
+    else:
+        return host

--- a/srv/salt/ceph/mds/auth/default.sls
+++ b/srv/salt/ceph/mds/auth/default.sls
@@ -4,8 +4,9 @@ prevent empty rendering:
     - name: skip
 
 {% for host in salt.saltutil.runner('select.minions', cluster='ceph', roles='mds', host=True) %}
-{% set client = "mds." + host %}
-{% set keyring_file = salt['keyring.file']('mds', host)  %}
+{% set name = salt['mds.get_name'](host) %}
+{% set client = "mds." + name %}
+{% set keyring_file = salt['keyring.file']('mds', name)  %}
 
 auth {{ keyring_file }}:
   cmd.run:

--- a/srv/salt/ceph/mds/default.sls
+++ b/srv/salt/ceph/mds/default.sls
@@ -2,9 +2,10 @@
 include:
   - .keyring
 
+{% set name = salt['mds.get_name'](grains['host']) %}
 start mds:
   service.running:
-    - name: ceph-mds@{{ grains['host'] }}
+    - name: ceph-mds@{{ name }}
     - enable: True
  
 

--- a/srv/salt/ceph/mds/key/default.sls
+++ b/srv/salt/ceph/mds/key/default.sls
@@ -9,8 +9,7 @@ prevent empty rendering:
 {% set keyring_file = salt['keyring.file']('mds', name)  %}
 {{ keyring_file}}:
   file.managed:
-    - source: 
-      - salt://ceph/mds/files/keyring.j2
+    - source: salt://ceph/mds/files/keyring.j2
     - template: jinja
     - user: salt
     - group: salt

--- a/srv/salt/ceph/mds/key/default.sls
+++ b/srv/salt/ceph/mds/key/default.sls
@@ -4,8 +4,9 @@ prevent empty rendering:
     - name: skip
 
 {% for host in salt.saltutil.runner('select.minions', cluster='ceph', roles='mds', host=True) %}
-{% set client = "mds." + host %}
-{% set keyring_file = salt['keyring.file']('mds', host)  %}
+{% set name = salt['mds.get_name'](host) %}
+{% set client = "mds." + name %}
+{% set keyring_file = salt['keyring.file']('mds', name)  %}
 {{ keyring_file}}:
   file.managed:
     - source: 

--- a/srv/salt/ceph/mds/keyring/default.sls
+++ b/srv/salt/ceph/mds/keyring/default.sls
@@ -3,8 +3,7 @@
 {% set name = salt['mds.get_name'](grains['host']) %}
 /var/lib/ceph/mds/ceph-{{ name }}/keyring:
   file.managed:
-    - source:
-      - salt://ceph/mds/cache/{{ name }}.keyring
+    - source: salt://ceph/mds/cache/{{ name }}.keyring
     - template: jinja
     - user: ceph
     - group: ceph

--- a/srv/salt/ceph/mds/keyring/default.sls
+++ b/srv/salt/ceph/mds/keyring/default.sls
@@ -1,9 +1,10 @@
 
 
-/var/lib/ceph/mds/ceph-{{ grains['host'] }}/keyring:
+{% set name = salt['mds.get_name'](grains['host']) %}
+/var/lib/ceph/mds/ceph-{{ name }}/keyring:
   file.managed:
     - source:
-      - salt://ceph/mds/cache/{{ grains['host'] }}.keyring
+      - salt://ceph/mds/cache/{{ name }}.keyring
     - template: jinja
     - user: ceph
     - group: ceph

--- a/srv/salt/ceph/mds/migrate-numerical-names.sls
+++ b/srv/salt/ceph/mds/migrate-numerical-names.sls
@@ -1,0 +1,55 @@
+{% set master = salt['pillar.get']('master_minion) %}
+
+{% if salt.saltutil.runner('select.minions', cluster='ceph', roles='mds') %}
+
+{% if salt['saltutil.runner']('validate.discovery', cluster='ceph') == False %}
+
+validate failed:
+  salt.state:
+    - name: just.exit
+    - tgt: {{ master }}
+    - failhard: True
+
+{% endif %}
+
+refresh_pillar1:
+  salt.state:
+    - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
+    - tgt_type: compound
+    - sls: ceph.refresh
+
+create renamed mds keys:
+  salt.state:
+    - tgt: {{ master }}
+    - tgt_type: compound
+    - sls: ceph.mds.key
+    - failhard: True
+
+push mds keys:
+  salt.state:
+    - tgt: {{ master }}
+    - tgt_type: compound
+    - sls: ceph.mds.key
+    - failhard: True
+
+auth new keys:
+  salt.state:
+    - tgt: {{ master }}
+    - sls: ceph.mds.auth
+    - failhard: True
+
+deploy renamed mds:
+  salt.state:
+    - tgt: "I@roles:mds and I@cluster:ceph"
+    - tgt_type: compound
+    - sls: ceph.mds
+    - failhard: True
+
+remove old mds:
+  salt.state:
+    - tgt: "I@roles:mds and I@cluster:ceph"
+    - tgt_type: compound
+    - sls: ceph.mds.remove-mds-with-numeric-names
+
+{% endif %}
+

--- a/srv/salt/ceph/mds/remove-mds-with-numeric-names.sls
+++ b/srv/salt/ceph/mds/remove-mds-with-numeric-names.sls
@@ -1,0 +1,14 @@
+mds nop:
+  test.nop
+
+{% set name = grains['host'] %}
+{% if name != salt['mds.get_name'](name) %}
+stop mds {{ name }}:
+  service.dead:
+    - name: ceph-mds@{{ name }}
+    - enable: False
+
+/var/lib/ceph/mds/ceph-{{ name }}/keyring:
+  file.absent
+{% endif %}
+

--- a/srv/salt/ceph/mds/restart/controlled/default-shared.sls
+++ b/srv/salt/ceph/mds/restart/controlled/default-shared.sls
@@ -1,9 +1,10 @@
 {% if salt['cephprocesses.need_restart'](role='mds') == True %}
+{% set name = salt['mds.get_name'](grains['host']) %}
 
 restart:
   cmd.run:
-    - name: "systemctl restart ceph-mds@{{ grains['host'] }}.service"
-    - unless: "systemctl is-failed ceph-mds@{{ grains['host'] }}.service"
+    - name: "systemctl restart ceph-mds@{{ name }}.service"
+    - unless: "systemctl is-failed ceph-mds@{{ name }}.service"
     - fire_event: True
 
  unset mds restart grain:

--- a/srv/salt/ceph/mds/restart/controlled/default.sls
+++ b/srv/salt/ceph/mds/restart/controlled/default.sls
@@ -1,9 +1,10 @@
 {% if salt['cephprocesses.need_restart'](role='mds') == True %}
+{% set name = salt['mds.get_name'](grains['host']) %}
 
 restart:
   cmd.run:
-    - name: "systemctl restart ceph-mds@{{ grains['host'] }}.service"
-    - unless: "systemctl is-failed ceph-mds@{{ grains['host'] }}.service"
+    - name: "systemctl restart ceph-mds@{{ name }}.service"
+    - unless: "systemctl is-failed ceph-mds@{{ name }}.service"
     - fire_event: True
 
 unset mds restart grain:

--- a/srv/salt/ceph/mds/restart/force/default.sls
+++ b/srv/salt/ceph/mds/restart/force/default.sls
@@ -1,5 +1,6 @@
+{% set name = salt['mds.get_name'](grains['host']) %}
 restart:
   cmd.run:
-    - name: "systemctl restart ceph-mds@{{ grains['host'] }}.service"
-    - unless: "systemctl is-failed ceph-mds@{{ grains['host'] }}.service"
+    - name: "systemctl restart ceph-mds@{{ name }}.service"
+    - unless: "systemctl is-failed ceph-mds@{{ name }}.service"
     - fire_event: True

--- a/srv/salt/ceph/mds/shutdown.sls
+++ b/srv/salt/ceph/mds/shutdown.sls
@@ -1,3 +1,4 @@
+{% set name = salt['mds.get_name'](grains['host']) %}
 shutdown daemon:
   service.dead:
-    - name: ceph-mds@{{ grains['host'] }}
+    - name: ceph-mds@{{ name }}

--- a/srv/salt/ceph/rescind/mds/default.sls
+++ b/srv/salt/ceph/rescind/mds/default.sls
@@ -3,9 +3,10 @@ mds nop:
   test.nop
 
 {% if 'mds' not in salt['pillar.get']('roles') %}
-stop mds {{ grains['host'] }}:
+{% set name = salt['mds.get_name'](grains['host']) %}
+stop mds {{ name }}:
   service.dead:
-    - name: ceph-mds@{{ grains['host'] }}
+    - name: ceph-mds@{{ name }}
     - enable: False
 
 stop mds:

--- a/srv/salt/ceph/rescind/mds/keyring/default.sls
+++ b/srv/salt/ceph/rescind/mds/keyring/default.sls
@@ -1,5 +1,6 @@
 
-/var/lib/ceph/mds/ceph-{{ grains['host'] }}/keyring:
+{% set name = salt['mds.get_name'](grains['host']) %}
+/var/lib/ceph/mds/ceph-{{ name }}/keyring:
   file.absent
 
 /var/lib/ceph/mds/ceph-mds/keyring:

--- a/tests/unit/_modules/test_mds.py
+++ b/tests/unit/_modules/test_mds.py
@@ -1,0 +1,18 @@
+import pytest
+from srv.salt._modules import mds
+
+
+@pytest.mark.parametrize(
+    'hostname, mds_name',
+    [
+        ('my_hostname', 'my_hostname'),
+        ('my_hostname1', 'my_hostname1'),
+        ('2my_hostname', 'mds.2my_hostname'),
+        ('666', 'mds.666'),
+    ])
+def test_get_name(hostname, mds_name):
+    res = mds.get_name(hostname)
+    err_report = 'get_name returned wrong mds name: {} vs {}'.format(res,
+                                                                     mds_name)
+    assert res == mds_name, err_report
+


### PR DESCRIPTION
This fixes the mds names for new deployments. daemon names that would start with a digit (i.e. when a hostname starts with a digit) get a `mds.` prefix.
This also adds an orchestration to migrate from the invalid names to the new naming scheme. Starting the migration with no invalid names present should not change anything, i.e. be safe to run at any time with an mds cluster present.