### PR TITLE
Fix rpmbuild warnings

### DIFF
--- a/deepsea.spec.in
+++ b/deepsea.spec.in
@@ -130,7 +130,6 @@ systemctl try-restart salt-api > /dev/null 2>&1 || :
 %dir /srv/salt/ceph/configuration
 %dir /srv/salt/ceph/configuration/files
 %dir /srv/salt/ceph/configuration/files/ceph.conf.d
-%dir /srv/salt/ceph/configuration/files/ceph.conf.checksum
 %dir %attr(0700, salt, salt) /srv/salt/ceph/configuration/files/ceph.conf.checksum
 %dir /srv/salt/ceph/configuration/check
 %dir /srv/salt/ceph/configuration/create
@@ -472,7 +471,8 @@ systemctl try-restart salt-api > /dev/null 2>&1 || :
 %config /srv/salt/ceph/admin/files/*.j2
 %config /srv/salt/ceph/admin/key/*.sls
 %config /srv/salt/ceph/apparmor/*.sls
-%config /srv/salt/ceph/apparmor/files/*
+%config /srv/salt/ceph/apparmor/files/usr.bin.ceph-*
+%config /srv/salt/ceph/apparmor/files/usr.bin.radosgw
 %config /srv/salt/ceph/apparmor/files/ceph.d/*
 %config /srv/salt/ceph/apparmor/install/*
 %config /srv/salt/ceph/benchmarks/*.sls
@@ -801,9 +801,8 @@ orchestration completes.
 
 %files cli
 %{_bindir}/deepsea
-%{python3_sitelib}/deepsea/
+%{python3_sitelib}/deepsea
 %{python3_sitelib}/deepsea-%{version}-py%{python3_version}.egg-info
-%{python3_sitelib}/deepsea-%{version}-py%{python3_version}.egg-info/*
 
 %package qa
 Summary:        DeepSea integration test scripts


### PR DESCRIPTION
warning: File listed twice: /srv/salt/ceph/apparmor/files/ceph.d
warning: File listed twice: /srv/salt/ceph/apparmor/files/ceph.d/common
warning: File listed twice: /srv/salt/ceph/configuration/files/ceph.conf.checksum
warning: File listed twice: /usr/lib/python3.6/site-packages/deepsea-0.9.22+69.gf6d75310-py3.6.egg-info/PKG-INFO
warning: File listed twice: /usr/lib/python3.6/site-packages/deepsea-0.9.22+69.gf6d75310-py3.6.egg-info/SOURCES.txt
warning: File listed twice: /usr/lib/python3.6/site-packages/deepsea-0.9.22+69.gf6d75310-py3.6.egg-info/dependency_links.txt
warning: File listed twice: /usr/lib/python3.6/site-packages/deepsea-0.9.22+69.gf6d75310-py3.6.egg-info/entry_points.txt
warning: File listed twice: /usr/lib/python3.6/site-packages/deepsea-0.9.22+69.gf6d75310-py3.6.egg-info/top_level.txt

Signed-off-by: Michael Fritch <mfritch@suse.com>


-----------------

**Checklist:**
- [ ] Added unittests and or functional tests
- [ ] Adapted documentation
- [ ] Referenced issues or internal bugtracker
- [ ] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
