### PR TITLE
[next] Refine the runner function decorator

### DIFF
--- a/srv/modules/runners/ext_lib/decorators.py
+++ b/srv/modules/runners/ext_lib/decorators.py
@@ -36,12 +36,13 @@ def catches(catch=None, called_by_orch=False, called_by_runner=False):
         @wraps(f)
         def newfunc(*a, **kw):
             try:
-                return f(*a, **kw)
+                results = f(*a, **kw)
             except catch as e:
 
                 # TODO: eval
                 if os.environ.get('IS_THIS_SOMETHING_FOR_US?'):
                     raise
+
                 if isinstance(e, RunnerException) or isinstance(
                         e, ModuleException):
                     if kw.get('called_by_orch', called_by_orch):
@@ -52,15 +53,22 @@ def catches(catch=None, called_by_orch=False, called_by_runner=False):
                         print(e.output_for_human())
                     return humanize_return(False)
 
+                # if we don't know what the Exceptions are
+                # we should just raise them
+                raise
+
             else:
                 if kw.get('called_by_runner', called_by_runner):
                     # This needs an aggregated result from the TODO above
-                    return result, data
+                    return results
                 if kw.get('called_by_orch', called_by_orch):
                     # what does the orchestrator expect. We can pass whatever we need here
-                    return result, data
+                    return results
 
-                return humanize_return(result)
+                return humanize_return(all(results))
+
+            finally:
+                pass
 
         return newfunc
 

--- a/srv/modules/runners/ext_lib/exceptions.py
+++ b/srv/modules/runners/ext_lib/exceptions.py
@@ -10,10 +10,10 @@ class ModuleException(Exception):
         ]
 
     def output_for_orchestrator(self):
-        return f"Caught an Exception while running <dummy>."
+        return f"Caught an Exception while running <dummy>.(ment for orchestrator)"
 
     def output_for_human(self):
-        return f"Caught an Exception while running <dummy>."
+        return f"Caught an Exception while running <dummy>.(ment for a human)"
 
     def __str__(self):
         return f"Insert some nice data from self.data : {self.result}"
@@ -28,7 +28,7 @@ class RunnerException(Exception):
         self.msg = msg or 'Default error message'
 
     def output_for_orchestrator(self):
-        return f"Caught an Exception in runner {self.cmd}"
+        return f"Caught an Exception in runner {self.cmd} (ment for orchestrator)"
 
     def output_for_human(self):
-        return f"Caught an Exception in runner {self.cmd}"
+        return f"Caught an Exception in runner {self.cmd} (ment for a human)"

--- a/srv/modules/runners/ext_lib/utils.py
+++ b/srv/modules/runners/ext_lib/utils.py
@@ -220,14 +220,22 @@ def humanize_return(inp):
     return 'failure'
 
 
-def exec_runner(cmd, cmd_args):
+def exec_runner(cmd, cmd_args=[], failhard=True):
     # This must always include `machine=True` to get
     # a tuple as return
+    cmd_args.append('called_by_runner=True')
+
     ret = runner().cmd(cmd, cmd_args)
-    if isinstance(ret, tuple):
+    if isinstance(ret, list):
+        # we get a list of return values back [True, True]
+        # pretty useless at that point..
         return ret
     if isinstance(ret, str):
         # We may be a bit more specific and search for *which* Exception was raised.
         if ret.startswith('Exception occurred in runner'):
-            raise RunnerException(cmd)
+            if failhard:
+                raise RunnerException(cmd)
+            # TODO:
+            # What to do in the failhard=False case?
+            pass
     #TODO else

--- a/srv/modules/runners/test.py
+++ b/srv/modules/runners/test.py
@@ -86,13 +86,13 @@ def good(non_interactive=False, called_by_runner=False, called_by_orch=False):
     # maybe we should collect the 'data' var aswell..
     results.append(result)
 
-    # TODO: have success returns for orch and runners aswell.
-    return humanize_return(all(results))
+    return results
 
 
 @catches(ModuleException)
 def bad(called_by_runner=False, called_by_orch=False):
-    # This is a module call behind the scene
+    results = list()
+
 
     result, data = exec_module(
         module='keyring',
@@ -101,6 +101,9 @@ def bad(called_by_runner=False, called_by_orch=False):
         arguments=['admin'])
         # TODO:
         # kwargs implementation is missing
+    results.append(result)
+
+    return results
 
 
 @catches(RunnerException)
