### PR TITLE
Report malformed responses from misbehaving minions

### DIFF
--- a/srv/modules/runners/advise.py
+++ b/srv/modules/runners/advise.py
@@ -176,12 +176,16 @@ def _tidy(key, report):
     """
     line = ""
     for minion in sorted(report):
-        if report[minion][key]:
-            if len(minion) + len(", ".join(report[minion][key])) < 80:
-                line += "{}: {}\n".format(minion, ", ".join(sorted(report[minion][key])))
-            else:
-                line += "\n{}:\n  {}\n".format(minion, "\n  ".join(sorted(report[minion][key])))
+        if key in report[minion]:
+            if report[minion][key]:
+                if len(minion) + len(", ".join(report[minion][key])) < 80:
+                    line += "{}: {}\n".format(minion, ", ".join(sorted(report[minion][key])))
+                else:
+                    line += "\n{}:\n  {}\n".format(minion, "\n  ".join(sorted(report[minion][key])))
+        else:
+            log.warning("Ignoring malformed response from minion {}".format(minion))
     return line
+
 
 __func_alias__ = {
                  'help_': 'help',

--- a/tests/unit/runners/test_advise.py
+++ b/tests/unit/runners/test_advise.py
@@ -13,6 +13,12 @@ class TestAdvise():
         expected = "data1.ceph: /dev/sdb, /dev/sdc\n"
         assert result == expected
 
+    def test_tidy_malformed(self):
+        report = {'data1.ceph': {'': "nothing"}}
+        result = advise._tidy('unconfigured', report)
+        expected = ""
+        assert result == expected
+
     def test_tidy_long(self):
         report = {'data1.long.domain.name': 
                    {'unconfigured': 


### PR DESCRIPTION
Signed-off-by: Eric Jackson <ejackson@suse.com>
bnc#1145945
-----------------

**Checklist:**
- [x] Added unittests and or functional tests
- [ ] Adapted documentation
- [x] Referenced issues or internal bugtracker
- [ ] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
