### PR TITLE
Add status function to advise on upgrade order

### DIFF
--- a/deepsea.spec.in
+++ b/deepsea.spec.in
@@ -47,6 +47,7 @@ Requires:       polkit
 Requires:       python3-boto
 Requires:       python3-configobj
 Requires:       python3-netaddr
+Requires:       python3-packaging
 Requires:       python3-rados
 Requires:       python3-six
 Requires:       salt-api

--- a/srv/modules/runners/status.py
+++ b/srv/modules/runners/status.py
@@ -16,16 +16,13 @@ def _get_data(cluster_name='ceph'):
     """
     Query grains, run commands for current versions
     """
-    local = salt.client.LocalClient()
-    search = "I@cluster:{}".format(cluster_name)
-    # grains might be inaccurate or not up to date because they are designed
-    # to hold static data about the minion. In case of an update though, the
-    # data will change.  grains are refreshed on reboot(restart of the service).
-    os_codename = local.cmd(search, 'grains.get', ['oscodename'], tgt_type="compound")
-    salt_version = local.cmd(search, 'grains.get', ['saltversion'], tgt_type="compound")
-    ceph_version = local.cmd(search, 'cmd.shell', ['ceph --version'], tgt_type="compound")
+    __opts__ = salt.config.client_config('/etc/salt/master')
+    __grains__ = salt.loader.grains(__opts__)
+    __opts__['grains'] = __grains__
+    __utils__ = salt.loader.utils(__opts__)
+    __salt__ = salt.loader.minion_mods(__opts__, utils=__utils__)
 
-    return os_codename, salt_version, ceph_version
+    return __utils__['status.get_sys_versions'](cluster_name)
 
 
 def help_():

--- a/srv/modules/runners/upgrade.py
+++ b/srv/modules/runners/upgrade.py
@@ -1,13 +1,16 @@
 # -*- coding: utf-8 -*-
+# vim: ts=8 et sw=4 sts=4
 # pylint: disable=modernize-parse-error
 """
 Verify that an automated upgrade is possible
 """
 from __future__ import absolute_import
 from __future__ import print_function
+import re
 # pylint: disable=import-error,3rd-party-module-not-gated,redefined-builtin
 import salt.client
 import salt.utils.error
+from packaging import version
 
 
 class UpgradeValidation(object):
@@ -107,6 +110,133 @@ def check():
             print(msg)
             return ret
     return ret
