### PR TITLE
[SES6] Prevent IOLoop error by calling Salt modules correctly

### DIFF
--- a/srv/salt/_modules/kernel.py
+++ b/srv/salt/_modules/kernel.py
@@ -32,11 +32,6 @@ import os
 log = logging.getLogger(__name__)
 
 try:
-    import salt.client
-except ImportError:
-    logging.error('Could not import salt.client')
-
-try:
     from salt.exceptions import CommandExecutionError
 except ImportError:
     logging.error('Could not import salt.exceptions')
@@ -57,11 +52,10 @@ def replace(**kwargs):
             for candidate in candidates:
                 log.debug("candidate: {}".format(candidate))
                 if re.match(candidate, package):
-                    caller = salt.client.Caller()
                     log.info("Removing: {}".format(candidate))
-                    ret = caller.cmd('pkg.remove', candidate)
+                    ret = __salt__['pkg.remove'](candidate)
                     log.info("Installing: {}".format(kernel))
-                    ret = caller.cmd('pkg.install', kernel)
+                    ret = __salt__['pkg.install'](kernel)
                     log.debug("ret: {}".format(ret))
                     return ret
         else:


### PR DESCRIPTION
Signed-off-by: Eric Jackson <ejackson@suse.com>
bnc#1123257
-----------------

**Checklist:**
- [ ] Added unittests and or functional tests
- [ ] Adapted documentation
- [x] Referenced issues or internal bugtracker
- [ ] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
