### PR TITLE
[next] Initial bootstrap code - SES-764

### DIFF
--- a/srv/modules/runners/advise.py
+++ b/srv/modules/runners/advise.py
@@ -88,16 +88,22 @@ def networks():
     Advise the installer the current network settings.
     """
     local = salt.client.LocalClient()
-    public = set(local.cmd('*', 'pillar.get', ['public_network']).values())
-    cluster = set(local.cmd('*', 'pillar.get', ['cluster_network']).values())
+    public = set(local.cmd('I@deepsea_minions:*', 'pillar.get', ['public_network'], tgt_type="compound").values())
+    cluster = set(local.cmd('I@deepsea_minions:*', 'pillar.get', ['cluster_network'], tgt_type="compound").values())
 
-    bold = '\033[1m'
-    endc = '\033[0m'
+    if not public and not cluster:
+        print("Couldn't detect networks. Please verify your network settings.")
+        return False
+    if not public:
+        print("Couldn't detect the public network.")
+        return False
+    if not cluster:
+        print("Couldn't detect the cluster network.")
+        return False
 
-    # pylint: disable=line-too-long
-    print("{:25}: {}{}{}".format('public network', bold, ", ".join([_f for _f in public if _f]), endc))
-    print("{:25}: {}{}{}".format('cluster network', bold, ", ".join([_f for _f in cluster if _f]), endc))
-    return ""
+    print(f"public network: {list(public)[0]}")
+    print(f"cluster network: {list(cluster)[0]}")
+    return True
 
 __func_alias__ = {
                  'help_': 'help',

--- a/srv/modules/runners/bootstrap.py
+++ b/srv/modules/runners/bootstrap.py
@@ -1,13 +1,13 @@
-from ext_lib.utils import runner, prompt
+from ext_lib.utils import runner, prompt, log_n_print
 from ext_lib.hash_dir import pillar_questioneer, module_questioneer
 from pydoc import pager
 from os.path import exists
 from salt.client import LocalClient
-
+import logging
 import signal
 import sys
 
-# We have to take care of the one-time operations that need to be done before a deployment
+log = logging.getLogger(__name__)
 
 
 def handle_ctrl_c(signal, frame):
@@ -16,57 +16,59 @@ def handle_ctrl_c(signal, frame):
 
 
 signal.signal(signal.SIGINT, handle_ctrl_c)
+
 """
-
 TODO: Make the time-server thing separate
-
-* Update the host system
-* Populate the proposals (salt-run populate.proposals)
-* Scan for the networks (maybe ask the user this time?)
 * SSL-certificates
-
-
 """
 
 proposals_dir = '/srv/pillar/ceph/proposals'
 policy_path = f'{proposals_dir}/policy.cfg'
 
 
+# maybe outsource
 def _read_policy_cfg():
     with open(policy_path, 'r') as _fd:
         return _fd.read()
 
 
-def _get_public_address():
-    __salt__['public.address']
+# outsource
+def run_and_eval(runner_name, extra_args=None):
+    # maybe supress the 'True' output from the screen
+    qrunner = runner(__opts__)
+    if not qrunner.cmd(runner_name, extra_args):
+        log_n_print(f"{runner_name} failed.")
+        raise Exception()
 
 
 def ceph(non_interactive=False):
     module_questioneer(non_interactive=non_interactive)
-    print("TODO make sure that podman is installed")
-    print("TODO zypper in -t pattern apparmor")
-    # or add suse-certs repo and install SUSE-CA
-    print(
-        "TODO podman pull registry.suse.de/devel/storage/6.0/images/ses/6/ceph/ceph --tls-verify=false"
+    log_n_print(
+        "TODO: check for deepsea_minions, There is a validate.deepsea_minions, check that"
     )
-    print(
-        "Print a basic help thing explaining the steps and asking for a timeserver"
+    run_and_eval("host.install_common_packages")
+    run_and_eval('host.update', ['parallel=True'])
+
+    log_n_print(
+        "TODO: podman pull registry.suse.de/devel/storage/6.0/images/ses/6/ceph/ceph --tls-verify=false"
     )
-    qrunner = runner(__opts__)
+    log_n_print(
+        "TODO: print a basic help thing explaining the steps and asking for a timeserver"
+    )
     if not exists(proposals_dir):
-        print("Creating proposals directory.")
-        qrunner.cmd('populate.proposals')
+        log_n_print("Creating proposals directory.")
+        run_and_eval('populate.proposals')
     else:
-        print("Found a proposals directory")
+        log.debug("Found a proposals directory")
 
     if not exists(policy_path):
-        print(
+        log_n_print(
             f"You don't appear to have a policy.cfg. Please create it under the proposals directory '{proposals_dir}' and re-run this command"
         )
-        print(f"You can find guidance on how to do that here: TODO")
+        log_n_print(f"You can find guidance on how to do that here: TODO")
         return False
     else:
-        print("Found a policy.cfg.")
+        log_n_print("Found a policy.cfg.")
         if prompt(
                 "Do you want to verify the content?",
                 non_interactive=non_interactive,
@@ -74,48 +76,45 @@ def ceph(non_interactive=False):
             pager(_read_policy_cfg())
             if not prompt("Do you want to continue?"):
                 return 'aborted'
-    print("We'll now we update the pillar with the your changes.")
+    log_n_print("We'll now we update the pillar with the your changes.")
     pillar_questioneer(non_interactive=non_interactive)
-    print("Ok, let's verify the network settings")
-    print("This is the network configuration we detected.")
-    qrunner.cmd('advise.networks')
+    log_n_print("Ok, let's verify the network settings")
+    log_n_print("This is the network configuration we detected.")
+    run_and_eval('advise.networks')
     if prompt(
             "Do you want to adapt this setting?",
             non_interactive=non_interactive,
             default_answer=False):
-        print(
+        log_n_print(
             'dummy for proposals/config/stack/default/ceph/cluster.yml:public_network manipulation'
         )
-        print("We'll now we update the pillar with the your changes.")
+        log_n_print("We'll now we update the pillar with the your changes.")
         pillar_questioneer(non_interactive=non_interactive)
-    print("TEMP: Creating the ceph.conf (will go away in further releases)")
-    qrunner.cmd('config.create_and_distribute_ceph_conf')
+    log_n_print(
+        "TEMP: Creating the ceph.conf (will go away in further releases)")
+    run_and_eval('config.deploy')
 
     # TODO: Break all(sysexit) on SIGINT
     print("Bootstrapping monitors..")
-    qrunner.cmd('mon.deploy',
-                ["bootstrap=True", f"non_interactive={non_interactive}"])
+    run_and_eval('mon.deploy',
+                 [f'bootstrap=True, non_interactive={non_interactive}'])
+
     # if the answer in mon.deploy is 'no'. It will still deploy the managers.. Handle global signals/returns
     print("Bootstrapping mgrs..")
-    qrunner.cmd('mgr.deploy', [f"non_interactive={non_interactive}"])
+    run_and_eval("mgr.deploy", [f'non_interactive={non_interactive}'])
+
+    run_and_eval("ceph.health")
+
+    print(
+        "Bootstrapping is complete now. Please proceed with the osd.deploy/help command."
+    )
+
+    return True
 
 
-#     print("If policty.cfg and proposals dir is not present")
-#     print("qrunner.cmd('host.update')")
-#     print("Ask the user to create(adapt) a policy.cfg. Exit and ask to re-run this command")
-#     print("This is now the entry point for the second invocation")
-#     print("Use salt-run advise-networks to ask user if that's the right networks")
-#     print("Tell user where mon and mgrs will be deployed")
-#     print("Do it with interactive mode")
-#     print("After successful deploy. Guide towards osd.deploy and drivegroups (wiki)")
-#     print("From there on every command (mon/osd/mgr) should be selfcontained and doesn't require an additional step")
-#     print("I.e. adding a MON. 1) Adapt the policy.cfg 2) Run mon.deploy")
-
-#     print(""" Open questions:
-
-#     When to update the /srv/pillar/ struct. Previously we did that in every stage.1 invocation
-#     We may keep track of the salt-key -L ('inventory')
-# """)
+#   print(""" Open questions:
+#   When to update the /srv/pillar/ struct. Previously we did that in every stage.1 invocation
+#   We may keep track of the salt-key -L ('inventory')
 
 
 def cluster():