@@ -112,13 +115,19 @@ def runner_calls_runner(called_by_runner=False, called_by_orch=False):
     """
     # This is a runner that calls a module behind the scene
 
+    results = list()
+
     #                                        this can be offloaded to exec_runner
-    result, data = exec_runner('test.good', ['called_by_runner=True'])
-    result, data = exec_runner('test.bad', ['called_by_runner=True'])
-    result, data = exec_runner('test.good', ['called_by_runner=True'])
+    result, data = exec_runner('test.good')
+    results.append(result)
+    result, data = exec_runner('test.bad')
+    results.append(result)
+    result, data = exec_runner('test.good')
+    results.append(result)
+
+    return results
 
 @catches(RunnerException)
 def runner_calls_runner_calls_runner(called_by_runner=False,
                                      called_by_orch=False):
-    result, data = exec_runner('test.runner_calls_runner',
-                                ['called_by_runner=True'])
+    result, data = exec_runner('test.runner_calls_runner')


### PR DESCRIPTION
This will not only handle the Exception case but also
return the correct values based on the context (orchestrator, runner)


This allows us to have consistent behavior independent of whether we are calling a runner or a module underneath.

We have three modes:

`human` (default)

We're returning the aggregated results in a  human readable form (success/failure)

----------------------

`orchestrator`

We're returning a datastructure of our choice (current this returns a list of returnvalues, which is not *terribly* insightful). We can adapt this returnvalue anytime when we have real requirements from the orchestrator.

----------------------

`runner`

That's for internal uses only. This will re-raise the Exception in form of a str when an isssue is encountered.
If it succeeds it will currently just print an aggregated list of  returnvalues.



## click  below to see all possible cases
<details>
  <summary>click me</summary>
 
```

admin:/srv/salt/_modules/ext_lib/c-d # salt-run test.good
keyring.mon on admin: success
keyring.mon on mon3: success
keyring.mon on mon1: success
keyring.mon on mon2: success
success

admin:/srv/salt/_modules/ext_lib/c-d # salt-run test.good called_by_orch=True
keyring.mon on admin: success
keyring.mon on mon1: success
keyring.mon on mon3: success
keyring.mon on mon2: success
- True
- True

admin:/srv/salt/_modules/ext_lib/c-d # salt-run test.bad
keyring.mon_failure on mon2: failure
No such file or directory: 'ceph-daemon'
keyring.mon_failure on mon1: failure
No such file or directory: 'ceph-daemon'
keyring.mon_failure on mon3: failure
No such file or directory: 'ceph-daemon'
Caught an Exception while running <dummy>.(ment for a human)
failure 

admin:/srv/salt/_modules/ext_lib/c-d # salt-run test.bad called_by_orch=True
keyring.mon_failure on mon3: failure
No such file or directory: 'ceph-daemon'
keyring.mon_failure on mon1: failure
No such file or directory: 'ceph-daemon'
keyring.mon_failure on mon2: failure
No such file or directory: 'ceph-daemon'
Caught an Exception while running <dummy>.(ment for orchestrator)

admin:/srv/salt/_modules/ext_lib/c-d # salt-run test.bad called_by_runner=True
keyring.mon_failure on mon3: failure
No such file or directory: 'ceph-daemon'
keyring.mon_failure on mon1: failure
No such file or directory: 'ceph-daemon'
keyring.mon_failure on mon2: failure
No such file or directory: 'ceph-daemon'
Exception occurred in runner test.bad: Traceback (most recent call last):
  File "/usr/lib/python3.6/site-packages/salt/client/mixins.py", line 377, in low
    data['return'] = func(*args, **kwargs)
  File "/srv/modules/runners/ext_lib/decorators.py", line 39, in newfunc
    results = f(*a, **kw)
  File "/srv/modules/runners/test.py", line 101, in bad
    arguments=['admin'])
  File "/srv/modules/runners/ext_lib/operation.py", line 22, in exec_module
    raise ModuleException(False, ret)
ext_lib.exceptions.ModuleException: Insert some nice data from self.data : False

admin:/srv/salt/_modules/ext_lib/c-d # salt-run test.good called_by_runner=True
keyring.mon on admin: success
keyring.mon on mon2: success
keyring.mon on mon3: success
keyring.mon on mon1: success
- True
- True

admin:/srv/salt/_modules/ext_lib/c-d # salt-run test.runner_calls_runner
keyring.mon on admin: success
keyring.mon on mon3: success
keyring.mon on mon2: success
keyring.mon on mon1: success
keyring.mon_failure on mon3: failure
No such file or directory: 'ceph-daemon'
keyring.mon_failure on mon1: failure
No such file or directory: 'ceph-daemon'
keyring.mon_failure on mon2: failure
No such file or directory: 'ceph-daemon'
Caught an Exception in runner test.bad (ment for a human)
failure 

admin:/srv/salt/_modules/ext_lib/c-d # salt-run test.runner_calls_runner called_by_orch=True
keyring.mon on admin: success
keyring.mon on mon2: success
keyring.mon on mon3: success
keyring.mon on mon1: success
keyring.mon_failure on mon1: failure
No such file or directory: 'ceph-daemon'
keyring.mon_failure on mon2: failure
No such file or directory: 'ceph-daemon'
keyring.mon_failure on mon3: failure
No such file or directory: 'ceph-daemon'
Caught an Exception in runner test.bad (ment for orchestrator)

admin:/srv/salt/_modules/ext_lib/c-d # salt-run test.runner_calls_runner called_by_runner=True
keyring.mon on admin: success
keyring.mon on mon2: success
keyring.mon on mon1: success
keyring.mon on mon3: success
keyring.mon_failure on mon3: failure
No such file or directory: 'ceph-daemon'
keyring.mon_failure on mon1: failure
No such file or directory: 'ceph-daemon'
keyring.mon_failure on mon2: failure
No such file or directory: 'ceph-daemon'
Exception occurred in runner test.runner_calls_runner: Traceback (most recent call last):
  File "/usr/lib/python3.6/site-packages/salt/client/mixins.py", line 377, in low
    data['return'] = func(*args, **kwargs)
  File "/srv/modules/runners/ext_lib/decorators.py", line 39, in newfunc
    results = f(*a, **kw)
  File "/srv/modules/runners/test.py", line 123, in runner_calls_runner
    result, data = exec_runner('test.bad')
  File "/srv/modules/runners/ext_lib/utils.py", line 237, in exec_runner
    raise RunnerException(cmd)
ext_lib.exceptions.RunnerException: test.bad

admin:/srv/salt/_modules/ext_lib/c-d # salt-run test.runner_calls_runner_calls_runner
keyring.mon on admin: success
keyring.mon on mon1: success
keyring.mon on mon3: success
keyring.mon on mon2: success
keyring.mon_failure on mon3: failure
No such file or directory: 'ceph-daemon'
keyring.mon_failure on mon1: failure
No such file or directory: 'ceph-daemon'
keyring.mon_failure on mon2: failure
No such file or directory: 'ceph-daemon'
Caught an Exception in runner test.runner_calls_runner (ment for a human)
failure

admin:/srv/salt/_modules/ext_lib/c-d # salt-run test.runner_calls_runner_calls_runner called_by_orch=True
keyring.mon on admin: success
keyring.mon on mon3: success
keyring.mon on mon1: success
keyring.mon on mon2: success
keyring.mon_failure on mon3: failure
No such file or directory: 'ceph-daemon'
keyring.mon_failure on mon1: failure
No such file or directory: 'ceph-daemon'
keyring.mon_failure on mon2: failure
No such file or directory: 'ceph-daemon'
Caught an Exception in runner test.runner_calls_runner (ment for orchestrator)

admin:/srv/salt/_modules/ext_lib/c-d # salt-run test.runner_calls_runner_calls_runner called_by_runner=True
keyring.mon on admin: success
keyring.mon on mon2: success
keyring.mon on mon1: success
keyring.mon on mon3: success
keyring.mon_failure on mon2: failure
No such file or directory: 'ceph-daemon'
keyring.mon_failure on mon3: failure
No such file or directory: 'ceph-daemon'
keyring.mon_failure on mon1: failure
No such file or directory: 'ceph-daemon'
Exception occurred in runner test.runner_calls_runner_calls_runner: Traceback (most recent call last):
  File "/usr/lib/python3.6/site-packages/salt/client/mixins.py", line 377, in low
    data['return'] = func(*args, **kwargs)
  File "/srv/modules/runners/ext_lib/decorators.py", line 39, in newfunc
    results = f(*a, **kw)
  File "/srv/modules/runners/test.py", line 133, in runner_calls_runner_calls_runner
    result, data = exec_runner('test.runner_calls_runner')
  File "/srv/modules/runners/ext_lib/utils.py", line 237, in exec_runner
    raise RunnerException(cmd)
ext_lib.exceptions.RunnerException: test.runner_calls_runner


```

</details>



Signed-off-by: Joshua Schmid <jschmid@suse.de>


