### PR TITLE
mds: numerical mds names are forbidden (have been deprecated since 2014)

### DIFF
--- a/srv/salt/_modules/cephprocesses.py
+++ b/srv/salt/_modules/cephprocesses.py
@@ -101,8 +101,11 @@ class SystemdUnit(object):
         service_names = []
         if self.osd_id and self.proc_name == 'ceph-osd':
             service_names = ["{}@{}".format(self.proc_name, self.osd_id)]
-        if self.proc_name in ['ceph-mon', 'ceph-mgr', 'ceph-mds']:
+        if self.proc_name in ['ceph-mon', 'ceph-mgr']:
             service_names = ["{}@{}".format(self.proc_name, __grains__['host'])]
+        if self.proc_name == 'ceph-mds':
+            service_names = ["{}@{}".format(self.proc_name,
+                                            __salt__['mds.get_name'](__grains__['host']))]
         if self.proc_name == 'radosgw':
             service_names = ["{}@{}".format('ceph-radosgw', __grains__['host'])]
         if self.proc_name == 'ganesha.nfsd':

--- a/srv/salt/_modules/mds.py
+++ b/srv/salt/_modules/mds.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+
+"""
+This module adds some MDS specific functions. Determining the name is its
+original use.
+"""
+
+from __future__ import absolute_import
+import logging
+# pylint: disable=incompatible-py3-code
+log = logging.getLogger(__name__)
+
+
+def get_name(host):
+    """
+    In most cases we use the hostname of the machine as the MDS name. However
+    MDS names must not start with a digit, so filter those out and prefix them
+    with "mds.".
+    """
+    if host[0].isdigit():
+        return 'mds.{}'.format(host)
+    return host

--- a/srv/salt/ceph/mds/auth/default.sls
+++ b/srv/salt/ceph/mds/auth/default.sls
@@ -4,8 +4,9 @@ prevent empty rendering:
     - name: skip
 
 {% for host in salt.saltutil.runner('select.minions', cluster='ceph', roles='mds', host=True) %}
-{% set client = "mds." + host %}
-{% set keyring_file = salt['keyring.file']('mds', host)  %}
+{% set name = salt['mds.get_name'](host) %}
+{% set client = "mds." + name %}
+{% set keyring_file = salt['keyring.file']('mds', name)  %}
 
 auth {{ keyring_file }}:
   cmd.run:

--- a/srv/salt/ceph/mds/default.sls
+++ b/srv/salt/ceph/mds/default.sls
@@ -2,9 +2,10 @@
 include:
   - .keyring
 
+{% set name = salt['mds.get_name'](grains['host']) %}
 start mds:
   service.running:
-    - name: ceph-mds@{{ grains['host'] }}
+    - name: ceph-mds@{{ name }}
     - enable: True
  
 

--- a/srv/salt/ceph/mds/key/default.sls
+++ b/srv/salt/ceph/mds/key/default.sls
@@ -3,12 +3,12 @@ prevent empty rendering:
     - name: skip
 
 {% for host in salt.saltutil.runner('select.minions', cluster='ceph', roles='mds', host=True) %}
-{% set client = "mds." + host %}
-{% set keyring_file = salt['keyring.file']('mds', host)  %}
+{% set name = salt['mds.get_name'](host) %}
+{% set client = "mds." + name %}
+{% set keyring_file = salt['keyring.file']('mds', name)  %}
 {{ keyring_file}}:
   file.managed:
-    - source:
-      - salt://ceph/mds/files/keyring.j2
+    - source: salt://ceph/mds/files/keyring.j2
     - template: jinja
     - user: {{ salt['deepsea.user']() }}
     - group: {{ salt['deepsea.group']() }}

--- a/srv/salt/ceph/mds/keyring/default.sls
+++ b/srv/salt/ceph/mds/keyring/default.sls
@@ -1,9 +1,9 @@
 
 
-/var/lib/ceph/mds/ceph-{{ grains['host'] }}/keyring:
+{% set name = salt['mds.get_name'](grains['host']) %}
+/var/lib/ceph/mds/ceph-{{ name }}/keyring:
   file.managed:
-    - source:
-      - salt://ceph/mds/cache/{{ grains['host'] }}.keyring
+    - source: salt://ceph/mds/cache/{{ name }}.keyring
     - template: jinja
     - user: ceph
     - group: ceph

--- a/srv/salt/ceph/mds/restart/controlled/default-shared.sls
+++ b/srv/salt/ceph/mds/restart/controlled/default-shared.sls
@@ -1,9 +1,10 @@
 {% if salt['cephprocesses.need_restart'](role='mds') == True %}
