### PR TITLE
The disk_led runner crashes (bsc#1142821)

### DIFF
--- a/tests/unit/runners/test_disk_led.py
+++ b/tests/unit/runners/test_disk_led.py
@@ -52,6 +52,19 @@ class TestDiskLed:
 
     @mock.patch('srv.modules.runners.disk_led._process', autospec=True)
     @mock.patch('salt.client.LocalClient', autospec=True)
+    def test_device_udev_links_none(self, mock_localclient, mock_process):
+        mock_localclient.return_value.cmd.side_effect = [
+            grains_get_result, None
+        ]
+
+        result = disk_led.device('data1.ceph', 'SanDisk_X400_M.2_2280_512GB_26453645624767',
+                                 'ident', 'on')
+        assert not mock_process.called
+        assert result == 'Could not find device "SanDisk_X400_M.2_2280_512GB_26453645624767" '\
+                         'on host "data1.ceph"'
+
+    @mock.patch('srv.modules.runners.disk_led._process', autospec=True)
+    @mock.patch('salt.client.LocalClient', autospec=True)
     def test_device_failure(self, mock_localclient, mock_process):
         mock_localclient.return_value.cmd.return_value = {}
 


### PR DESCRIPTION
* Check the result type of 'udev.links' before iterating.
* Check if the identifier is in 'grains.get disks' before iterating over the device names (including all the other stuff). This will reduce the work to do in some cases.

Signed-off-by: Volker Theile <vtheile@suse.com>

-----------------

**Checklist:**
- [x] Added unittests and or functional tests
- [ ] Adapted documentation
- [x] Referenced issues or internal bugtracker
- [ ] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
