### PR TITLE
[SES5] Check that all OSDs are "in" during restart

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -784,6 +784,8 @@ copy-files:
 	install -m 644 srv/salt/ceph/wait/4hours/until/OK/*.sls $(DESTDIR)/srv/salt/ceph/wait/4hours/until/OK
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/wait/until/OK
 	install -m 644 srv/salt/ceph/wait/until/OK/*.sls $(DESTDIR)/srv/salt/ceph/wait/until/OK
+	install -d -m 755 $(DESTDIR)/srv/salt/ceph/wait/until/all_osds_in
+	install -m 644 srv/salt/ceph/wait/until/all_osds_in/*.sls $(DESTDIR)/srv/salt/ceph/wait/until/all_osds_in
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/wait/until/expired/30sec
 	install -m 644 srv/salt/ceph/wait/until/expired/30sec/*.sls $(DESTDIR)/srv/salt/ceph/wait/until/expired/30sec
 	# state files - check processes

--- a/deepsea.spec.in
+++ b/deepsea.spec.in
@@ -396,6 +396,7 @@ systemctl try-restart salt-api > /dev/null 2>&1 || :
 %dir /srv/salt/ceph/wait/4hours/until/OK
 %dir /srv/salt/ceph/wait/until
 %dir /srv/salt/ceph/wait/until/OK
+%dir /srv/salt/ceph/wait/until/all_osds_in
 %dir /srv/salt/ceph/wait/until/expired
 %dir /srv/salt/ceph/wait/until/expired/30sec
 %dir /srv/salt/ceph/warning
@@ -704,6 +705,7 @@ systemctl try-restart salt-api > /dev/null 2>&1 || :
 %config /srv/salt/ceph/wait/2hours/until/OK/*.sls
 %config /srv/salt/ceph/wait/4hours/until/OK/*.sls
 %config /srv/salt/ceph/wait/until/OK/*.sls
+%config /srv/salt/ceph/wait/until/all_osds_in/*.sls
 %config /srv/salt/ceph/wait/until/expired/30sec/*.sls
 %config /srv/salt/ceph/warning/*.sls
 %config /srv/salt/ceph/warning/noout/*.sls

--- a/srv/salt/ceph/restart/osd/default.sls
+++ b/srv/salt/ceph/restart/osd/default.sls
@@ -21,4 +21,11 @@
         - sls: ceph.osd.restart
         - failhard: True
 
+    wait for osds to be "in" Ceph on {{ host }}:
+      salt.state:
+        - tgt: {{ master }}
+        - tgt_type: compound
+        - sls: ceph.wait.until.all_osds_in
+        - failhard: True
+
 {% endfor %}

--- a/srv/salt/ceph/restart/osd/lax/default.sls
+++ b/srv/salt/ceph/restart/osd/lax/default.sls
@@ -21,4 +21,11 @@
         - sls: ceph.osd.restart
         - failhard: True
 
+    wait for osds to be "in" Ceph on {{ host }}:
+      salt.state:
+        - tgt: {{ master }}
+        - tgt_type: compound
+        - sls: ceph.wait.until.all_osds_in
+        - failhard: True
+
 {% endfor %}

--- a/srv/salt/ceph/wait/until/all_osds_in/default.sls
+++ b/srv/salt/ceph/wait/until/all_osds_in/default.sls
@@ -1,0 +1,7 @@
+wait for OSDs:
+ module.run:
+   - name: wait.until_all_osds_in
+   - kwargs:
+       'timeout': 300
+   - fire_event: True
+   - failhard: True

--- a/srv/salt/ceph/wait/until/all_osds_in/init.sls
+++ b/srv/salt/ceph/wait/until/all_osds_in/init.sls
@@ -1,0 +1,3 @@
+include:
+  - .{{ salt['pillar.get']('wait_until_all_osds_in', 'default') }}
+


### PR DESCRIPTION
Signed-off-by: Eric Jackson <swiftgist@gmail.com>
bnc:#1153310
-----------------

**Checklist:**
- [ ] Added unittests and or functional tests
- [ ] Adapted documentation
- [x] Referenced issues or internal bugtracker
- [ ] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
