### PR TITLE
'make pyc' target should fail if unable to compile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,8 +64,8 @@ setup.py:
 
 pyc: setup.py
 	#make sure to create bytecode with the correct version
-	find srv/ -name '*.py' -exec python$(PY_VER) -m py_compile {} \;
-	find cli/ -name '*.py' -exec python$(PY_VER) -m py_compile {} \;
+	find srv/ -name '*.py' -exec python$(PY_VER) -m py_compile {} +
+	find cli/ -name '*.py' -exec python$(PY_VER) -m py_compile {} +
 
 copy-files:
 	# salt-master config files


### PR DESCRIPTION
Description:

The `make pyc` target was succeeding even though py_complie failed to generate valid bytecode:
```
# make pyc
#make sure to create bytecode with the correct version
find srv/ -name '*.py' -exec python3 -m py_compile {} \;
  File "srv/modules/runners/cmd.py", line 10
    undef run(**kwargs):
            ^
SyntaxError: invalid syntax

find cli/ -name '*.py' -exec python3 -m py_compile {} \;

# echo $?
0
```

This is also causing the `make install` target to succeed despite the failed `pyc` dependency.

New behavior of `make pyc` is as follows:
```
# make pyc
#make sure to create bytecode with the correct version
find srv/ -name '*.py' -exec python3 -m py_compile {} +
  File "srv/modules/runners/cmd.py", line 10
    undef run(**kwargs):
            ^
SyntaxError: invalid syntax

make: *** [Makefile:67: pyc] Error 1

# echo $?
2
```

-----------------

**Checklist:**
- [ ] Added unittests and or functional tests
- [ ] Adapted documentation
- [ ] Referenced issues or internal bugtracker
- [x] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
