### PR TITLE
iscsi: SSL enabled deployment by default

### DIFF
--- a/srv/modules/runners/changed.py
+++ b/srv/modules/runners/changed.py
@@ -11,6 +11,7 @@ from __future__ import print_function
 import os.path
 import hashlib
 import logging
+import glob
 # pylint: disable=import-error,3rd-party-module-not-gated
 import salt.client
 
@@ -36,7 +37,7 @@ class Role(object):
         self.conf_dir = kwargs.get('conf_dir', '/srv/salt/ceph/configuration/files/ceph.conf.d/')
         self.conf_filename = kwargs.get('conf_filename', self._role_name)
         self.conf_extension = kwargs.get('conf_extension', '.conf')
-        self._conf_files = [self.conf_dir + self.conf_filename + self.conf_extension]
+        self._conf_files = glob.glob(self.conf_dir + self.conf_filename + self.conf_extension)
         self._depends = [self]
         self.rgw_configurations()
 
@@ -291,9 +292,11 @@ def client():
 def igw():
     """
     Returns whether igw configuration has changed
-    Note: ceph-iscsi configuration is not kept in DeepSea
     """
-    return False
+    return requires_conf_change(role=Role(role_name='igw',
+                                          conf_dir='/srv/salt/ceph/igw/cache/',
+                                          conf_filename="iscsi-gateway.*",
+                                          conf_extension=".cfg"))
 
 
 def config(**kwargs):

--- a/srv/modules/runners/select.py
+++ b/srv/modules/runners/select.py
@@ -55,7 +55,14 @@ def _grain_host(client, minion):
     return list(client.cmd(minion, 'grains.item', ['host']).values())[0]['host']
 
 
-def minions(host=False, format='{}', **kwargs):
+def _grain_fqdn(client, minion):
+    """
+    Return the fqdn grain for a given minion
+    """
+    return list(client.cmd(minion, 'grains.item', ['fqdn']).values())[0]['fqdn']
+
+
+def minions(host=False, format='{}', fqdn=False, **kwargs):
     """
     Some targets needs to match all minions within a search criteria.
     """
@@ -83,6 +90,8 @@ def minions(host=False, format='{}', **kwargs):
     sys.stdout = _stdout
 
     if host:
+        if fqdn:
+            return sorted([format.format(_grain_fqdn(local, k)) for k in _minions.keys()])
         return sorted([format.format(_grain_host(local, k)) for k in _minions.keys()])
     return sorted([format.format(m) for m in _minions.keys()])
 

--- a/srv/salt/ceph/igw/config/apply_iscsi_config.sls
+++ b/srv/salt/ceph/igw/config/apply_iscsi_config.sls
@@ -7,7 +7,7 @@
     - mode: 600
     - fire_event: True
 
-{% if pillar.get('ceph_iscsi_ssl', False) %}
+{% if pillar.get('ceph_iscsi_ssl', True) %}
 
 /etc/ceph/iscsi-gateway.crt:
   file.managed:

--- a/srv/salt/ceph/igw/config/create_iscsi_config.sls
+++ b/srv/salt/ceph/igw/config/create_iscsi_config.sls
@@ -14,7 +14,7 @@
         trusted_ip_list: {{ ip_addresses }}
 {% endfor %}
 
-{% if pillar.get('ceph_iscsi_ssl', False) %}
+{% if pillar.get('ceph_iscsi_ssl', True) %}
 {% if pillar.get('ceph_iscsi_ssl_cert', None) and pillar.get('ceph_iscsi_ssl_key', None) %}
 
 /srv/salt/ceph/igw/cache/tls/certs/iscsi-gateway.crt:

--- a/srv/salt/ceph/igw/files/iscsi-gateway.cfg.j2
+++ b/srv/salt/ceph/igw/files/iscsi-gateway.cfg.j2
@@ -7,7 +7,7 @@ fqdn_enabled=true
 api_port = {{ pillar.get('ceph_iscsi_port', '5000') }}
 api_user = {{ pillar.get('ceph_iscsi_username', 'admin') }}
 api_password = {{ pillar.get('ceph_iscsi_password', 'admin') }}