+
+
+def _sort_nodes_by_role(nodes, roles):
+    """
+    Given a list of nodes, return the list sorted first by role in upgrade order
+    (master, then mon/mgr, then mds, then storage, ...), and secondly by name.
+
+    The roles parameter is a dict mapping _all_ node names to a list of their
+    assigned roles (i.e. `salt '*' pillar.get roles`), so that this function can
+    actually figure out what roles are assigned to each node in the nodes list.
+    """
+    nodes_sorted = []
+    for role in ['master', 'mon', 'mgr', 'mds', 'storage', 'rgw', 'igw', 'ganesha']:
+        role_nodes = [node for node in roles if role in roles[node] and node in nodes]
+        role_nodes.sort()
+        nodes_sorted.extend([node for node in role_nodes if node not in nodes_sorted])
+    return nodes_sorted
+
+
+def _print_nodes_to_upgrade(releases, newest, roles):
+    """
+    Prints a list of nodes currently on the newest release, followed by an ordered
+    list of which nodes need upgrading next.
+
+    releases is a dict mapping node names to software versions
+    newest is the newest installed version
+    roles is a dict as used by _sort_nodes_by_role()
+    """
+    upgraded_nodes = _sort_nodes_by_role([node for node in releases if releases[node] == newest],
+                                         roles)
+    nodes_to_upgrade = _sort_nodes_by_role([node for node in releases if releases[node] < newest],
+                                           roles)
+
+    print("Nodes running these software versions:")
+    for node in upgraded_nodes:
+        print("  {} (assigned roles: {})".format(node, ", ".join(roles[node])))
+    print("")
+
+    print("Nodes running older software versions must be upgraded in the following order:")
+    i = 1
+    for node in nodes_to_upgrade:
+        print("{:4}: {} (assigned roles: {})".format(i, node, ", ".join(roles[node])))
+        i += 1
+    print("")
+
+
+def status():
+    """
+    Check status of upgrade.  This is similar to status.report, but if the
+    base OS version or ceph version isn't identical on all nodes, it will
+    advise which node(s) should be upgraded next.
+    """
+    __opts__ = salt.config.client_config('/etc/salt/master')
+    __grains__ = salt.loader.grains(__opts__)
+    __opts__['grains'] = __grains__
+    __utils__ = salt.loader.utils(__opts__)
+    __salt__ = salt.loader.minion_mods(__opts__, utils=__utils__)
+
+    os_codename, _, ceph_version = __utils__['status.get_sys_versions']()
+    # os_codename and ceph_version are pretty strings, e.g.:
+    # - SUSE Linux Enterprise Server 15 SP1
+    # - ceph version 14.2.1-468-g994fd9e0cc (994fd9e0cc[...]) nautilus (stable)
+    # (Unless a node is down, in which case they'll be "Unknown (node down?)"
+    # or "Not installed" if Ceph is not installed yet)
+
+    if len(set(os_codename.values())) == 1 and len(set(ceph_version.values())) == 1:
+        # OS version and ceph version are the same across the whole cluster
+        print("All nodes are running:")
+        print("  ceph: {}".format(next(iter(ceph_version.values()))))
+        print("  os: {}".format(next(iter(os_codename.values()))))
+        print("")
+        return True
+
+    # We've got different versions of base OS, or ceph, or both, so we need:
+    # - all the roles, to provide advice on what next to upgrade
+    # - the OS and ceph versions in an easily comparable form, to figure out
+    #   what's newest
+
+    down_nodes = [node for node in os_codename if os_codename[node].startswith("Unknown")]
+
+    search = "I@cluster:ceph"
+    if down_nodes:
+        search += " and not ( {} )".format("or ".join(down_nodes))
+
+    local = salt.client.LocalClient()
+    roles = local.cmd(search, 'pillar.get', ['roles'], tgt_type="compound")
+
+    os_release = local.cmd(search, 'grains.get', ['osrelease'], tgt_type="compound")
+    for node in os_release:
+        os_release[node] = version.parse(os_release[node])
+
+    ceph_release = {}
+    for node in ceph_version:
+        match = re.match(r'ceph version ([^\s]+)', ceph_version[node])
+        if match:
+            ceph_release[node] = version.parse(match.group(1))
+        else:
+            # If ceph_version is "Unknown" or "Not installed", this still gives
+            # a comparable version object, which sorts before actual versions
+            ceph_release[node] = version.parse(ceph_version[node])
+
+    # this max trick gives us the dict key of some host with the highest
+    # version, so we can use that to extract the pretty string from os_codename
+    # or ceph_version for display
+    newest_os = max(os_release, key=os_release.get)
+    newest_ceph = max(ceph_release, key=ceph_release.get)
+
+    print("The newest installed software versions are:")
+    print("  ceph: {}".format(ceph_version[newest_ceph]))
+    print("  os: {}".format(os_codename[newest_os]))
+    print("")
+
+    if len(set(os_codename.values())) > 1:
+        # If there's more than one operating system present, use the OS version as the
+        # basis for what to upgrade...
+        _print_nodes_to_upgrade(os_release, os_release[newest_os], roles)
+    else:
+        # ...otherwise, it's just the ceph version we care about
+        _print_nodes_to_upgrade(ceph_release, ceph_release[newest_ceph], roles)
+
+    if down_nodes:
+        print("Unable to contact these nodes (node down or Salt minion inactive?):")
+        for node in down_nodes:
+            print("  {}".format(node))
+        print("")
+
+    return ""
 
 
 __func_alias__ = {

--- a/srv/modules/utils/status.py
+++ b/srv/modules/utils/status.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 # vim: ts=8 et sw=4 sts=4
-
+"""
+Helper for upgrade.status and status.report runners
+"""
+from __future__ import absolute_import
 import salt.client
 
 
@@ -26,7 +29,9 @@ def get_sys_versions(cluster_name='ceph'):
         search += " and not ( {} )".format("or ".join(down_nodes))
 
     salt_version = local.cmd(search, 'grains.get', ['saltversion'], tgt_type="compound")
-    ceph_version = local.cmd(search, 'cmd.shell', ['test -e /usr/bin/ceph && ceph --version || echo "Not installed"'], tgt_type="compound")
+    ceph_version = local.cmd(search, 'cmd.shell',
+                             ['test -e /usr/bin/ceph && ceph --version || echo "Not installed"'],
+                             tgt_type="compound")
 
     # Better to indicate the node is down or inaccessible than just the bool False
     for node in down_nodes:

--- a/srv/modules/utils/status.py
+++ b/srv/modules/utils/status.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+# vim: ts=8 et sw=4 sts=4
+
+import salt.client
+
+
+def get_sys_versions(cluster_name='ceph'):
+    """
+    Query grains, run commands for current versions
+    """
+    local = salt.client.LocalClient()
+    search = "I@cluster:{}".format(cluster_name)
+    # grains might be inaccurate or not up to date because they are designed
+    # to hold static data about the minion. In case of an update though, the
+    # data will change.  grains are refreshed on reboot(restart of the service).
+    os_codename = local.cmd(search, 'grains.get', ['oscodename'], tgt_type="compound")
+    salt_version = local.cmd(search, 'grains.get', ['saltversion'], tgt_type="compound")
+    ceph_version = local.cmd(search, 'cmd.shell', ['ceph --version'], tgt_type="compound")
+    return os_codename, salt_version, ceph_version

--- a/srv/modules/utils/status.py
+++ b/srv/modules/utils/status.py
@@ -15,5 +15,5 @@ def get_sys_versions(cluster_name='ceph'):
     # data will change.  grains are refreshed on reboot(restart of the service).
     os_codename = local.cmd(search, 'grains.get', ['oscodename'], tgt_type="compound")
     salt_version = local.cmd(search, 'grains.get', ['saltversion'], tgt_type="compound")
-    ceph_version = local.cmd(search, 'cmd.shell', ['ceph --version'], tgt_type="compound")
+    ceph_version = local.cmd(search, 'cmd.shell', ['test -e /usr/bin/ceph && ceph --version || echo "Not installed"'], tgt_type="compound")
     return os_codename, salt_version, ceph_version

--- a/srv/modules/utils/status.py
+++ b/srv/modules/utils/status.py
@@ -14,6 +14,22 @@ def get_sys_versions(cluster_name='ceph'):
     # to hold static data about the minion. In case of an update though, the
     # data will change.  grains are refreshed on reboot(restart of the service).
     os_codename = local.cmd(search, 'grains.get', ['oscodename'], tgt_type="compound")
+
+    # If any nodes are down, the value of each item in the dict will be False.
+    # We can use this to modify the search string for the subsequent two calls,
+    # which will save 30 seconds of execution time (15 seconds per call) if any
+    # nodes are down.  So if any nodes are down, this function will take about
+    # 15 seconds to return (because the first search included down nodes), rather
+    # than 45 seconds (which is a very long time to stare at a blinking cursor)
+    down_nodes = [node for node in os_codename if not os_codename[node]]
+    if down_nodes:
+        search += " and not ( {} )".format("or ".join(down_nodes))
+
     salt_version = local.cmd(search, 'grains.get', ['saltversion'], tgt_type="compound")
     ceph_version = local.cmd(search, 'cmd.shell', ['test -e /usr/bin/ceph && ceph --version || echo "Not installed"'], tgt_type="compound")
+
+    # Better to indicate the node is down or inaccessible than just the bool False
+    for node in down_nodes:
+        os_codename[node] = salt_version[node] = ceph_version[node] = "Unknown (node down?)"
+
     return os_codename, salt_version, ceph_version


### PR DESCRIPTION
This is similar to status.report, but specifically intended to advise the user on what order to perform an upgrade in.  The underlying assumption is that the admin node has already been upgraded to the latest possible version.  Then, when you run `salt-run upgrade.status`, you'll see similar to one of the following:

1) If everything is the same version:

