### PR TITLE
[SES5] Prevent IOLoop error by calling Salt modules correctly

### DIFF
--- a/srv/salt/_modules/kernel.py
+++ b/srv/salt/_modules/kernel.py
@@ -46,11 +46,10 @@ def replace(**kwargs):
             for candidate in candidates:
                 log.debug("candidate: {}".format(candidate))
                 if re.match(candidate, package):
-                    caller = salt.client.Caller()
                     log.info("Removing: {}".format(candidate))
-                    ret = caller.cmd('pkg.remove', candidate)
+                    ret = __salt__['pkg.remove'](candidate)
                     log.info("Installing: {}".format(kernel))
-                    ret = caller.cmd('pkg.install', kernel)
+                    ret = __salt__['pkg.install'](kernel)
                     log.debug("ret: {}".format(ret))
                     return ret
         else:


### PR DESCRIPTION
Signed-off-by: Eric Jackson <ejackson@suse.com>
Port: #1740 
-----------------

**Checklist:**
- [ ] Added unittests and or functional tests
- [ ] Adapted documentation
- [ ] Referenced issues or internal bugtracker
- [ ] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
