### PR TITLE
[SES6] Evacutate OSDs simultaneously when removing OSDs

### DIFF
--- a/srv/salt/_modules/osd.py
+++ b/srv/salt/_modules/osd.py
@@ -516,6 +516,16 @@ def ceph_quiescent(**kwargs):
     return ceph_pgs.quiescent()
 
 
+def vacate(*args, **kwargs):
+    """
+    Set the weight to zero on a list of osds
+    """
+    results = {}
+    for osd_id in args:
+        results[osd_id] = zero_weight(osd_id, wait=False, **kwargs)
+    return results
+
+
 def zero_weight(osd_id, wait=True, **kwargs):
     """
     Set weight to zero and wait until PGs are moved
@@ -530,6 +540,16 @@ def zero_weight(osd_id, wait=True, **kwargs):
     if wait:
         return osdweight.wait()
     return ""
+
+
+def restore_weights(*args, **kwargs):
+    """
+    Restore the previous setting for a list of osds
+    """
+    results = {}
+    for osd_id in args:
+        results[osd_id] = restore_weight(osd_id, wait=False, **kwargs)
+    return results
 
 
 def restore_weight(osd_id, **kwargs):

--- a/tests/unit/runners/test_osd.py
+++ b/tests/unit/runners/test_osd.py
@@ -22,6 +22,7 @@ class TestOSDUtil():
                               lambda x, osd_id: None):
                 c = osd_module.OSDUtil('1')
                 c.osd_id = '1'
+                c.osd_list = ['1']
                 c.host = "dummy_host"
                 c.host_osds = {c.host: ['1', '2', '3', '4', '5']}
                 c.osd_state = dict(_in=osd_in, out=osd_out)
@@ -62,15 +63,15 @@ class TestOSDUtil():
             test_fix._delete_grain.assert_called_once_with(test_fix)
 
     @pytest.mark.parametrize("force", [True, False])
+    @patch('srv.modules.runners.osd.OSDUtil._is_empty', autospec=True)
     @patch('srv.modules.runners.osd.OSDUtil._lvm_zap', autospec=True)
     @patch('srv.modules.runners.osd.OSDUtil._delete_grain', autospec=True)
     @patch('srv.modules.runners.osd.OSDUtil._purge_osd', autospec=True)
-    @patch('srv.modules.runners.osd.OSDUtil._empty_osd', autospec=True)
     @patch('srv.modules.runners.osd.OSDUtil._service', autospec=True)
     @patch('srv.modules.runners.osd.OSDUtil._mark_osd', autospec=True)
-    def test_remove(self, mark_osd_mock, service_mock, is_empty_mock,
-                    purge_osd_mock, delete_grain_mock, lvm_zap_mock, force,
-                    test_fix):
+    def test_remove(self, mark_osd_mock, service_mock,
+                    purge_osd_mock, delete_grain_mock, lvm_zap_mock,
+                    is_empty_mock, force, test_fix):
         """
         Doesn't empty if force=True
         """
@@ -78,11 +79,11 @@ class TestOSDUtil():
         force = force
         test_fix = test_fix(operation=operation, force=force)
         test_fix.remove()
+        if not force:
+            test_fix._is_empty.assert_called_once()
         test_fix._mark_osd.assert_called_once_with(test_fix, 'out')
         test_fix._service.assert_called_with(test_fix, 'stop')
         test_fix._service.assert_any_call(test_fix, 'disable')
-        if not force:
-            test_fix._empty_osd.assert_called_once_with(test_fix)
         test_fix._purge_osd.assert_called_once_with(test_fix)
         test_fix._delete_grain.assert_called_once_with(test_fix)
 
@@ -98,33 +99,29 @@ class TestOSDUtil():
         'srv.modules.runners.osd.Util.master_minion',
         autospec=True,
         return_value="master_minion")
-    @patch(
-        'srv.modules.runners.osd.OSDUtil._wait_loop',
-        autospec=True,
-        return_value=True)
-    def test_is_empty(self, wait_loop, master_minion, test_fix):
+    def test_vacate_1(self, master_minion, test_fix):
         test_fix = test_fix()
-        test_fix._is_empty()
+        test_fix.local.cmd = Mock(return_value={'master_minion': {'1': ''}})
+        result = test_fix.vacate()
         test_fix.local.cmd.assert_called_once_with(
             "master_minion",
-            "osd.wait_until_empty", [test_fix.osd_id],
+            "osd.vacate", test_fix.osd_list,
             tgt_type='glob')
-        assert wait_loop.called is True
+        assert result == ['1']
 
     @patch(
         'srv.modules.runners.osd.Util.master_minion',
         autospec=True,
         return_value="master_minion")
-    @patch(
-        'srv.modules.runners.osd.OSDUtil._wait_loop',
-        autospec=True,
-        return_value=True)
-    def test_empty_osd(self, wait_loop, master_minion, test_fix):
+    def test_vacate_2(self, master_minion, test_fix):
         test_fix = test_fix()
-        test_fix._empty_osd()
+        test_fix.local.cmd = Mock(return_value={'master_minion': {'1': 'Error'}})
+        result = test_fix.vacate()
         test_fix.local.cmd.assert_called_once_with(
-            "master_minion", "osd.empty", [test_fix.osd_id], tgt_type='glob')
-        assert wait_loop.called is True
+            "master_minion",
+            "osd.vacate", test_fix.osd_list,
+            tgt_type='glob')
+        assert result == []
 
     @patch(
         'srv.modules.runners.osd.time.sleep', autospec=True, return_value=True)

--- a/tests/unit/runners/test_rebuild.py
+++ b/tests/unit/runners/test_rebuild.py
@@ -197,39 +197,39 @@ class TestRebuild():
     @patch('srv.modules.runners.rebuild.master_minion', autospec=True)
     @patch('salt.runner.Runner', autospec=True)
     @patch('salt.client.LocalClient', autospec=True)
-    def test_check_return(self, localclient, runner, mm):
+    def test_check_failed(self, localclient, runner, mm):
         rebuild.__opts__ = {}
 
         rr = rebuild.Rebuild(['data*.ceph'])
 
         ret = {0: True, 1:True}
-        result = rr._check_return(ret, 'data1.ceph')
+        result = rr._check_failed(ret, 'data1.ceph')
         assert result == False
         assert rr.skipped == []
 
     @patch('srv.modules.runners.rebuild.master_minion', autospec=True)
     @patch('salt.runner.Runner', autospec=True)
     @patch('salt.client.LocalClient', autospec=True)
-    def test_check_return_finds_failure(self, localclient, runner, mm):
+    def test_check_failed_finds_failure(self, localclient, runner, mm):
         rebuild.__opts__ = {}
 
         rr = rebuild.Rebuild(['data*.ceph'])
 
         ret = {0: False, 1:True}
-        result = rr._check_return(ret, 'data1.ceph')
+        result = rr._check_failed(ret, 'data1.ceph')
         assert result == True
         assert rr.skipped == ['data1.ceph']
 
     @patch('srv.modules.runners.rebuild.master_minion', autospec=True)
     @patch('salt.runner.Runner', autospec=True)
     @patch('salt.client.LocalClient', autospec=True)
-    def test_check_return_finds_error(self, localclient, runner, mm):
+    def test_check_failed_finds_error(self, localclient, runner, mm):
         rebuild.__opts__ = {}
 
         rr = rebuild.Rebuild(['data*.ceph'])
 
         ret = "An error message"
-        result = rr._check_return(ret, 'data1.ceph')
+        result = rr._check_failed(ret, 'data1.ceph')
         assert result == True
         assert rr.skipped == ['data1.ceph']
 
@@ -250,8 +250,8 @@ class TestRebuild():
         rr._busy_wait = mock.Mock()
         rr.runner.cmd = mock.Mock()
         rr.runner.cmd.return_value = {}
-        rr._check_return = mock.Mock()
-        rr._check_return.return_value = False
+        rr._check_failed = mock.Mock()
+        rr._check_failed.return_value = False
         rr._skipped_summary = mock.Mock()
 
         result = rr.run()
@@ -259,7 +259,7 @@ class TestRebuild():
         assert rr._osd_list.called
         assert rr.safe.called
         assert rr.runner.cmd.called
-        assert rr._check_return.called
+        assert rr._check_failed.called
         assert rr._skipped_summary.called
 
     @patch('srv.modules.runners.rebuild.master_minion', autospec=True)
@@ -279,16 +279,16 @@ class TestRebuild():
         rr._busy_wait = mock.Mock()
         rr.runner.cmd = mock.Mock()
         rr.runner.cmd.return_value = {}
-        rr._check_return = mock.Mock()
-        rr._check_return.return_value = False
+        rr._check_failed = mock.Mock()
+        rr._check_failed.return_value = False
         rr._skipped_summary = mock.Mock()
 
         result = rr.run()
         assert result == ""
         assert rr._osd_list.call_count == 2
         assert rr.safe.call_count == 2
-        assert rr.runner.cmd.call_count == 6
-        assert rr._check_return.call_count == 4
+        assert rr.runner.cmd.call_count == 4
+        assert rr._check_failed.call_count == 2
         assert rr._skipped_summary.called
 
     @patch('srv.modules.runners.rebuild.master_minion', autospec=True)
@@ -307,8 +307,8 @@ class TestRebuild():
         rr.safe.return_value = True
         rr.runner.cmd = mock.Mock()
         rr.runner.cmd.return_value = {}
-        rr._check_return = mock.Mock()
-        rr._check_return.return_value = False
+        rr._check_failed = mock.Mock()
+        rr._check_failed.return_value = False
         rr._skipped_summary = mock.Mock()
 
         result = rr.run(checkonly=True)
@@ -316,7 +316,7 @@ class TestRebuild():
         assert rr._osd_list.called
         assert rr.safe.called
         assert rr.runner.cmd.called is False
-        assert rr._check_return.called is False
+        assert rr._check_failed.called is False
         assert rr._skipped_summary.called
 
     @patch('srv.modules.runners.rebuild.master_minion', autospec=True)
@@ -335,8 +335,8 @@ class TestRebuild():
         rr.safe.return_value = True
         rr.runner.cmd = mock.Mock()
         rr.runner.cmd.return_value = {}
-        rr._check_return = mock.Mock()
-        rr._check_return.return_value = False
+        rr._check_failed = mock.Mock()
+        rr._check_failed.return_value = False
         rr._skipped_summary = mock.Mock()
 
         result = rr.run()
@@ -344,7 +344,7 @@ class TestRebuild():
         assert rr._osd_list.called is False
         assert rr.safe.called is False
         assert rr.runner.cmd.called is False
-        assert rr._check_return.called is False
+        assert rr._check_failed.called is False
         assert rr._skipped_summary.called is False
 
     @patch('srv.modules.runners.rebuild.master_minion', autospec=True)
@@ -363,8 +363,8 @@ class TestRebuild():
         rr.safe.return_value = True
         rr.runner.cmd = mock.Mock()
         rr.runner.cmd.return_value = {}
-        rr._check_return = mock.Mock()
-        rr._check_return.return_value = False
+        rr._check_failed = mock.Mock()
+        rr._check_failed.return_value = False
         rr._skipped_summary = mock.Mock()
 
         result = rr.run()
@@ -372,7 +372,7 @@ class TestRebuild():
         assert rr._osd_list.called
         assert rr.safe.called is False
         assert rr.runner.cmd.called
-        assert rr._check_return.called is False
+        assert rr._check_failed.called is False
         assert rr._skipped_summary.called
 
     @patch('srv.modules.runners.rebuild.master_minion', autospec=True)
@@ -391,8 +391,8 @@ class TestRebuild():
         rr.safe.return_value = False
         rr.runner.cmd = mock.Mock()
         rr.runner.cmd.return_value = {}
-        rr._check_return = mock.Mock()
-        rr._check_return.return_value = False
+        rr._check_failed = mock.Mock()
+        rr._check_failed.return_value = False
         rr._skipped_summary = mock.Mock()
 
         result = rr.run()
@@ -400,7 +400,7 @@ class TestRebuild():
         assert rr._osd_list.called
         assert rr.safe.called
         assert rr.runner.cmd.called is False
-        assert rr._check_return.called is False
+        assert rr._check_failed.called is False
         assert rr._skipped_summary.called is False
 
     @patch('srv.modules.runners.rebuild.master_minion', autospec=True)
@@ -420,8 +420,8 @@ class TestRebuild():
         rr._busy_wait = mock.Mock()
         rr.runner.cmd = mock.Mock()
         rr.runner.cmd.return_value = {}
-        rr._check_return = mock.Mock()
-        rr._check_return.return_value = True
+        rr._check_failed = mock.Mock()
+        rr._check_failed.return_value = True
         rr._skipped_summary = mock.Mock()
 
         result = rr.run()
@@ -429,7 +429,7 @@ class TestRebuild():
         assert rr._osd_list.called
         assert rr.safe.called
         assert rr.runner.cmd.called
-        assert rr._check_return.called
+        assert rr._check_failed.called
         assert rr._skipped_summary.called
 
 


### PR DESCRIPTION
Signed-off-by: Eric Jackson <swiftgist@gmail.com>
bnc: 1154096
-----------------

**Checklist:**
- [x] Added unittests and or functional tests
- [ ] Adapted documentation
- [x] Referenced issues or internal bugtracker
- [ ] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