+{% set name = salt['mds.get_name'](grains['host']) %}
 
 restart:
   cmd.run:
-    - name: "systemctl restart ceph-mds@{{ grains['host'] }}.service"
-    - unless: "systemctl is-failed ceph-mds@{{ grains['host'] }}.service"
+    - name: "systemctl restart ceph-mds@{{ name }}.service"
+    - unless: "systemctl is-failed ceph-mds@{{ name }}.service"
     - fire_event: True
 
  unset mds restart grain:

--- a/srv/salt/ceph/mds/restart/controlled/default.sls
+++ b/srv/salt/ceph/mds/restart/controlled/default.sls
@@ -1,9 +1,10 @@
 {% if salt['cephprocesses.need_restart'](role='mds') == True %}
+{% set name = salt['mds.get_name'](grains['host']) %}
 
 restart:
   cmd.run:
-    - name: "systemctl restart ceph-mds@{{ grains['host'] }}.service"
-    - unless: "systemctl is-failed ceph-mds@{{ grains['host'] }}.service"
+    - name: "systemctl restart ceph-mds@{{ name }}.service"
+    - unless: "systemctl is-failed ceph-mds@{{ name }}.service"
     - fire_event: True
 
 unset mds restart grain:

--- a/srv/salt/ceph/mds/restart/force/default.sls
+++ b/srv/salt/ceph/mds/restart/force/default.sls
@@ -1,5 +1,6 @@
+{% set name = salt['mds.get_name'](grains['host']) %}
 restart:
   cmd.run:
-    - name: "systemctl restart ceph-mds@{{ grains['host'] }}.service"
-    - unless: "systemctl is-failed ceph-mds@{{ grains['host'] }}.service"
+    - name: "systemctl restart ceph-mds@{{ name }}.service"
+    - unless: "systemctl is-failed ceph-mds@{{ name }}.service"
     - fire_event: True

--- a/srv/salt/ceph/mds/shutdown.sls
+++ b/srv/salt/ceph/mds/shutdown.sls
@@ -1,3 +1,5 @@
+{% set name = salt['mds.get_name'](grains['host']) %}
+
 shutdown daemon:
   service.dead:
-    - name: ceph-mds@{{ grains['host'] }}
+    - name: ceph-mds@{{ name }}

--- a/srv/salt/ceph/rescind/mds/default.sls
+++ b/srv/salt/ceph/rescind/mds/default.sls
@@ -3,9 +3,10 @@ mds nop:
   test.nop
 
 {% if 'mds' not in salt['pillar.get']('roles') %}
-stop mds {{ grains['host'] }}:
+{% set name = salt['mds.get_name'](grains['host']) %}
+stop mds {{ name }}:
   service.dead:
-    - name: ceph-mds@{{ grains['host'] }}
+    - name: ceph-mds@{{ name }}
     - enable: False
 
 stop mds:

--- a/srv/salt/ceph/rescind/mds/keyring/default.sls
+++ b/srv/salt/ceph/rescind/mds/keyring/default.sls
@@ -1,5 +1,6 @@
 
-/var/lib/ceph/mds/ceph-{{ grains['host'] }}/keyring:
+{% set name = salt['mds.get_name'](grains['host']) %}
+/var/lib/ceph/mds/ceph-{{ name }}/keyring:
   file.absent
 
 /var/lib/ceph/mds/ceph-mds/keyring:

--- a/tests/unit/_modules/test_mds.py
+++ b/tests/unit/_modules/test_mds.py
@@ -1,0 +1,18 @@
+import pytest
+from srv.salt._modules import mds
+
+
+@pytest.mark.parametrize(
+    'hostname, mds_name',
+    [
+        ('my_hostname', 'my_hostname'),
+        ('my_hostname1', 'my_hostname1'),
+        ('2my_hostname', 'mds.2my_hostname'),
+        ('666', 'mds.666'),
+    ])
+def test_get_name(hostname, mds_name):
+    res = mds.get_name(hostname)
+    err_report = 'get_name returned wrong mds name: {} vs {}'.format(res,
+                                                                     mds_name)
+    assert res == mds_name, err_report
+


### PR DESCRIPTION
This adds a "mds." prefix the the daemon name in case a mds hostname starts
with a digit.

Fixes: bsc#1138442

Signed-off-by: Jan Fajerski <jfajerski@suse.com>

This fixes the mds names for new deployments. daemon names that would start with a digit (i.e. when a hostname starts with a digit) get a `mds.` prefix.