### PR TITLE
dg: workaround ceph-volume infused bugs 

### DIFF
--- a/srv/salt/_modules/dg.py
+++ b/srv/salt/_modules/dg.py
@@ -36,6 +36,11 @@ deploy:
 A simple function that calls c_v_commands and executes it on the minion.
 
 
+To call from the commandline:
+
+`salt-call dg.<func> 'filter_args={'key': 'value'}'`
+
+
 """
 
 
@@ -152,18 +157,36 @@ class Inventory():
         return '{}'
 
     @property
-    def disks(self) -> list:
+    def _disks(self) -> list:
         """ All disks found on the 'target'
 
         Loads the json data from ceph-volume inventory
         """
         log.debug('Loading disks from inventory')
-        disks = _parse_dirty_json(self.raw)
-        filtered_disks = [
+        return _parse_dirty_json(self.raw)
+
+    @property
+    def disks(self):
+        """ apply filter before returning
+        Those filters are needed for various reasons
+        Explanations in comments
+        """
+        # Disks smaller than 5GB are problematic for ceph-volume
+        # todo: http://tracker.ceph.com/issues/40776
+        disks = self._disks
+
+        filtered_for_size = [
             disk for disk in disks
             if disk.get('sys_api', dict()).get('size', 0) > 5368709120
         ]
-        return filtered_disks
+        filtered_for_path = [
+            # ceph-volume inventory reads /dev/mapper (crypt devices) as valid and available devices
+            # this creates a nice little loop and needs to be excluded
+            # todo: http://tracker.ceph.com/issues/40799
+            disk for disk in filtered_for_size
+            if not disk.get('path', '').startswith('/dev/mapper')
+        ]
+        return filtered_for_path
 
 
 # pylint: disable=too-few-public-methods

--- a/srv/salt/_modules/dg.py
+++ b/srv/salt/_modules/dg.py
@@ -158,7 +158,12 @@ class Inventory():
         Loads the json data from ceph-volume inventory
         """
         log.debug('Loading disks from inventory')
-        return _parse_dirty_json(self.raw)
+        disks = _parse_dirty_json(self.raw)
+        filtered_disks = [
+            disk for disk in disks
+            if disk.get('sys_api', dict()).get('size', 0) > 5368709120
+        ]
+        return filtered_disks
 
 
 # pylint: disable=too-few-public-methods
@@ -548,6 +553,7 @@ class DriveGroup(object):
     # pylint: disable=too-many-instance-attributes
     def __init__(self, filter_args: dict, include_unavailable=False) -> None:
         self.filter_args: dict = filter_args
+        log.debug("Initializing DriveGroups with {}".format(self.filter_args))
         self._check_filter_support()
         self._include_unavailable = include_unavailable
         self._data_devices = None

