### PR TITLE
[SES5] Restrict lsof to ceph user (performs better on some servers)

### DIFF
--- a/srv/salt/_modules/cephprocesses.py
+++ b/srv/salt/_modules/cephprocesses.py
@@ -173,7 +173,12 @@ def _process_map():
     Create a map of processes that have deleted files.
     """
     procs = []
-    proc1 = Popen(shlex.split('lsof '), stdout=PIPE)
+    try:
+      _ = pwd.getpwnam('ceph')
+    except KeyError:
+      return procs
+
+    proc1 = Popen(shlex.split('lsof -uceph'), stdout=PIPE)
     # pylint: disable=line-too-long
     proc2 = Popen(shlex.split("awk 'BEGIN {IGNORECASE = 1} /deleted/ {print $1 \" \" $2 \" \" $4}'"),
                   stdin=proc1.stdout, stdout=PIPE, stderr=PIPE)

--- a/tests/unit/_modules/test_cephprocesses.py
+++ b/tests/unit/_modules/test_cephprocesses.py
@@ -1,0 +1,11 @@
+import pytest
+from srv.salt._modules import cephprocesses
+
+from mock import patch, MagicMock
+
+@patch('pwd.getpwnam')
+def test_process_map(mock_pwd):
+    mock_pwd.side_effect = KeyError()
+    result = cephprocesses._process_map()
+    assert result == []
+


### PR DESCRIPTION
Signed-off-by: Eric Jackson <ejackson@suse.com>
bnc#1139168
-----------------

**Checklist:**
- [x] Added unittests and or functional tests
- [ ] Adapted documentation
- [x] Referenced issues or internal bugtracker
- [ ] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
