### PR TITLE
makefile: update for ubuntu/python 3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,7 @@ else
 debian := $(wildcard /etc/debian_version)
 ifneq ($(strip $(debian)),)
 PKG_INSTALL=apt-get install -y
+PYTHON_DEPS=python3-setuptools python3-click tox python3-configobj
 endif
 endif
 endif


### PR DESCRIPTION
Helps # https://github.com/SUSE/DeepSea/issues/57. Supercedes #1697 

Description:

This PR fixes `make install` on Ubuntu (Debian) with python3.

-----------------

**Checklist:**
- [ n ] Added unittests and or functional tests
- [ n ] Adapted documentation
- [ n ] Referenced issues or internal bugtracker
- [ y ] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
