### PR TITLE
cephfs: fix pool creation prerequisite

### DIFF
--- a/srv/salt/ceph/mds/pools/default.sls
+++ b/srv/salt/ceph/mds/pools/default.sls
@@ -7,27 +7,29 @@ prevent empty rendering:
 
 {% else %}
 
+{# create cephfs_data pool iif it doesn't exist and no fs instance exists #}
 cephfs data:
   cmd.run:
-    - name: "ceph osd pool create cephfs_data 128"
-    - unless:
-      - "rados lspools | grep -q cephfs_data"
-      - "ceph fs ls | grep -q ^name"
+    - name: "ceph osd pool create cephfs_data 256"
+    - onlyif:
+      - 'test -z "$(rados lspools | grep cephfs_data)"'
+      - 'test -z "$(ceph fs ls | grep ^name)"'
 
 cephfs data pool enable application:
   cmd.run:
-    - name: "ceph osd pool application enable cephfs cephfs_data || :"
+    - name: "ceph osd pool application enable cephfs_data cephfs || :"
 
+{# create cephfs_metadata pool iif it doesn't exist and no fs instance exists #}
 cephfs metadata:
   cmd.run:
-    - name: "ceph osd pool create cephfs_metadata 128"
-    - unless:
-      - "rados lspools | grep -q cephfs_metadata"
-      - "ceph fs ls | grep -q ^name"
+    - name: "ceph osd pool create cephfs_metadata 64"
+    - onlyif:
+      - 'test -z "$(rados lspools | grep cephfs_metadata)"'
+      - 'test -z "$(ceph fs ls | grep ^name)"'
 
 cephfs metadata pool enable application:
   cmd.run:
-    - name: "ceph osd pool application enable cephfs cephfs_metadata || :"
+    - name: "ceph osd pool application enable cephfs_metadata cephfs || :"
 
 cephfs:
   cmd.run:


### PR DESCRIPTION
With unless the state is executed when one condition returns false. For
example it'll try to create the cephfs_data pool if the pool is present
but the cephfs instance is not yet.
Negating the condition and using onlyif yields the expected behaviour.

Signed-off-by: Jan Fajerski <jfajerski@suse.com>
(cherry picked from commit 8667b12adbd66a773e29cc7c59e97e496a586b05)

Backport for #1750 