```
All nodes are running:
  ceph: ceph version 14.2.1-468-g994fd9e0cc (994fd9e0ccc50c2f3a55a3b7a3d4e0ba74786d50) nautilus (stable)
  os: SUSE Linux Enterprise Server 15 SP1
````

2) If there's a mix of versions:

```
The newest installed software versions are:
  ceph: ceph version 14.2.1-468-g994fd9e0cc (994fd9e0ccc50c2f3a55a3b7a3d4e0ba74786d50) nautilus (stable)
  os: SUSE Linux Enterprise Server 15 SP1

Nodes running these software versions:
  admin.ceph (roles: master)
  mon2.ceph (roles: admin, mon, mgr)

Nodes running older software versions must be upgraded in the following order:
   1: mon1.ceph (roles: admin, mon, mgr)
   2: mon3.ceph (roles: admin, mon, mgr)
   3: data1.ceph (roles: storage)
   4: data2.ceph (roles: storage)
   5: data3.ceph (roles: storage)
   6: data4.ceph (roles: storage)
   7: data5.ceph (roles: storage)
```

3) If there's a mix of versions and some node(s) are down (which could be becuase they're being upgraded at the time):

```
The newest installed software versions are:
  ceph: ceph version 14.2.1-468-g994fd9e0cc (994fd9e0ccc50c2f3a55a3b7a3d4e0ba74786d50) nautilus (stable)
  os: SUSE Linux Enterprise Server 15 SP1

Nodes running these software versions:
  admin.ceph (roles: master)
  mon2.ceph (roles: admin, mon, mgr)

Nodes running older software versions must be upgraded in the following order:
   1: mon3.ceph (roles: admin, mon, mgr)
   2: data1.ceph (roles: storage)
   3: data2.ceph (roles: storage)
   4: data3.ceph (roles: storage)
   5: data4.ceph (roles: storage)
   6: data5.ceph (roles: storage)

Unable to contact these nodes (node down or Salt minion inactive?):
  mon1.ceph
```

This PR notably does not yet include any unit tests, because I wanted to get feedback on the output and the behaviour first in case it turns out I have to change everything :-) and also on whether I should have just folded this into the existing `status.report` function somehow.

-----------------

**Checklist:**
- [ ] Added unittests and or functional tests
- [ ] Adapted documentation
- [ ] Referenced issues or internal bugtracker
- [ ] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