--- a/srv/modules/runners/bootstrap.py
+++ b/srv/modules/runners/bootstrap.py
@@ -112,7 +112,7 @@ def ceph(non_interactive=False):
     return True
 
 
-#   print(""" Open questions:
+# TODO:
 #   When to update the /srv/pillar/ struct. Previously we did that in every stage.1 invocation
 #   We may keep track of the salt-key -L ('inventory')
 

--- a/srv/modules/runners/ceph.py
+++ b/srv/modules/runners/ceph.py
@@ -1,7 +1,8 @@
 from ext_lib.utils import runner
-
+from salt.client import LocalClient
 
 # Downside of calling runners from runners and that every runner is selfcontained (in terms of module/pillar sync) is that we now check the dir checksums for every call here
+
 
 def deploy_core():
     print("may check for updates before")
@@ -9,6 +10,7 @@ def deploy_core():
     foo.cmd('mon.deploy')
     foo.cmd('mgr.deploy')
     foo.cmd('disks.deploy')
+
 
 def deploy_services(demo=False):
     """ Just an alias to salt-run services.deploy """
@@ -20,6 +22,7 @@ def deploy_services(demo=False):
 def deploy(demo=False):
     deploy_core()
     deploy_services(demo=demo)
+
 
 # I'm not quite convinced that this is the right interface to go with.
 # salt-run ceph.deploy (core and services)
@@ -40,3 +43,22 @@ def deploy(demo=False):
 # followed by the operation (component.update/deploy)
 # is it worth to make this an exception?
 # same goes for bootstrap btw
+
+
+def health():
+    ret: str = LocalClient().cmd(
+        'roles:master',
+        'podman.ceph_cli', [
+            'registry.suse.de/devel/storage/6.0/images/ses/6/ceph/ceph',
+            'health'
+        ],
+        tgt_type='pillar')
+
+    # TODO: improve the extraction, this will eventually fail
+    status = list(ret.values())[0].strip()
+    if status == 'HEALTH_OK' or status == 'HEALTH_WARN':
+        print(f"Ceph cluster status is {status}")
+        return True
+
+    print(f"Ceph cluster status is {status}")
+    return False

--- a/srv/modules/runners/config.py
+++ b/srv/modules/runners/config.py
@@ -1,0 +1,21 @@
+from salt.client import LocalClient
+
+
+def distribute_ceph_conf():
+    LocalClient().cmd(
+        "cluster:ceph",
+        'state.apply', ['ceph.configuration'],
+        tgt_type='pillar')
+    return True
+
+
+def create_ceph_conf():
+    LocalClient().cmd(
+        "roles:master",
+        'state.apply', ['ceph.configuration.create'],
+        tgt_type='pillar')
+
+
+def create_and_distribute_ceph_conf():
+    create_ceph_conf()
+    distribute_ceph_conf()

--- a/srv/modules/runners/config.py
+++ b/srv/modules/runners/config.py
@@ -1,21 +1,25 @@
 from salt.client import LocalClient
