### PR TITLE
Accommodate Salt integration tests

### DIFF
--- a/srv/modules/runners/remove.py
+++ b/srv/modules/runners/remove.py
@@ -26,6 +26,16 @@ def osd(*args, **kwargs):
     Remove an OSD gracefully or forcefully.  Always attempt to remove
     ID from Ceph even if OSD has been removed from the minion.
     """
+    # Specifically for Salt integration testing
+    # The 'arg' keyword is passed as a kwarg to the salt.runner
+    # See delay.sls and multiple.sls for examples
+    if not args:
+        if 'arg' in kwargs and kwargs['arg']:
+            args = kwargs['arg']
+
+    if not args:
+        help()
+        return ""
     kwargs['remove'] = 'remove'
     result = __salt__['replace.osd'](*args, called=True, **kwargs)
 
@@ -35,6 +45,7 @@ def osd(*args, **kwargs):
     master_minion = result['master_minion']
 
     local = salt.client.LocalClient()
+
 
     for osd_id in args:
         # All of these commands return success whether the operation succeeds


### PR DESCRIPTION
I hate changing code to accommodate tests, but I don't see another path
for this one.  The structure of a Salt orchestration file provides `arg`
as a keyword to the runner internally.  Changing from using `osd_list`
to `args` broke the tests, but matches the user requirement.

Signed-off-by: Eric Jackson <swiftgist@gmail.com>

-----------------

**Checklist:**
- [ ] Added unittests and or functional tests
- [ ] Adapted documentation
- [ ] Referenced issues or internal bugtracker
- [x] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
