### PR TITLE
[SES6] Handle the apparmor disabled at boot scenario

### DIFF
--- a/srv/salt/ceph/apparmor/default-teardown.sls
+++ b/srv/salt/ceph/apparmor/default-teardown.sls
@@ -1,10 +1,14 @@
+aa-enabled:
+  cmd.run:
+    - onfail:
+      - test: apparmor
 
 aa-teardown:
   cmd.run:
     - onlyif:
       - which aa-teardown
 
-apparmor:
+stop apparmor:
   service.dead:
     - enable: False
 
@@ -13,3 +17,6 @@ uninstall apparmor:
     - pkgs:
       - apparmor
       - apparmor-utils
+
+apparmor:
+  test.nop


### PR DESCRIPTION
Adding apparmor=0 to grub.cfg causes aa-teardown to always fail

Signed-off-by: Eric Jackson <ejackson@suse.com>
bnc#1149405
-----------------

**Checklist:**
- [ ] Added unittests and or functional tests
- [ ] Adapted documentation
- [x] Referenced issues or internal bugtracker
- [ ] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