+from ext_lib.utils import evaluate_state_return
 
 
-def distribute_ceph_conf():
-    LocalClient().cmd(
+def distribute():
+    ret = LocalClient().cmd(
         "cluster:ceph",
         'state.apply', ['ceph.configuration'],
         tgt_type='pillar')
-    return True
+    return evaluate_state_return(ret)
 
 
-def create_ceph_conf():
-    LocalClient().cmd(
+def create():
+    ret = LocalClient().cmd(
         "roles:master",
         'state.apply', ['ceph.configuration.create'],
         tgt_type='pillar')
+    return evaluate_state_return(ret)
 
 
-def create_and_distribute_ceph_conf():
-    create_ceph_conf()
-    distribute_ceph_conf()
+def deploy():
+    """ Technically this is the wrong word.. Just keeping it consistent """
+    if all([create(), distribute()]):
+        return True
+    return False

--- a/srv/modules/runners/ext_lib/hash_dir.py
+++ b/srv/modules/runners/ext_lib/hash_dir.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import salt.client
 import logging
 from .pillar import proposal
+from .utils import prompt
 
 
 def update_pillar(directory, checksum):
@@ -11,7 +12,9 @@ def update_pillar(directory, checksum):
     print('Updating the pillar')
     proposal()
     ret: str = local_client.cmd(
-        "I@deepsea_minions:*", 'state.apply', ['ceph.refresh'], tgt_type='compound')
+        "I@deepsea_minions:*",
+        'state.apply', ['ceph.refresh'],
+        tgt_type='compound')
     # if (accumulated)ret == 0:
     # update md5()
     # TODO catch errors here
@@ -87,18 +90,16 @@ def pillar_questioneer(non_interactive=False):
     directory = '/srv/pillar/ceph'
     checksum_path = f'{directory}/.md5.save'
     if pillar_has_changes(directory, checksum_path):
-        print(
+        message = (
             "You have pending changes in the pillar that needs to be synced to the minions. Would you like to sync now?"
         )
-        if non_interactive:
-            answer = 'y'
-        else:
-            answer = input("(y/n)")
-        if answer.lower() == 'y':
+
+        if prompt(
+                message, non_interactive=non_interactive, default_answer=True):
             update_pillar(directory, checksum_path)
         else:
             print(
-                "\nNot updating the pillar, please keep in mind that lalalalala"
+                "\nNot updating the pillar, please keep in mind that #TOOD write text"
             )
 
 
@@ -106,14 +107,12 @@ def module_questioneer(non_interactive=False):
     directory = '/srv/salt/_modules'
     checksum_path = '/srv/salt/ceph/.modules.md5.save'
     if minion_modules_have_changes(directory, checksum_path):
-        print(
+        message = (
             "You have pending changes in the modules direcotry that needs to be synced to the minions. Would you like to sync now?"
         )
-        if non_interactive:
-            answer = 'y'
-        else:
-            answer = input("(y/n)")
-        if answer.lower() == 'y':
+
+        if prompt(
+                message, non_interactive=non_interactive, default_answer=True):
             sync_modules(directory, checksum_path)
         else:
             print(

--- a/srv/modules/runners/ext_lib/utils.py
+++ b/srv/modules/runners/ext_lib/utils.py
@@ -2,6 +2,7 @@ from salt.client import LocalClient
 from salt.runner import RunnerClient
 from salt.config import client_config
 
+
 def runner(opts):
     runner = RunnerClient(opts)
     __master_opts__ = client_config("/etc/salt/master")
@@ -16,9 +17,27 @@ def cluster_minions():
     TODO:
     Move select.py in this realm (/ext_lib) and make it python-import consumable
     """
-    potentials = LocalClient().cmd("I@cluster:ceph", 'test.ping', tgt_type='compound')
+    potentials = LocalClient().cmd(
+        "I@cluster:ceph", 'test.ping', tgt_type='compound')
     minions = list()
     for k, v in potentials.items():
         if v:
             minions.append(k)
     return minions
+
+
+def prompt(message,
+           options='(y/n)',
+           non_interactive=False,
+           default_answer=False):
+    if non_interactive:
+        print(f"running in non-interactive mode. default answer is {default_answer}")
+        return default_answer
+    answer = input(f"{message} - {options}")
+    if answer.lower() == 'y' or answer.lower() == 'Y':
+        return True
+    elif answer.lower() == 'n' or answer.lower() == 'N':
+        return False
+    else:
+        answer = input(f"You typed {answer}. We accept {options}")
+        prompt(message, options=options)

--- a/srv/modules/runners/ext_lib/utils.py
+++ b/srv/modules/runners/ext_lib/utils.py
@@ -1,9 +1,13 @@
 from salt.client import LocalClient
 from salt.runner import RunnerClient
 from salt.config import client_config
+import logging
+
+log = logging.getLogger(__name__)
 
 
 def runner(opts):
+    log.debug("Initializing runner")
     runner = RunnerClient(opts)
     __master_opts__ = client_config("/etc/salt/master")
     __master_opts__['quiet'] = False
@@ -17,6 +21,7 @@ def cluster_minions():
     TODO:
     Move select.py in this realm (/ext_lib) and make it python-import consumable
     """
+    log.debug("Searching for cluster_minions")
     potentials = LocalClient().cmd(
         "I@cluster:ceph", 'test.ping', tgt_type='compound')
     minions = list()
@@ -31,7 +36,9 @@ def prompt(message,
            non_interactive=False,
            default_answer=False):
     if non_interactive:
-        print(f"running in non-interactive mode. default answer is {default_answer}")
+        log.debug(
+            f"running in non-interactive mode. default answer is {default_answer}"
+        )
         return default_answer
     answer = input(f"{message} - {options}")
     if answer.lower() == 'y' or answer.lower() == 'Y':
@@ -41,3 +48,43 @@ def prompt(message,
     else:
         answer = input(f"You typed {answer}. We accept {options}")
         prompt(message, options=options)
+
+
+def evaluate_module_return(job_data):
+    failed = False
+    for minion_id, result in job_data.items():
+        log.debug(f"results for job are: {result} - running on {minion_id}")
+        if not result:
+            print(f"Module call failed on {minion_id}")
+            failed = True
+
+    if failed:
+        return False
+    return True
+
+
+def evaluate_state_return(job_data):
+    """ TODO """
+    # does log.x actually log in the salt log? I don't think so..
+    failed = False
+    for minion_id, job_data in job_data.items():
+        log.debug(f"{job_data} ran on {minion_id}")
+        for jid, metadata in job_data.items():
+            log.debug(f"Job {jid} run under: {metadata.get('name', 'n/a')}")
+            log.debug(
+                f"Job {jid } was successful: {metadata.get('result', False)}")
+            if not metadata.get('result', False):
+                log.debug(
+                    f"Job {metadata.get('name', 'n/a')} failed on minion: {minion_id}"
+                )
+                print(
+                    f"Job {metadata.get('name', 'n/a')} failed on minion: {minion_id}"
+                )
+                failed = True
+    if failed:
+        return False
+    return True
+
+def log_n_print(message):
+    log.debug(message)
+    print(message)

--- a/srv/modules/runners/ext_lib/utils.py
+++ b/srv/modules/runners/ext_lib/utils.py
@@ -7,6 +7,7 @@ log = logging.getLogger(__name__)
 
 
 def runner(opts):
+    """ TODO: docstring """
     log.debug("Initializing runner")
     runner = RunnerClient(opts)
     __master_opts__ = client_config("/etc/salt/master")
@@ -35,6 +36,7 @@ def prompt(message,
            options='(y/n)',
            non_interactive=False,
            default_answer=False):
+    """ TODO: docstring """
     if non_interactive:
         log.debug(
             f"running in non-interactive mode. default answer is {default_answer}"
@@ -53,7 +55,7 @@ def prompt(message,
 def evaluate_module_return(job_data):
     failed = False
     for minion_id, result in job_data.items():
-        log.debug(f"results for job are: {result} - running on {minion_id}")
+        log.debug(f"results for job on minion: {minion_id} is: {result}")
         if not result:
             print(f"Module call failed on {minion_id}")
             failed = True
@@ -85,6 +87,157 @@ def evaluate_state_return(job_data):
         return False
     return True
 
+
 def log_n_print(message):
+    """ TODO: docstring """
+    # TODO: I assume I have to pass a context logger to this function when invoked from a salt_module
+    # this lib is not executed with the salt context, hence no logging will end up in the salt-master logs
     log.debug(message)
     print(message)
+
+
+def _get_candidates(role=None):
+    """ TODO: docstring """
+    # Is this the right appracoh or should cephprocesses be used again?
+    assert role
+    all_minions = LocalClient().cmd(
+        f"roles:{role}", f'{role}.already_running', tgt_type='pillar')
+
+    candidates = list()
+
+    for k, v in all_minions.items():
+        if not v:
+            candidates.append(k)
+    return candidates
+
+
+def _is_running(role_name=None, minion=None, func='wait_role_up'):
+    """ TODO: docstring """
+    assert role_name
+    search = f"I@role:{role_name}"
+    running = True
+    if minion:
+        search = minion
+    log_n_print("Checking if processes are running. This may take a while..")
+    minions_return = LocalClient().cmd(
+        search,
+        f'cephprocesses.{func}', [f"role={role_name}"],
+        tgt_type='compound')
+    for minion, status in minions_return.items():
+        # TODO: Refactor the 'wait_role_down' function. This is horrible
+        if status:
+            log_n_print(f"role-{role_name} is running on {minion}")
+            log_n_print(f"This is showing the wrong status for role deletion currently")
+        if not status:
+            log_n_print(f"This is showing the wrong status for role deletion currently")
+            log_n_print(f"role-{role_name} is *NOT* running on {minion}")
+            running = False
+    return running
+
+
+def _remove_role(role=None, non_interactive=False):
+    # TODO: already_running vs is_running
+    # find process id vs. systemd
+    ##
+    ## There is mon ok-to-rm, ok-to-stop, ok-to-add-offline
+    ##
+    """ TODO: docstring """
+    assert role
+    already_running = LocalClient().cmd(
+        f"I@cluster:ceph and not I@roles:{role}",
+        f'{role}.already_running',
+        tgt_type='compound')
+    to_remove = [k for (k, v) in already_running.items() if v]
+    if not to_remove:
+        print("Nothing to remove. Exiting..")
+        return True
+    if prompt(
+            f"""Removing role: {role} on minion {', '.join(to_remove)}
+Continue?""",
+            non_interactive=non_interactive,
+            default_answer=True):
+        print(f"Removing {role} on {' '.join(to_remove)}")
+        ret: str = LocalClient().cmd(
+            to_remove,
+            f'podman.remove_{role}',
+            ['registry.suse.de/devel/storage/6.0/images/ses/6/ceph/ceph'],
+            tgt_type='list')
+        if not evaluate_module_return(ret):
+            return False
+
+        ret = [is_running(minion, role_name=role, func='wait_role_down') for minion in to_remove]
+        # TODO: do proper checks here:
+        if all(ret):
+            print(f"{role} deletion was successful.")
+            return True
+        return False
+
+
+    else:
+        return 'aborted'
+
+
+def _deploy_role(role=None, non_interactive=False):
+    assert role
+    candidates = _get_candidates(role=role)
+    if candidates:
+        if prompt(
+                f"""These minions will be {role}: {', '.join(candidates)}
+Continue?""",
+                non_interactive=non_interactive,
+                default_answer=True):
+            print("Deploying..")
+
+            if role == 'mgr':
+                for candidate in candidates:
+                    # create and register keyring
+                    ret: str = LocalClient().cmd(
+                        "roles:master",
+                        f'podman.create_mgr_keyring',
+                        ['registry.suse.de/devel/storage/6.0/images/ses/6/ceph/ceph', candidate],
+                        tgt_type='pillar')
+
+
+                if not evaluate_module_return(ret):
+                    return False
+
+                # distrubute keyring
+                ret: str = LocalClient().cmd(
+                    "roles:mgr",
+                    'state.apply',
+                    ['ceph.mgr.keyring'],
+                    tgt_type='pillar')
+
+                if not evaluate_state_return(ret):
+                    return False
+
+
+            ret: str = LocalClient().cmd(
+                candidates,
+                f'podman.create_{role}',
+                ['registry.suse.de/devel/storage/6.0/images/ses/6/ceph/ceph'],
+                tgt_type='list')
+
+            if not evaluate_module_return(ret):
+                return False
+
+            # TODO: query in a loop with a timeout
+            # TODO: Isn't that what we have in cephproceses.wait?
+            # TODO: Check that.
+            ret = [is_running(minion, role_name=role) for minion in candidates]
+            if not all(ret):
+                print(f"{role} deployment was not successful.")
+                return False
+            return True
+
+        return False
+    else:
+        print(f"No candidates for a {role} deployment found")
+        return True
+
+
+def is_running(minion, role_name=None, func='wait_role_up'):
+    assert role_name
+    if _is_running(role_name=role_name, minion=minion, func=func):
+        return True
+    return False

--- a/srv/modules/runners/host.py
+++ b/srv/modules/runners/host.py
@@ -1,5 +1,8 @@
-from ext_lib.utils import cluster_minions
+from ext_lib.utils import cluster_minions, evaluate_state_return
 from salt.client import LocalClient
+import logging
+
+log = logging.getLogger(__name__)
 
 
 def update(*args, **kwargs):
@@ -54,3 +57,15 @@ def update(*args, **kwargs):
         print(f"salt said: {upgrade_metadata[0].get('comment', '')}")
         print(f"Updated {minion}")
     return True
+
+
+def install_common_packages():
+    # Is this deepsea_minion targeting correct?
+    print(
+        "Installing required packages on all hosts marked with the 'deepsea_minions' grain."
+    )
+    ret = LocalClient().cmd(
+        'I@deepsea_minions:*',
+        'state.apply', ['ceph.packages.common'],
+        tgt_type='compound')
+    return evaluate_state_return(ret)

--- a/srv/modules/runners/mgr.py
+++ b/srv/modules/runners/mgr.py
@@ -1,4 +1,5 @@
 from ext_lib.hash_dir import pillar_questioneer, module_questioneer
+from ext_lib.utils import evaluate_module_return
 from salt.client import LocalClient
 
 
@@ -11,4 +12,8 @@ def deploy(non_interactive=False):
         'podman.create_mgr',
         ['registry.suse.de/devel/storage/6.0/images/ses/6/ceph/ceph'],
         tgt_type='compound')
+
+    if not evaluate_module_return(ret):
+        return False
     print("Mgr created")
+    return True

--- a/srv/modules/runners/mgr.py
+++ b/srv/modules/runners/mgr.py
@@ -1,0 +1,14 @@
+from ext_lib.hash_dir import pillar_questioneer, module_questioneer
+from salt.client import LocalClient
+
+
+def deploy(non_interactive=False):
+    pillar_questioneer(non_interactive=False)
+    module_questioneer(non_interactive=False)
+    print("Deploying mgrs..")
+    ret: str = LocalClient().cmd(
+        "I@roles:mgr",
+        'podman.create_mgr',
+        ['registry.suse.de/devel/storage/6.0/images/ses/6/ceph/ceph'],
+        tgt_type='compound')
+    print("Mgr created")

--- a/srv/modules/runners/mgr.py
+++ b/srv/modules/runners/mgr.py
@@ -1,19 +1,22 @@
 from ext_lib.hash_dir import pillar_questioneer, module_questioneer
-from ext_lib.utils import evaluate_module_return
+from ext_lib.utils import _deploy_role, _remove_role
 from salt.client import LocalClient
 
+# TODO: The non_interactive passing is weird..
+# change that by abstracting to a class or a config option
 
 def deploy(non_interactive=False):
-    pillar_questioneer(non_interactive=False)
-    module_questioneer(non_interactive=False)
-    print("Deploying mgrs..")
-    ret: str = LocalClient().cmd(
-        "I@roles:mgr",
-        'podman.create_mgr',
-        ['registry.suse.de/devel/storage/6.0/images/ses/6/ceph/ceph'],
-        tgt_type='compound')
+    pillar_questioneer(non_interactive=non_interactive)
+    module_questioneer(non_interactive=non_interactive)
+    return _deploy_role(role='mgr', non_interactive=non_interactive)
 
-    if not evaluate_module_return(ret):
-        return False
-    print("Mgr created")
-    return True
+
+def remove(non_interactive=False):
+    pillar_questioneer(non_interactive=non_interactive)
+    return _remove_role(role='mgr', non_interactive=non_interactive)
+
+
+def update():
+    # TODO: implementation
+    """ How to query/pull from the registry? """
+    pass

--- a/srv/modules/runners/mon.py
+++ b/srv/modules/runners/mon.py
@@ -1,79 +1,20 @@
 from ext_lib.hash_dir import pillar_questioneer, module_questioneer
 from salt.client import LocalClient
-from ext_lib.utils import prompt, evaluate_module_return
+from ext_lib.utils import _deploy_role, _remove_role
 
-# TODO: implement non-interactive mode
+# TODO: The non_interactive passing is weird..
+# change that by abstracting to a class or a config option
 
 
 def deploy(bootstrap=False, non_interactive=False):
     pillar_questioneer(non_interactive=non_interactive)
     module_questioneer(non_interactive=non_interactive)
-    # 'target' <- roles with 'role' foo.
-    # call podman module targeting 'target'
-    # podman modules figures out if we need to re-deploy/newly create
-    # NOTE:
-    # stage.5 sort of things need to go away.
-    # only allow to specifically target nodes/hosts/services etc.
-    # salt-run mon.remove <host>
-
-    # scan for minons (with role:mon) that return False at already_running
-
-    # Implement this call for all roles.. One inferface makes this abstractable
-    potientials = LocalClient().cmd(
-        "roles:mon", 'mon.already_running', tgt_type='pillar')
-
-    mon_candidates = list()
-
-    for k, v in potientials.items():
-        if not v:
-            mon_candidates.append(k)
-    if mon_candidates:
-        if prompt(
-                f"""These minions will be mons: {', '.join(mon_candidates)}
-Continue?""",
-                non_interactive=non_interactive,
-                default_answer=True):
-            print("Deploying..")
-
-            ############################################################
-            # Should this be combined into one execution&eval function?
-            ret: str = LocalClient().cmd(
-                mon_candidates,
-                'podman.create_mon',
-                ['registry.suse.de/devel/storage/6.0/images/ses/6/ceph/ceph'],
-                kwarg={'bootstrap': bootstrap},
-                tgt_type='list')
-
-            if not evaluate_module_return(ret):
-                return False
-            ###########################################################
-
-            print(f"Mon(s) created on {', '.join(mon_candidates)}")
-            return True
-        print("Aborted.")
-        return False
-    else:
-        print("No candidates for a mon deployment found")
-        return True
+    return _deploy_role(role='mon')
 
 
-def remove():
-    pillar_questioneer()
-    already_running = LocalClient().cmd(
-        "I@cluster:ceph and not I@roles:mon",
-        'mon.already_running',
-        tgt_type='compound')
-    to_remove = [k for (k, v) in already_running.items() if v]
-    if not to_remove:
-        print("Nothing to remove. Exiting..")
-        return True
-    print(f"Removing MON(s) on {' '.join(to_remove)}")
-    ret: str = LocalClient().cmd(
-        to_remove,
-        'podman.remove_mon',
-        ['registry.suse.de/devel/storage/6.0/images/ses/6/ceph/ceph'],
-        tgt_type='list')
-    return True
+def remove(non_interactive=False):
+    pillar_questioneer(non_interactive=non_interactive)
+    return _remove_role(role='mon')
 
 
 def update():

--- a/srv/modules/runners/mon.py
+++ b/srv/modules/runners/mon.py
@@ -1,12 +1,13 @@
 from ext_lib.hash_dir import pillar_questioneer, module_questioneer
 from salt.client import LocalClient
+from ext_lib.utils import prompt
 
 # TODO: implement non-interactive mode
 
 
-def deploy():
-    pillar_questioneer()
-    module_questioneer()
+def deploy(bootstrap=False, non_interactive=False):
+    pillar_questioneer(non_interactive=non_interactive)
+    module_questioneer(non_interactive=non_interactive)
     # 'target' <- roles with 'role' foo.
     # call podman module targeting 'target'
     # podman modules figures out if we need to re-deploy/newly create
@@ -27,14 +28,28 @@ def deploy():
         if not v:
             mon_candidates.append(k)
     if mon_candidates:
-        print(f"These minions will be mons: {', '.join(mon_candidates)}")
-        user_inp = input("Do you want to continue? (y/n)")
-        if user_inp.lower() == 'y':
+        if prompt(
+                f"""These minions will be mons: {', '.join(mon_candidates)}
+Continue?""", non_interactive=non_interactive, default_answer=True
+        ):
             print("Deploying..")
+            ret: str = LocalClient().cmd(
+                mon_candidates,
+                'podman.generate_osd_bootstrap_keyring',
+                ['registry.suse.de/devel/storage/6.0/images/ses/6/ceph/ceph'],
+                tgt_type='list')
+
+            ret: str = LocalClient().cmd(
+                mon_candidates,
+                'podman.create_initial_keyring',
+                ['registry.suse.de/devel/storage/6.0/images/ses/6/ceph/ceph'],
+                tgt_type='list')
+
             ret: str = LocalClient().cmd(
                 mon_candidates,
                 'podman.create_mon',
                 ['registry.suse.de/devel/storage/6.0/images/ses/6/ceph/ceph'],
+                kwarg={'bootstrap': bootstrap},
                 tgt_type='list')
             # improve returncode reporting
             print(f"Mon(s) created on {', '.join(mon_candidates)}")

--- a/srv/salt/_modules/mgr.py
+++ b/srv/salt/_modules/mgr.py
@@ -1,0 +1,41 @@
+import logging
+# pylint: disable=import-error,3rd-party-module-not-gated
+from subprocess import check_output, CalledProcessError
+log = logging.getLogger(__name__)
+
+
+def already_running():
+
+    # TODO:
+    # This code is almost identical with mon.already_running.
+    # refactor and share it!
+
+    # check if a container is already running.
+    # Check the higher-level instance - systemd.
+
+    # there needs to be a second check for existence..
+    # we might have the case where a mon is down, but still exists
+    # check for directory existence? or for podman image existance?
+
+    # TODO: refine the logic when to return false/true..
+
+    # is /host/ fine?
+    mgr_name = __grains__.get('host', '')
+    if not mgr_name:
+        log.error("Could not retrieve host grain. Aborting")
+        return False
+    try:
+        status = check_output(
+            ['systemctl', 'is-active',
+             f'ceph-mgr@{mgr_name}.service']).decode('utf-8').strip()
+    except CalledProcessError as e:
+        log.info(f'{e}')
+        return False
+    if status == 'active':
+        return True
+    elif status == 'inactive' or os.path.exists(
+            f'/var/lib/ceph/mgr/ceph-{mgr_name}'):
+        return False
+    else:
+        log.error(f"Could not determine state of {mgr_name}")
+        return False

--- a/srv/salt/_modules/podman.py
+++ b/srv/salt/_modules/podman.py
@@ -4,8 +4,12 @@ import shutil
 import sys
 from distutils.spawn import find_executable
 from os.path import expanduser
-from subprocess import check_output, CalledProcessError
+from subprocess import check_output, CalledProcessError, Popen, PIPE
+from subprocess import run as subprocess_run
 from typing import List, Dict, Sequence
+
+# Takes care of shell escaping way better than just .split()
+from shlex import split as shlex_split
 
 logger = logging.getLogger(__name__)
 
@@ -43,6 +47,7 @@ class CephContainer(object):
         name = ['--name', self.name] if self.name else []
         return [
             find_program('podman'),
+            # TODO: remove later <- what a bullshit..
             'run',
             '--rm',
             '--net=host',
@@ -50,8 +55,9 @@ class CephContainer(object):
             '--entrypoint', f'/usr/bin/{self.entrypoint}', self.image
         ] + self.args
 
+    # TODO: if entrypoint == 'ceph' -> set timeout
+
     def run(self):
-        logger.info(self.run_cmd)
         print(' '.join(self.run_cmd))
         print(check_output(self.run_cmd))
 
@@ -69,6 +75,7 @@ def ceph_cli(image, passed_args=['--version']):
             volume_mounts={
                 '/var/lib/ceph': '/var/lib/ceph:z',
                 '/var/run/ceph': '/var/run/ceph:z',
+                '/etc/ceph': '/etc/ceph:z',
                 '/etc/localtime': '/etc/localtime:ro',
                 '/var/log/ceph': '/var/log/ceph:z'
             },
@@ -76,17 +83,6 @@ def ceph_cli(image, passed_args=['--version']):
     except CalledProcessError as e:
         logger.info(f'{e}')
         sys.exit(1)
-
-
-"""
-bootstrap
-ceph-authtool --create-keyring /tmp/bootstrap_keyring --gen-key -n mon.
-ceph-authtool /tmp/bootstrap_keyring --gen-key -n client.admin --cap mon 'allow *' --cap osd 'allow *' --cap mds 'allow'
-(maybe) ceph-authtool --create-keyring /var/lib/ceph/bootstrap-osd/ceph.keyring --gen-key -n client.bootstrap-osd --cap mon 'profile bootstrap-osd'
-monmaptool --create --add {hostname} {ip-address} --fsid {uuid} /tmp/monmap
-mkdir /var/lib/ceph/mon/ceph-{hostname}
-ceph-mon --mkfs -i admin --public-network 172.16.1.0/24 --cluster-network 172.16.2.0/24 --keyring /tmp/bootstrap_keyring --monmap /tmp/monmap -f -d
-"""
 
 
 def _get_public_network():
@@ -105,17 +101,15 @@ def _get_public_address():
 
 
 def make_monmap(image, fsid=None):
-    # monmaptool --create --add {hostname} {ip-address} --fsid {uuid} /tmp/monmap
     hostname = get_hostname()
     ip_address = _get_public_address()
-    fsid = fsid or make_fsid()
     dest = '/tmp/bootstrap_monmap'
     CephContainer(
         image,
         entrypoint='monmaptool',
-        args=
-        f'--create --add {hostname} {ip_address} --fsid {fsid} {dest} --clobber'
-        .split(),
+        args=shlex_split(
+            f'--create --add {hostname} {ip_address} --fsid {fsid} {dest} --clobber'
+        ),
         volume_mounts={
             '/tmp': '/tmp'
         }).run()
@@ -125,21 +119,92 @@ def make_monmap(image, fsid=None):
 
 
 def create_initial_keyring(image):
-    mon_keyring_path = '/tmp'
+    mon_keyring_path = '/var/lib/ceph/tmp'
     mon_keyring = f'{mon_keyring_path}/bootstrap_keyring'
-
+    admin_keyring = '/etc/ceph/ceph.client.admin.keyring'
     makedirs(mon_keyring_path)
 
     CephContainer(
         image=image,
         entrypoint='ceph-authtool',
-        args=f'--create-keyring {mon_keyring} --gen-key -n mon.'.split(),
+        args=shlex_split(
+            f"--create-keyring {mon_keyring} --gen-key -n mon. --cap mon 'allow *'"
+        ),
         volume_mounts={
-            '/tmp': '/tmp'
+            '/var/lib/ceph/tmp': '/var/lib/ceph/tmp',
+            # '/var/lib/ceph': '/var/lib/ceph',
+            # '/etc/ceph': '/etc/ceph'
         }).run()
 
-    logger.info(f'{mon_keyring} created')
+    CephContainer(
+        image=image,
+        entrypoint='ceph-authtool',
+        args=shlex_split(
+            f"--create-keyring {admin_keyring} --gen-key -n client.admin --cap mon 'allow *' --cap osd 'allow *' --cap mds 'allow *' --cap mgr 'allow *'"
+        ),
+        volume_mounts={
+            '/tmp': '/tmp',
+            '/var/lib/ceph': '/var/lib/ceph',
+            '/etc/ceph': '/etc/ceph'
+        }).run()
+
     return mon_keyring
+
+
+def generate_osd_bootstrap_keyring(image):
+    osd_bootstrap_path = '/var/lib/ceph/bootstrap-osd'
+    osd_bootstrap_keyring = f'{osd_bootstrap_path}/ceph.keyring'
+
+    makedirs(osd_bootstrap_path)
+
+    CephContainer(
+        image=image,
+        entrypoint='ceph-authtool',
+        args=shlex_split(
+            f"--create-keyring {osd_bootstrap_keyring} --gen-key -n client.bootstrap-osd --cap mon 'profile bootstrap-osd'"
+        ),
+        volume_mounts={
+            '/tmp': '/tmp',
+            '/var/lib/ceph': '/var/lib/ceph',
+            '/etc/ceph': '/etc/ceph'
+        }).run()
+
+    return osd_bootstrap_keyring
+
+
+def add_generated_keys(image):
+    mon_keyring_path = '/var/lib/ceph/tmp'
+    osd_bootstrap_path = '/var/lib/ceph/bootstrap-osd'
+    mon_keyring = f'{mon_keyring_path}/bootstrap_keyring'
+
+    makedirs(osd_bootstrap_path)
+
+    CephContainer(
+        image=image,
+        entrypoint='ceph-authtool',
+        args=shlex_split(
+            f"{mon_keyring} --import-keyring /etc/ceph/ceph.client.admin.keyring "
+        ),
+        volume_mounts={
+            '/tmp': '/tmp',
+            '/var/lib/ceph': '/var/lib/ceph',
+            '/etc/ceph': '/etc/ceph'
+        }).run()
+
+    CephContainer(
+        image=image,
+        entrypoint='ceph-authtool',
+        args=shlex_split(
+            f"{mon_keyring} --import-keyring /var/lib/ceph/bootstrap-osd/ceph.keyring"
+        ),
+        volume_mounts={
+            '/tmp': '/tmp',
+            '/var/lib/ceph': '/var/lib/ceph',
+            '/etc/ceph': '/etc/ceph'
+        }).run()
+
+    # TODO
+    return True
 
 
 def extract_keyring(image):
@@ -150,7 +215,7 @@ def extract_keyring(image):
     CephContainer(
         image=image,
         entrypoint='ceph',
-        args=f'auth get-or-create mon. -o {keyring}'.split(),
+        args=shlex_split(f'auth get-or-create mon. -o {keyring}'),
         volume_mounts={
             '/var/lib/ceph/': '/var/lib/ceph',
             # etc ceph needs to go away, how does one query ceph auth get mon without the ceph.conf needs?
@@ -170,7 +235,7 @@ def extract_mon_map(image):
     CephContainer(
         image=image,
         entrypoint='ceph',
-        args=f'mon getmap -o {mon_map}'.split(),
+        args=shlex_split(f'mon getmap -o {mon_map}'),
         volume_mounts={
             '/var/lib/ceph/tmp': '/var/lib/ceph/tmp',
             # etc ceph needs to go away, how does one query ceph mon getmap without the ceph.conf needs?
@@ -179,17 +244,26 @@ def extract_mon_map(image):
     return mon_map
 
 
-def create_mon(image, uid=0, gid=0, start=True, bootstrap=False):
+def create_mon(image, fsid=None, uid=0, gid=0, start=True, bootstrap=False):
     mon_name = get_hostname()
+    fsid = fsid or make_or_get_fsid()
+
+    makedirs('/var/lib/ceph')
+
     if bootstrap:
-        map_filename = make_monmap(image)  #TODO
+        logger.warning(f"bootstrap is: {bootstrap}")
         mon_keyring_path = create_initial_keyring(image)
+        generate_osd_bootstrap_keyring(image)
+        add_generated_keys(image)
+        map_filename = make_monmap(image, fsid=fsid)  #TODO
     else:
+        logger.warning(f"bootstrap is: {bootstrap}")
         map_filename = extract_mon_map(image)
         mon_keyring_path = extract_keyring(image)
 
     makedirs(f'/var/lib/ceph/mon/ceph-{mon_name}')
     makedirs(f'/var/log/ceph')
+    # TODO: change ownership to ceph:ceph
     cluster_network = _get_cluster_network()
     public_network = _get_public_network()
 
@@ -203,13 +277,18 @@ def create_mon(image, uid=0, gid=0, start=True, bootstrap=False):
         image=image,
         entrypoint='ceph-mon',
         args=[
-            '--mkfs', '-i', mon_name, '--keyring', mon_keyring_path,
-            '--monmap', map_filename, '--public-network', public_network,
-            '--cluster_network', cluster_network
+            '--mkfs',
+            '-i',
+            mon_name,
+            '--keyring',
+            mon_keyring_path,
+            '--monmap',
+            map_filename  #'--public-network', public_network, #'--cluster_network', cluster_network # Not needed when ceph.conf is in place
         ] + user_args(uid, gid),
         volume_mounts={
             '/var/lib/ceph/': '/var/lib/ceph',
-            '/tmp': '/tmp'
+            '/tmp': '/tmp',
+            '/etc/ceph/': '/etc/ceph'
         }).run()
 
     # source this (hardcoded) information from somewhere else
@@ -217,36 +296,45 @@ def create_mon(image, uid=0, gid=0, start=True, bootstrap=False):
         start_mon(
             image,
             mon_name,
-            mon_keyring_path,
-            '172.16.2.254',
-            '172.16.1.254',
-            mon_initial_members=_get_public_address())
+            #mon_keyring_path,
+            #'172.16.2.254',
+            #'172.16.1.254',
+            #mon_initial_members=_get_public_address(),
+            #fsid=fsid,
+        )
         return True
     return True
 
 
-def create_mgr(image, uid=0, gid=0, start=True):
-    # TODO: boostrap
-    #mon_keyring_path = create_initial_keyring(image)
-    mgr_name = __grains__.get('host', '')
-    assert mgr_name
-    mgr_keyring_path = extract_keyring(image, role='mgr', name=mgr_name)
-    # move
-    keyring_location = f'/var/lib/ceph/mgr/ceph-{mgr_name}'
-    makedirs(keyring_location)
-    shutil.copyfile(mgr_keyring_path, f'{keyring_location}/keyring')
-
+def create_mgr_keyring(image, name, path):
+    assert image
+    assert name
     CephContainer(
         image=image,
-        entrypoint='ceph-mgr',
-        args=['-i', mgr_name] + user_args(uid, gid),
+        entrypoint='ceph',
+        args=shlex_split(
+            f"auth get-or-create mgr.{name} mon 'allow profile mgr' osd 'allow *' mds 'allow *' -o {path}/keyring"
+        ),
         volume_mounts={
             '/var/lib/ceph/': '/var/lib/ceph',
+            # etc ceph needs to go away, how does one query ceph auth get mon without the ceph.conf needs?
             '/etc/ceph/': '/etc/ceph'
         }).run()
 
 
+def create_mgr(image, uid=0, gid=0, start=True):
+    mgr_name = __grains__.get('host', '')
+    assert mgr_name
+    mgr_path = f'/var/lib/ceph/mgr/ceph-{mgr_name}'
+    makedirs(mgr_path)
+    create_mgr_keyring(image, mgr_name, mgr_path)
+
+    if start:
+        start_mgr(image, mgr_name)
+
+
 def remove_mon(image):
+    # TODO: removal of last monitor
     mon_name = __grains__.get('host', '')
     assert mon_name
     CephContainer(
@@ -267,17 +355,80 @@ def remove_mon(image):
     check_output(['systemctl', 'disable', f'ceph-mon@{mon_name}.service'])
     rmdir(f'/var/lib/ceph/mon/ceph-{mon_name}')
     rmfile(f'/usr/lib/systemd/system/ceph-mon@.service')
+    check_output(['systemctl', 'daemon-reload'])
     return True
 
 
-def start_mon(image,
-              mon_name,
-              mon_keyring_path,
-              cluster_addr,
-              public_addr,
-              mon_initial_members=None,
-              uid=0,
-              gid=0):
+def remove_mgr(image):
+    mgr_name = __grains__.get('host', '')
+    assert mgr_name
+
+    # TODO: make this failproof
+    check_output(['systemctl', 'stop', f'ceph-mgr@{mgr_name}.service'])
+    check_output(['systemctl', 'disable', f'ceph-mgr@{mgr_name}.service'])
+    rmdir(f'/var/lib/ceph/mgr/ceph-{mgr_name}')
+    rmfile(f'/usr/lib/systemd/system/ceph-mgr@.service')
+    check_output(['systemctl', 'daemon-reload'])
+    return True
+
+
+def start_mgr(image, mgr_name):
+    mgr_container = CephContainer(
+        image=image,
+        entrypoint='ceph-mgr',
+        args=[
+            '-i',
+            mgr_name,
+            '-f',  # foreground
+            '-d'  # log to stderr
+        ],
+        volume_mounts={
+            '/var/lib/ceph': '/var/lib/ceph:z',
+            '/var/run/ceph': '/var/run/ceph:z',
+            '/etc/ceph/': '/etc/ceph',
+            '/etc/localtime': '/etc/localtime:ro',
+            '/var/log/ceph': '/var/log/ceph:z'
+        },
+        name='ceph-mgr-%i',
+    )
+    unit_path = expanduser('/usr/lib/systemd/system')
+    makedirs(unit_path)
+    logger.info(mgr_container.run_cmd)
+    print(" ".join(mgr_container.run_cmd))
+    with open(f'{unit_path}/ceph-mgr@.service', 'w') as f:
+        f.write(f"""[Unit]
+Description=Ceph Manager
+After=network.target
+[Service]
+EnvironmentFile=-/etc/environment
+ExecStartPre=-/usr/bin/podman rm ceph-mgr-%i
+ExecStart={' '.join(mgr_container.run_cmd)}
+ExecStop=-/usr/bin/podman stop ceph-mgr-%i
+ExecStopPost=-/bin/rm -f /var/run/ceph/ceph-mgr.%i.asok
+Restart=always
+RestartSec=10s
+TimeoutStartSec=120
+TimeoutStopSec=15
+[Install]
+WantedBy=multi-user.target
+""")
+    check_output(['systemctl', 'disable', f'ceph-mgr@{mgr_name}.service'])
+    check_output(['systemctl', 'enable', f'ceph-mgr@{mgr_name}.service'])
+    check_output(['systemctl', 'start', f'ceph-mgr@{mgr_name}.service'])
+    logger.info(f'See > journalctl --user -f -u ceph-mgr@{mgr_name}.service')
+    print(f'See > journalctl --user -f -u ceph-mgr@{mgr_name}.service')
+
+
+def start_mon(
+        image,
+        mon_name,
+        #mon_keyring_path,
+        #cluster_addr,
+        #public_addr,
+        #mon_initial_members=None,
+        #fsid=None,
+        uid=0,
+        gid=0):
     makedirs('/var/run/ceph')
     mon_container = CephContainer(
         image=image,
@@ -285,19 +436,20 @@ def start_mon(image,
         args=[
             '-i',
             mon_name,
-            # '--fsid',
-            # fsid,
-            # '--keyring',
-            # mon_keyring_path,
-            f'--cluster_addr={cluster_addr}',
-            f'--public_addr={public_addr}',
-            f'--mon_initial_members={mon_initial_members}',
+            #'--fsid',
+            #fsid,
+            #'--keyring',
+            #mon_keyring_path,
+            #f'--cluster_addr={cluster_addr}',
+            #f'--public_addr={public_addr}',
+            #f'--mon_initial_members={mon_initial_members}',
             '-f',  # foreground
             '-d'  # log to stderr
         ] + user_args(uid, gid),
         volume_mounts={
             '/var/lib/ceph': '/var/lib/ceph:z',
             '/var/run/ceph': '/var/run/ceph:z',
+            #'/etc/ceph/': '/etc/ceph',
             '/etc/localtime': '/etc/localtime:ro',
             '/var/log/ceph': '/var/log/ceph:z'
         },
@@ -327,8 +479,8 @@ WantedBy=multi-user.target
     check_output(['systemctl', 'disable', f'ceph-mon@{mon_name}.service'])
     check_output(['systemctl', 'enable', f'ceph-mon@{mon_name}.service'])
     check_output(['systemctl', 'start', f'ceph-mon@{mon_name}.service'])
-    logger.info(f'See > journalctl --user -f -u ceph-mon@{mon_name}.service')
-    print(f'See > journalctl --user -f -u ceph-mon@{mon_name}.service')
+    logger.info(f'See > journalctl -f -u ceph-mon@{mon_name}.service')
+    print(f'See > journalctl -f -u ceph-mon@{mon_name}.service')
 
 
 # Utils
@@ -347,9 +499,9 @@ def get_hostname():
     return __salt__['grains.get']('host', '')
 
 
-def make_fsid():
+def make_or_get_fsid():
     import uuid
-    return str(uuid.uuid1())
+    return __salt__['pillar.get']('fsid', str(uuid.uuid1()))
 
 
 def find_program(filename):

--- a/srv/salt/ceph/mgr/keyring/default.sls
+++ b/srv/salt/ceph/mgr/keyring/default.sls
@@ -1,13 +1,10 @@
-
-
 /var/lib/ceph/mgr/ceph-{{ grains['host'] }}/keyring:
   file.managed:
     - source:
       - salt://ceph/mgr/cache/{{ grains['host'] }}.keyring
     - template: jinja
-    - user: ceph
-    - group: ceph
+    - user: root
+    - group: root
     - mode: 600
     - makedirs: True
     - fire_event: True
-

--- a/srv/salt/ceph/packages/common/default.sls
+++ b/srv/salt/ceph/packages/common/default.sls
@@ -19,9 +19,9 @@ stage prep dependencies suse:
       - hwinfo
       - pciutils
       - gptfdisk
-      - python3-boto
-      - python3-rados
-      - python3-netaddr
+      # - python3-boto
+      # - python3-rados
+      # - python3-netaddr
       - iperf
       - lsof
       - jq
@@ -30,7 +30,10 @@ stage prep dependencies suse:
       - polkit
       - libstoragemgmt
       - curl
-      - ceph
+      - podman
+      - patterns-base-apparmor
+      - apparmor-utils
+
     - fire_event: True
     - refresh: True
 
@@ -49,7 +52,8 @@ stage prep dependencies ubuntu:
       - iperf
       - jq
       - curl
-      - ceph
+      - podman
+      # apparmor?
     - fire_event: True
     - refresh: True
 
@@ -80,7 +84,8 @@ stage prep dependencies CentOS:
       - jq
       - libstoragemgmt
       - curl
-      - ceph
+      - podman
+      # apparmor?
     - fire_event: True
     - refresh: True
 


### PR DESCRIPTION
Signed-off-by: Joshua Schmid <jschmid@suse.de>

Description:

This PR enables DS-next to bootstrap a cluster(mon&mgr) using containers.

* Added/Completed the `salt-run bootstrap.ceph` runner.

`salt-run bootstrap.ceph [non_interactive=True/False]`

Will bootstrap a cluster from nothing to N monitors and N managers (N depending on your policy.cfg).

* Added non-interactive modes for mon/mgr

* Added a unitfied `promp` method that supports non_interactive calls

CAVEAT:

* I experienced issues when invoking podman(version 1.01) via the remote salt context.

`salt \admin* podman.get_ceph_version`

would make podman/conmon/runc stuck, and runc's child processes even defunct. This would eventually time out in salt, but not in podman, leaving zombie processes behind.

This behavior was *not* seen when executed in a local context via:

`salt-call podman.get_ceph_version` 

After unsuccessful debugging I switched to a newer version of podman from OBS:

https://download.opensuse.org/repositories/devel:/kubic/openSUSE_Leap_15.1/
(ignoring the missing *-fuse package works fine)

which seems to not have this issues.

* ceph.conf 

it **is** required for mgr deployment, but seems not to be required for mon bootstrapping. Also for querying ceph for health requires a (minimal) ceph.conf with mon_host options.

footnote: this is an experimental, unfinished, highly fragile and 'untested' code. It's just presented as a PR to other people as it will unblock further development. The code will be changed in the future and unittests will be added at a later stage.