-{% if pillar.get('ceph_iscsi_ssl', False) %}
+{% if pillar.get('ceph_iscsi_ssl', True) %}
 api_secure = true
 {% else %}
 api_secure = false

--- a/srv/salt/ceph/stage/deploy/core/default.sls
+++ b/srv/salt/ceph/stage/deploy/core/default.sls
@@ -67,7 +67,6 @@ configuration:
 {% set ret_client = salt['saltutil.runner']('changed.client') %}
 {% set ret_global = salt['saltutil.runner']('changed.global') %}
 {% set ret_mds = salt['saltutil.runner']('changed.mds') %}
-{% set ret_igw = salt['saltutil.runner']('changed.igw') %}
 
 admin:
   salt.state:

--- a/srv/salt/ceph/stage/iscsi/dashboard.sls
+++ b/srv/salt/ceph/stage/iscsi/dashboard.sls
@@ -1,0 +1,38 @@
+{% if salt.saltutil.runner('select.minions', cluster='ceph', roles='igw') %}
+
+{% set master = salt['master.minion']() %}
+
+{% set iscsi_username = pillar.get('ceph_iscsi_username', 'admin') %}
+{% set iscsi_password = pillar.get('ceph_iscsi_password', 'admin') %}
+{% set iscsi_port = pillar.get('ceph_iscsi_port', '5000') %}
+{% set iscsi_ssl = pillar.get('ceph_iscsi_ssl', True) %}
+
+remove iscsi gateways:
+  salt.function:
+    - name: cmd.run
+    - tgt: {{ master }}
+    - tgt_type: compound
+    - arg:
+      - "for i in `ceph dashboard iscsi-gateway-list | jq -r '.gateways | to_entries[].key'`; do ceph dashboard iscsi-gateway-rm $i; done"
+
+{% for igw_address in salt.saltutil.runner('select.minions', roles='igw', cluster='ceph', host=True, fqdn=True) %}
+
+{% if iscsi_ssl %}
+{% set iscsi_url = "https://" + iscsi_username + ":" + iscsi_password + "@" + igw_address + ":" + iscsi_port %}
+{% else %}
+{% set iscsi_url = "http://" + iscsi_username + ":" + iscsi_password + "@" + igw_address + ":" + iscsi_port %}
+{% endif %}
+
+add iscsi gateway {{ igw_address }} to dashboard:
+  salt.function:
+    - name: cmd.run
+    - tgt: {{ master }}
+    - tgt_type: compound
+    - arg:
+      - "ceph dashboard iscsi-gateway-add {{ iscsi_url }}"
+    - kwarg:
+        unless: ceph dashboard iscsi-gateway-list | jq .gateways | grep -q "{{ igw_address }}:{{ iscsi_port }}"
+
+{% endfor %}
+
+{% endif %}

--- a/srv/salt/ceph/stage/iscsi/default.sls
+++ b/srv/salt/ceph/stage/iscsi/default.sls
@@ -3,3 +3,4 @@ include:
   - .migrate
   - .core
   - ...restart.igw.lax
+  - .dashboard

--- a/tests/unit/runners/test_changed.py
+++ b/tests/unit/runners/test_changed.py
@@ -30,8 +30,10 @@ class TestChanged():
     @patch('os.path.exists', new=f_os.path.exists)
     @patch('builtins.open', new=f_open)
     @patch('srv.modules.runners.changed.hashlib')
-    def test_create_checksum(self, hashlib_mock, cfg, role):
+    @patch('glob.glob')
+    def test_create_checksum(self, glob_mock, hashlib_mock, cfg, role):
         fs.CreateFile("{}/{}".format(conf_dir, 'rgw.conf'), contents="foo=bar")
+        glob_mock.return_value = ["{}/{}".format(conf_dir, 'rgw.conf')]
         cfg = cfg(role=role(role_name='rgw'))
         ret = cfg.create_checksum()
         assert isinstance(ret, MagicMock) is True


### PR DESCRIPTION
Fixes: bsc#1134536

This PR makes the deployment of iscsi (ceph-iscsi) service to have SSL enabled by default for its REST API.

Signed-off-by: Ricardo Dias <rdias@suse.com>
