### PR TITLE
[backport][SES6] 'make pyc' target should fail if unable to compile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,8 +52,8 @@ setup.py:
 
 pyc: setup.py
 	#make sure to create bytecode with the correct version
-	find srv/ -name '*.py' -exec $(PYTHON) -m py_compile {} \;
-	find cli/ -name '*.py' -exec $(PYTHON) -m py_compile {} \;
+	find srv/ -name '*.py' -exec $(PYTHON) -m py_compile {} +
+	find cli/ -name '*.py' -exec $(PYTHON) -m py_compile {} +
 
 copy-files:
 	# salt-master config files


### PR DESCRIPTION
Backport of #1770