### PR TITLE
fix(makefile): remove hardcoded user:group

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -266,7 +266,7 @@ copy-files:
 	install -m 644 srv/salt/ceph/configuration/files/ceph.conf.import $(DESTDIR)/srv/salt/ceph/configuration/files/
 	install -m 644 srv/salt/ceph/configuration/files/drive_groups.yml $(DESTDIR)/srv/salt/ceph/configuration/files/
 	install -m 644 srv/salt/ceph/configuration/files/deprecated_map.yml $(DESTDIR)/srv/salt/ceph/configuration/files/
-	-chown salt:salt $(DESTDIR)/srv/salt/ceph/configuration/files/ceph.conf.import || true
+	-chown $(USER):$(GROUP) $(DESTDIR)/srv/salt/ceph/configuration/files/ceph.conf.import || true
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/configuration/files/ceph.conf.d
 	install -m 644 srv/salt/ceph/configuration/files/ceph.conf.d/README $(DESTDIR)/srv/salt/ceph/configuration/files/ceph.conf.d
 	# state files - ganesha
@@ -946,7 +946,7 @@ copy-files:
 	install -d -m 700 $(DESTDIR)/srv/salt/ceph/osd/cache
 	install -d -m 700 $(DESTDIR)/srv/salt/ceph/rgw/cache
 	install -d -m 700 $(DESTDIR)/srv/salt/ceph/configuration/files/ceph.conf.checksum
-	# At runtime, these need to be owned by salt:salt.  This won't work
+	# At runtime, these need to be owned by $(USER):$(GROUP).  This won't work
 	# in a buildroot on OBS, hence the leading '-' to ignore failures
 	# and '|| true' to suppress some error output, but will work fine
 	# in development when root runs `make install`.


### PR DESCRIPTION
Fixes #


Description:

This PR changes hardcoded `salt:salt` string to dynamic variable.


-----------------

**Checklist:**
- [ n ] Added unittests and or functional tests
- [  n ] Adapted documentation
- [ n ] Referenced issues or internal bugtracker
- [ y ] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
