### PR TITLE
remove/replace: add path to status report for better identification

### DIFF
--- a/srv/salt/_modules/cephdisks.py
+++ b/srv/salt/_modules/cephdisks.py
@@ -80,7 +80,7 @@ class Inventory(object):
         """
         assert isinstance(devices, list)
         if not devices:
-            devices = self.devices.devices
+            devices = self.devices
         else:
             devices = [self.device(path) for path in devices]
         osd_ids: list = list()
@@ -199,7 +199,7 @@ class Inventory(object):
         osd_ids. This may also be offloaded to c-v in the future.
         """
         devs = list()
-        for dev in self.devices.devices:
+        for dev in self.devices:
             for _lv in dev.lvs:
                 # each lv can have multiple volumes
                 if not isinstance(_lv, list):


### PR DESCRIPTION
Signed-off-by: Joshua Schmid <jschmid@suse.de>

before:

`salt-run osd.remove(replace) $osd_id`
[..snip..]     
```                                                                                                                                                                                                                                                                                                                                              
14:                                                                                                                                                                                                                                            
    True 
```

after:

```
14:                                                                                                                                                                                      
    ----------                                                                                                                                                                                                                                 
    path:                                                                                                                                                                                                                                      
        /dev/vdb                                                                                                                                                                                                                               
    returncode:                                                                                                                                                                                                                                
        True               
```

suse_internal: bnc#1142663

-----------------

**Checklist:**
~- [ ] Added unittests and or functional tests~
~- [ ] Adapted documentation~
~- [ ] Referenced issues or internal bugtracker~
- [ ] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
