### PR TITLE
Add 'ext_lib' runners to 'make install'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -186,6 +186,8 @@ copy-files:
 	install -d -m 755 $(DESTDIR)/srv/modules/runners
 	install -m 644 srv/modules/runners/*.py* $(DESTDIR)/srv/modules/runners/
 	sed -i "s/DEVVERSION/"$(VERSION)"/" $(DESTDIR)/srv/modules/runners/deepsea.py
+	install -d -m 755 $(DESTDIR)/srv/modules/runners/ext_lib
+	install -m 644 srv/modules/runners/ext_lib/*.py* $(DESTDIR)/srv/modules/runners/ext_lib
 	# utils
 	install -d -m 755 $(DESTDIR)/srv/modules/utils
 	install -m 644 srv/modules/utils/*.py* $(DESTDIR)/srv/modules/utils


### PR DESCRIPTION
Description:

Makefile does not include 'ext_lib' runners dir.

admin:~/DeepSea # salt-run mon.deploy
'mon' __virtual__ returned False: No module named 'ext_lib'
Exception ignored in: <bound method IPCClient.__del__ of <salt.transport.ipc.IPCMessageClient object at 0x7f6e513360f0>>
Traceback (most recent call last):
  File "/usr/lib/python3.6/site-packages/salt/transport/ipc.py", line 374, in __del__
  File "/usr/lib/python3.6/site-packages/salt/transport/ipc.py", line 405, in close
  File "/usr/lib64/python3.6/logging/__init__.py", line 1296, in debug
  File "/usr/lib/python3.6/site-packages/salt/log/setup.py", line 343, in _log
  File "/usr/lib64/python3.6/logging/__init__.py", line 1443, in _log
  File "/usr/lib/python3.6/site-packages/salt/log/setup.py", line 363, in makeRecord
NameError: name '__salt_system_encoding__' is not defined


-----------------

**Checklist:**
- [ ] Added unittests and or functional tests
- [ ] Adapted documentation
- [ ] Referenced issues or internal bugtracker
- [ ] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
