### PR TITLE
Added data tag in cephdisks/dg for filestore OSDs

### DIFF
--- a/srv/salt/_modules/cephdisks.py
+++ b/srv/salt/_modules/cephdisks.py
@@ -204,15 +204,17 @@ class Inventory(object):
                 # each lv can have multiple volumes
                 if not isinstance(_lv, list):
                     osd_id = _lv.tags.get('ceph.osd_id', '')
-                    if str(osd_id_search) == str(osd_id) and _lv.tags.get(
-                            'ceph.type') == 'block':
+                    if str(osd_id_search) == str(osd_id) and \
+                            (_lv.tags.get('ceph.type') == 'block' or
+                             _lv.tags.get('ceph.type') == 'data'):
                         devs.append(dev)
                 if isinstance(_lv, list):
                     for _vol in _lv:
                         # search volume's tags for ceph.osd_id
                         osd_id = _vol.tags.get('ceph.osd_id', '')
-                        if str(osd_id_search) == str(osd_id) and _lv.tags.get(
-                                'ceph.type') == 'block':
+                        if str(osd_id_search) == str(osd_id) and \
+                                (_lv.tags.get('ceph.type') == 'block' or
+                                 _lv.tags.get('ceph.type') == 'data'):
                             devs.append(dev)
         return devs
 

--- a/srv/salt/_modules/dg.py
+++ b/srv/salt/_modules/dg.py
@@ -900,7 +900,8 @@ class LvmOSD(object):
         for _vol in self.device.lvs:
             # search lvolume tags for ceph.osd_id
             osd_id: str = _vol.tags.get('ceph.osd_id', '')
-            if osd_id and _vol.tags.get('ceph.type') == 'block':
+            if osd_id and (_vol.tags.get('ceph.type') == 'block'
+                           or _vol.tags.get('ceph.type') == 'data'):
                 osd_ids.append(osd_id)
         return osd_ids
 


### PR DESCRIPTION
Proposed solution for "#Bug 1145600 - Unable to remove/rebuild Filestore OSDs through Deepsea", I also added it on `dg.py` since I saw that it's applied there as well.



Description:
Add the 'ceph.type' tag for filestore OSDs


-----------------

**Checklist:**
- [ ] Added unittests and or functional tests
- [ ] Adapted documentation
- [ ] Referenced issues or internal bugtracker
- [ ] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
