### PR TITLE
Fixup rpmbuild in Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 setup.py
-deepsea.spec
 
 *.sw[pon]
 *~
@@ -35,7 +34,6 @@ wheels/
 #  Usually these files are written by a python script from a template
 #  before PyInstaller builds the exe, so as to inject date/other infos into it.
 *.manifest
-*.spec
 
 # Installer logs
 pip-log.txt

--- a/Makefile
+++ b/Makefile
@@ -995,8 +995,12 @@ $(RPMBUILD_DEPS):
 	$(PKG_INSTALL) $(RPMBUILD_REQUIRES)
 
 rpm: tarball $(RPMBUILD_DEPS)
-	sed '/^Version:/s/[^ ]*$$/'$(VERSION)'/' deepsea.spec.in > deepsea.spec
-	rpmbuild -bb deepsea.spec
+	$(eval _SOURCEDIR := $(shell rpm -E "%{_sourcedir}"))
+	$(eval _SPECDIR := $(shell rpm -E "%{_specdir}"))
+	mkdir -p $(_SOURCEDIR) $(_SPECDIR)
+	cp deepsea-$(VERSION).tar.bz2 $(_SOURCEDIR)
+	sed '/^Version:/s/[^ ]*$$/'$(VERSION)'/' deepsea.spec.in > $(_SPECDIR)/deepsea.spec
+	rpmbuild -ba $(_SPECDIR)/deepsea.spec
 
 $(TARBALL_DEPS):
 	$(PKG_INSTALL) $(TARBALL_DEPS)
@@ -1009,9 +1013,8 @@ tarball: $(TARBALL_DEPS)
 	sed "s/DEVVERSION/"$(VERSION)"/" $(TEMPDIR)/deepsea-$(VERSION)/setup.py.in > $(TEMPDIR)/deepsea-$(VERSION)/setup.py
 	sed "s/DEVVERSION/"$(VERSION)"/" $(TEMPDIR)/deepsea-$(VERSION)/deepsea.spec.in > $(TEMPDIR)/deepsea-$(VERSION)/deepsea.spec
 	sed -i "s/DEVVERSION/"$(VERSION)"/" $(TEMPDIR)/deepsea-$(VERSION)/srv/modules/runners/deepsea.py
-	mkdir -p ~/rpmbuild/SOURCES
 	cp $(TEMPDIR)/deepsea-$(VERSION)/setup.py .
-	tar -cjf ~/rpmbuild/SOURCES/deepsea-$(VERSION).tar.bz2 -C $(TEMPDIR) .
+	tar -cjf deepsea-$(VERSION).tar.bz2 -C $(TEMPDIR) .
 	rm -r $(TEMPDIR)
 
 test: setup.py

--- a/Makefile
+++ b/Makefile
@@ -975,18 +975,16 @@ copy-files:
 	-chown $(USER):$(GROUP) $(DESTDIR)/srv/salt/ceph/configuration/files/ceph.conf.checksum || true
 
 install-deps:
