### PR TITLE
fix(makefile): update for centos/python3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,8 +23,7 @@ USER=root
 GROUP=root
 ifeq ($(OS), centos)
 PKG_INSTALL=yum install -y
-PYTHON_DEPS=python-setuptools python-click python-tox python-configobj
-PYTHON=python
+PYTHON_DEPS=rh-python36-setuptools python36-click tox python36-configobj
 else
 ifeq ($(OS), fedora)
 PKG_INSTALL=yum install -y


### PR DESCRIPTION
Fixes #

Update Makefile to use python3 on Centos

Description:


-----------------

**Checklist:**
- [ n ] Added unittests and or functional tests
- [ n ] Adapted documentation
- [ n ] Referenced issues or internal bugtracker
- [ y ] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