--- a/tests/unit/_modules/test_dg.py
+++ b/tests/unit/_modules/test_dg.py
@@ -180,8 +180,7 @@ class TestMatcher(object):
         """
         virtual_mock.return_value = False
         disk_map = dict(path='/dev/vdb')
-        with pytest.raises(
-                Exception):
+        with pytest.raises(Exception):
             dg.Matcher('bar', 'foo')._get_disk_key(disk_map)
             pytest.fail("No disk_key found for foo or None")
 
@@ -387,6 +386,23 @@ class TestSizeMatcher(object):
         ret = matcher.compare(disk_dict)
         assert ret is expected
 
+    @pytest.mark.parametrize("test_input,expected", [
+        ("1.00 GB", False),
+        ("20.00 GB", False),
+        ("50.00 GB", False),
+        ("100.00 GB", False),
+        ("101.00 GB", False),
+        ("1101.00 GB", True),
+        ("9.10 TB", True),
+    ])
+    @patch("srv.salt._modules.dg.Matcher._virtual", autospec=True)
+    def test_compare_at_least_1TB(self, virtual_mock, test_input, expected):
+        virtual_mock.return_value = False
+        matcher = dg.SizeMatcher('size', '1TB:')
+        disk_dict = dict(path='/dev/sdz', size=test_input)
+        ret = matcher.compare(disk_dict)
+        assert ret is expected
+
     @patch("srv.salt._modules.dg.Matcher._virtual", autospec=True)
     def test_compare_raise(self, virtual_mock):
         virtual_mock.return_value = False
@@ -436,8 +452,7 @@ class TestSizeMatcher(object):
     @patch("srv.salt._modules.dg.Matcher._virtual", autospec=True)
     def test_normalize_suffix_raises(self, virtual_mock):
         virtual_mock.return_value = False
-        with pytest.raises(
-                dg.UnitNotSupported):
+        with pytest.raises(dg.UnitNotSupported):
             dg.SizeMatcher('10P', 'size')._normalize_suffix("P")
             pytest.fail("Unit 'P' not supported")
 
@@ -654,20 +669,25 @@ class TestDriveGroup(object):
         def make_sample_data(available=available,
                              data_devices=10,
                              wal_devices=0,
-                             db_devices=2):
+                             db_devices=2,
+                             human_readable_size_data='50.00 GB',
+                             human_readable_size_wal='20.00 GB',
+                             human_readable_size_db='20.00 GB'):
             factory = InventoryFactory()
             inventory_sample = []
             data_disks = factory.produce(
-                pieces=data_devices, available=available)
+                pieces=data_devices,
+                available=available,
+                human_readable_size=human_readable_size_data)
             wal_disks = factory.produce(
                 pieces=wal_devices,
-                human_readable_size='20.00 GB',
+                human_readable_size=human_readable_size_wal,
                 rotational='0',
                 model='ssd_type_model',
                 available=available)
             db_disks = factory.produce(
                 pieces=db_devices,
-                human_readable_size='20.00 GB',
+                human_readable_size=human_readable_size_db,
                 rotational='0',
                 model='ssd_type_model',
                 available=available)
@@ -868,8 +888,7 @@ class TestDriveGroup(object):
 
     def test_check_filter_raise(self, test_fix):
         test_fix = test_fix()
-        with pytest.raises(
-                dg.FilterNotSupported):
+        with pytest.raises(dg.FilterNotSupported):
             test_fix._check_filter(dict(unknown='foo'))
             pytest.fail("Filter unknown is not supported")
 
@@ -960,6 +979,22 @@ class TestDriveGroup(object):
         assert [
             'ceph-volume lvm batch --no-auto /dev/vdb /dev/vdd /dev/vdf /dev/vdh /dev/vdj --db-devices /dev/vdo --wal-devices /dev/vdl /dev/vdn --yes',
             'ceph-volume lvm batch --no-auto /dev/vdc /dev/vde /dev/vdg /dev/vdi /dev/vdk --db-devices /dev/vdp --wal-devices /dev/vdm --yes'
+        ] == ret
+
+    def test_c_v_commands_10TB_size_match(self, test_fix, inventory):
+        inventory(
+            data_devices=3,
+            human_readable_size_data='9.10 TB',
+            wal_devices=0,
+            db_devices=0)
+        ret = dg.c_v_commands(filter_args={
+            'data_devices': {
+                'size': '1TB:'
+            },
+            'encryption': 'true'
+        })
+        assert [
+            'ceph-volume lvm batch --no-auto /dev/vdb /dev/vdc /dev/vdd --yes --dmcrypt',
         ] == ret
 
     def test_c_v_commands_11_data_external_3_dbs_and_1_wals(


### PR DESCRIPTION
Add workarounds for:

1) Do not accept disks < 5GB
2) Do not accept /dev/mapper disks (this needs more thinking as you actually may want to deploy /dev/mapper devices)

Tests for various cases added.

The workarounds need to be adapted with the addition of #1690. With this PR we source the `disks list` from the ceph_volume library and not from the CLI. Also, we moved the logic in `cephdisks.py`.

suse_internal: bsc#1141368, bsc#1141367, bsc#1141503

-----------------

**Checklist:**
- [x] Added unittests and or functional tests
~- [ ] Adapted documentation~
- [x] Referenced issues or internal bugtracker
- [ ] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