-	# Using '|| true' to suppress failure (packages already installed, etc)
-	([ -n "$(DEEPSEA_DEPS)" ] && $(PKG_INSTALL) $(DEEPSEA_DEPS)) || true
-	([ -n "$(PYTHON_DEPS)" ] && $(PKG_INSTALL) $(PYTHON_DEPS)) || true
+	([ -z "$(DEEPSEA_DEPS)" ] || $(PKG_INSTALL) $(DEEPSEA_DEPS))
+	([ -z "$(PYTHON_DEPS)" ] || $(PKG_INSTALL) $(PYTHON_DEPS))
 
 install: pyc install-deps copy-files
 	sed -i '/^sharedsecret: /s!{{ shared_secret }}!'`cat /proc/sys/kernel/random/uuid`'!' $(DESTDIR)/etc/salt/master.d/sharedsecret.conf
 	chown $(USER):$(GROUP) $(DESTDIR)/etc/salt/master.d/*
 	echo "deepsea_minions: '*'" > $(DESTDIR)/srv/pillar/ceph/deepsea_minions.sls
 	chown -R $(USER) $(DESTDIR)/srv/pillar/ceph
-	# Use '|| true' to suppress some error output in corner cases
 	systemctl restart salt-master
-	([ -n "$(SALT_API)" ] && systemctl restart $(SALT_API)) || true
+	([ -z "$(SALT_API)" ] || systemctl restart $(SALT_API))
 	# deepsea-cli
 	python$(PY_VER) setup.py install --root=$(DESTDIR)/
 

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,8 @@ PYTHON_DEPS=python${PY_VER}-setuptools python${PY_VER}-click python${PY_VER}-tox
 RPMBUILD_DEPS=rpm-build
 TARBALL_DEPS=bzip2 git tar
 
+SUDO=sudo --preserve-env
+
 OS=$(shell source /etc/os-release 2>/dev/null ; echo $$ID)
 suse=
 ifneq (,$(findstring opensuse,$(OS)))
@@ -977,7 +979,7 @@ copy-files:
 	-chown $(USER):$(GROUP) $(DESTDIR)/srv/salt/ceph/configuration/files/ceph.conf.checksum || true
 
 $(DEEPSEA_DEPS):
-	([ -z "$(DEEPSEA_DEPS)" ] || $(PKG_INSTALL) $(DEEPSEA_DEPS))
+	([ -z "$(DEEPSEA_DEPS)" ] || $(SUDO) $(PKG_INSTALL) $(DEEPSEA_DEPS))
 
 install: pyc $(DEEPSEA_DEPS) copy-files
 	sed -i '/^sharedsecret: /s!{{ shared_secret }}!'`cat /proc/sys/kernel/random/uuid`'!' $(DESTDIR)/etc/salt/master.d/sharedsecret.conf
@@ -990,9 +992,9 @@ install: pyc $(DEEPSEA_DEPS) copy-files
 	python$(PY_VER) setup.py install --root=$(DESTDIR)/
 
 $(RPMBUILD_DEPS):
-	$(PKG_INSTALL) $(RPMBUILD_DEPS)
+	$(SUDO) $(PKG_INSTALL) $(RPMBUILD_DEPS)
 	$(eval RPMBUILD_REQUIRES := $(shell rpmspec -q --srpm --requires deepsea.spec.in))
-	$(PKG_INSTALL) $(RPMBUILD_REQUIRES)
+	$(SUDO) $(PKG_INSTALL) $(RPMBUILD_REQUIRES)
 
 rpm: tarball $(RPMBUILD_DEPS)
 	$(eval _SOURCEDIR := $(shell rpm -E "%{_sourcedir}"))
@@ -1003,7 +1005,7 @@ rpm: tarball $(RPMBUILD_DEPS)
 	rpmbuild -ba $(_SPECDIR)/deepsea.spec
 
 $(TARBALL_DEPS):
-	$(PKG_INSTALL) $(TARBALL_DEPS)
+	$(SUDO) $(PKG_INSTALL) $(TARBALL_DEPS)
 
 # Removing test dependency until resolved
 tarball: $(TARBALL_DEPS)

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,8 @@ VERSION ?= $(shell (git describe --tags --long --match 'v*' 2>/dev/null || echo 
 SALT_API=salt-api
 PY_VER=3
 PYTHON_DEPS=python${PY_VER}-setuptools python${PY_VER}-click python${PY_VER}-tox python${PY_VER}-configobj
+RPMBUILD_DEPS=rpm-build
+TARBALL_DEPS=bzip2 git tar
 
 OS=$(shell source /etc/os-release 2>/dev/null ; echo $$ID)
 suse=
@@ -44,7 +46,7 @@ endif
 endif
 endif
 
-DEEPSEA_DEPS=${SALT_API}
+DEEPSEA_DEPS=$(SALT_API) $(PYTHON_DEPS)
 
 usage:
 	@echo "Usage:"
@@ -974,11 +976,10 @@ copy-files:
 	-chown $(USER):$(GROUP) $(DESTDIR)/srv/salt/ceph/rgw/cache || true
 	-chown $(USER):$(GROUP) $(DESTDIR)/srv/salt/ceph/configuration/files/ceph.conf.checksum || true
 
-install-deps:
+$(DEEPSEA_DEPS):
 	([ -z "$(DEEPSEA_DEPS)" ] || $(PKG_INSTALL) $(DEEPSEA_DEPS))
-	([ -z "$(PYTHON_DEPS)" ] || $(PKG_INSTALL) $(PYTHON_DEPS))
 
-install: pyc install-deps copy-files
+install: pyc $(DEEPSEA_DEPS) copy-files
 	sed -i '/^sharedsecret: /s!{{ shared_secret }}!'`cat /proc/sys/kernel/random/uuid`'!' $(DESTDIR)/etc/salt/master.d/sharedsecret.conf
 	chown $(USER):$(GROUP) $(DESTDIR)/etc/salt/master.d/*
 	echo "deepsea_minions: '*'" > $(DESTDIR)/srv/pillar/ceph/deepsea_minions.sls
@@ -988,12 +989,20 @@ install: pyc install-deps copy-files
 	# deepsea-cli
 	python$(PY_VER) setup.py install --root=$(DESTDIR)/
 
-rpm: tarball
+$(RPMBUILD_DEPS):
+	$(PKG_INSTALL) $(RPMBUILD_DEPS)
+	$(eval RPMBUILD_REQUIRES := $(shell rpmspec -q --srpm --requires deepsea.spec.in))
+	$(PKG_INSTALL) $(RPMBUILD_REQUIRES)
+
+rpm: tarball $(RPMBUILD_DEPS)
 	sed '/^Version:/s/[^ ]*$$/'$(VERSION)'/' deepsea.spec.in > deepsea.spec
 	rpmbuild -bb deepsea.spec
 
+$(TARBALL_DEPS):
+	$(PKG_INSTALL) $(TARBALL_DEPS)
+
 # Removing test dependency until resolved
-tarball:
+tarball: $(TARBALL_DEPS)
 	$(eval TEMPDIR := $(shell mktemp -d))
 	mkdir $(TEMPDIR)/deepsea-$(VERSION)
 	git archive HEAD | tar -x -C $(TEMPDIR)/deepsea-$(VERSION)
@@ -1010,3 +1019,5 @@ test: setup.py
 
 lint: setup.py
 	tox -e lint
+
+.PHONY: $(DEEPSEA_DEPS) $(TARBALL_DEPS) $(RPMBUILD_DEPS)


### PR DESCRIPTION
Description:

The 'make tarball' and 'make rpm' targets were failing in various ways when run as user 'root' and also when run as a 'non-root' user.

-----------------

**Checklist:**
- [ ] Added unittests and or functional tests
- [ ] Adapted documentation
- [ ] Referenced issues or internal bugtracker
- [ ] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
