### PR TITLE
flip logic for /available/ disks filtering

### DIFF
--- a/srv/salt/_modules/cephdisks.py
+++ b/srv/salt/_modules/cephdisks.py
@@ -47,13 +47,13 @@ class Inventory(object):
         self.root_disk = self._find_root_disk()
 
     @property
-    def exclude_available(self) -> bool:
-        """ The available filter """
-        return self.kwargs.get('exclude_available', False)
+    def exclude_unavailable(self) -> bool:
+        """ The unavailable filter """
+        return self.kwargs.get('exclude_unavailable', False)
 
     @property
     def exclude_cephdisk_member(self) -> bool:
-        """ The available filter """
+        """ The cephdisks_member filter """
         return self.kwargs.get('exclude_cephdisk_member', False)
 
     @property
@@ -157,9 +157,9 @@ class Inventory(object):
                     )
                     continue
 
-            if self.exclude_available:
-                # exclude disks that are marked 'available'
-                if dev.available:
+            if self.exclude_unavailable:
+                # exclude disks that are marked not 'available'
+                if not dev.available:
                     log.debug(
                         f"Skipping disk <{dev.path}> due to <available> filter"
                     )
@@ -277,7 +277,7 @@ def unused(**kwargs):
     kwargs.update(
         dict(
             exclude_used_by_ceph=True,
-            exclude_available=False,
+            exclude_unavailable=True,
             exclude_cephdisk_member=True))
     return [x.json_report() for x in Inventory(**kwargs).filter_()]
 

--- a/tests/unit/_modules/test_cephdisks.py
+++ b/tests/unit/_modules/test_cephdisks.py
@@ -27,16 +27,16 @@ def test_fix():
 class TestInventory(object):
     def test_inventory_init_defaults(self, test_fix):
         inv = test_fix()
-        assert inv.exclude_available is False
+        assert inv.exclude_unavailable is False
         assert inv.exclude_used_by_ceph is False
         assert inv.exclude_root_disk is True
 
     def test_inventory_init_kwargs(self, test_fix):
         inv = test_fix(
-            exclude_available=True,
+            exclude_unavailable=True,
             exclude_used_by_ceph=True,
             exclude_root_disk=False)
-        assert inv.exclude_available is True
+        assert inv.exclude_unavailable is True
         assert inv.exclude_used_by_ceph is True
         assert inv.exclude_root_disk is False
         assert inv._min_osd_size == 5368709120.0
@@ -120,8 +120,8 @@ class TestInventory(object):
     def test_filter_available_device_exclusion(self, test_fix):
         """ /dev/sdb is the available_device but we exclude it """
         conf = dict(
-            pieces=1, device_config=dict(path='/dev/sdb', available=True))
-        inv = test_fix(conf, exclude_available=True)
+            pieces=1, device_config=dict(path='/dev/sdb', available=False))
+        inv = test_fix(conf, exclude_unavailable=True)
         ret = inv.filter_()
         assert len(ret) == 0
 


### PR DESCRIPTION
Signed-off-by: Joshua Schmid <jschmid@suse.de>

Fixes #1721

-----------------

**Checklist:**
- [x] Added unittests and or functional tests
~- [ ] Adapted documentation~
- [x] Referenced issues or internal bugtracker
- [ ] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
