### PR TITLE
conf: rgw: drop rgw dns name configurable

### DIFF
--- a/srv/salt/ceph/configuration/files/rgw-ssl.conf
+++ b/srv/salt/ceph/configuration/files/rgw-ssl.conf
@@ -1,4 +1,3 @@
 [client.{{ client }}]
 rgw frontends = "beast ssl_port={{ pillar.get('rgw_frontend_ssl_port', 443) }} ssl_certificate=/etc/ceph/rgw.pem"
-rgw dns name = {{ fqdn }}
 rgw enable usage log = true

--- a/srv/salt/ceph/configuration/files/rgw.conf
+++ b/srv/salt/ceph/configuration/files/rgw.conf
@@ -1,4 +1,3 @@
 [client.{{ client }}]
 rgw frontends = "beast port={{ pillar.get('rgw_frontend_port', 80) }}"
-rgw dns name = {{ fqdn }}
 rgw enable usage log = true


### PR DESCRIPTION
This is only useful for s3 clients which don't support path style access, and
even in those cases there needs to be an additional dnsmasq setting or the like
that can correctly redirect `<bucketname>.<rgw-endpoint>` to `<rgw-endpoint>`.
For the remainder of use cases; if this is configured incorrectly it always leads
to bugs for all s3 clients and it is hard to get this right, as many rgws may be
terminated with a load balancer in which case we need the endpoint to be that.
So moving forward, we'd make this option manually configurable for those sites
that really need the vhost style access, as this requires some knowledge on the
s3 clients and their site dns setting which is hard to predict correctly anyway

Fixes: #842
Signed-off-by: Abhishek Lekshmanan <abhishek@suse.com>


**Checklist:**
- [ ] Added unittests and or functional tests
- [ ] Adapted documentation
- [ ] Referenced issues or internal bugtracker
- [ ] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
