### PR TITLE
[next] Extend the demo runner (test.py) with interactive prompts

### DIFF
--- a/srv/modules/runners/config.py
+++ b/srv/modules/runners/config.py
@@ -236,8 +236,9 @@ def deploy_salt_conf():
     return False
 
 
-def deploy_roles():
+def deploy_roles(**kwargs):
     ''' Creates role assignments '''
+
     policy = Policy()
     if not policy.load():
         log.error(policy.error)
@@ -257,7 +258,7 @@ def deploy_roles():
     return True
 
 
-def deploy_global():
+def deploy_global(**kwargs):
     ''' Creates initial global configuration '''
     dsg = DeepSeaGlobal()
     if dsg.absent():

--- a/srv/modules/runners/ext_lib/decorators.py
+++ b/srv/modules/runners/ext_lib/decorators.py
@@ -1,11 +1,20 @@
 from functools import wraps
-from .exceptions import ModuleException, RunnerException
+from .exceptions import ModuleException, RunnerException, NoMinionsFound, AbortedByUser
 from .utils import humanize_return
+from .hash_dir import module_questioneer, pillar_questioneer
 import os
 
 
-def catches(catch=None, called_by_orch=False, called_by_runner=False):
+def catches(catch=None,
+            non_interactive=False,
+            called_by_orch=False,
+            called_by_runner=False,
+            refresh_pillar=True,
+            refresh_modules=True):
     """
+    This decorator was shamelessly stolen from ceph/ceph's ceph-volume
+    and adapted for DeepSea's need.
+
     Very simple decorator that tries any of the exception(s) passed in as
     a single exception class or tuple (containing multiple ones) returning the
     exception message and optionally handling the problem if it rises with the
@@ -35,26 +44,48 @@ def catches(catch=None, called_by_orch=False, called_by_runner=False):
     def decorate(f):
         @wraps(f)
         def newfunc(*a, **kw):
+            # TODO: properly assign defaults from the function signature
+            non_interactive = kw.get('non_interactive', False)
+            called_by_orch = kw.get('called_by_orch', False)
+            called_by_runner = kw.get('called_by_runner', False)
+
+            if called_by_runner or called_by_orch:
+                # Implicitly setting non_interactive=True
+                # when called with those contexts
+                non_interactive = True
+
+            if refresh_modules:
+                sync_modules(non_interactive)
+            if refresh_pillar:
+                sync_pillar(non_interactive)
+
             try:
                 results = f(*a, **kw)
             except catch as e:
 
-                # TODO: eval
-                if os.environ.get('IS_THIS_SOMETHING_FOR_US?'):
-                    raise
+                # debug
+                if os.environ.get('DEEPSEA_DEBUG'):
+                    # Useful for unexpected Exceptions that need to be analyzed post mortem
+                    # https://docs.python.org/3.7/library/pdb.html#pdb.post_mortem
+                    import pdb
+                    pdb.post_mortem(e.__traceback__)
 
+                # aborted by user
+                if isinstance(e, AbortedByUser):
+                    return 'aborted by user.'
+
+                # Known errors
                 if isinstance(e, RunnerException) or isinstance(
-                        e, ModuleException):
-                    if kw.get('called_by_orch', called_by_orch):
+                        e, ModuleException) or isinstance(e, NoMinionsFound):
+                    if called_by_orch:
                         return e.output_for_orchestrator()
-                    elif kw.get('called_by_runner', called_by_runner):
+                    elif called_by_runner:
                         raise
                     else:
                         print(e.output_for_human())
                     return humanize_return(False)
 
-                # if we don't know what the Exceptions are
-                # we should just raise them
+                # if we don't know about the Exception are should just raise them
                 raise
 
             else:
@@ -73,3 +104,10 @@ def catches(catch=None, called_by_orch=False, called_by_runner=False):
         return newfunc
 
     return decorate
+
+
+def sync_modules(non_interactive):
+    module_questioneer(non_interactive=non_interactive)
+
+def sync_pillar(non_interactive):
+    pillar_questioneer(non_interactive=non_interactive)

--- a/srv/modules/runners/ext_lib/exceptions.py
+++ b/srv/modules/runners/ext_lib/exceptions.py
@@ -19,6 +19,49 @@ class ModuleException(Exception):
         return f"Insert some nice data from self.data : {self.result}"
 
 
+class AbortedByUser(Exception):
+
+    def __init__(self, answer):
+        self.answer =  answer
+
+    def __repr__(self):
+        return f"Aborted by user with answer {self.answer}"
+
+class NoMinionsFound(Exception):
+    def __init__(self, result, target, module, function, tgt_type):
+        self.result = result
+        self.target = target
+        self.module = module
+        self.function = function
+        self.tgt_type = tgt_type
+
+    def _prefix(self):
+        if self.tgt_type == 'pillar':
+            return "-I"
+        if self.tgt_type == 'compound':
+            return ""
+        if self.tgt_type == 'grain':
+            return "-G"
+
+    @property
+    def guide(self):
+        return f"""
+This is usally due to a wrong pillar configuration. Please verify if
+the targeted role is assigned to any hosts. Verify it with:
+
+salt {self._prefix()} {self.target} test.true
+        """
+
+    def output_for_orchestrator(self):
+        return f"{self.module}.{self.function} failed. Can't find minions assigned to role {self.target} (ment for orchestrator)"
+
+    def output_for_human(self):
+        return f"{self.module}.{self.function} failed. Can't find minions assigned to role {self.target} (ment for human)\n{self.guide}"
+
+    def __str__(self):
+        return f"NoMinionsFound<{self.target}>"
+
+
 class RunnerException(Exception):
     """ Runner command failed """
 

--- a/srv/modules/runners/ext_lib/hash_dir.py
+++ b/srv/modules/runners/ext_lib/hash_dir.py
@@ -3,18 +3,23 @@ import os
 from pathlib import Path
 import salt.client
 import logging
-from .utils import prompt, run_and_eval
+from .utils import prompt, exec_runner
 
 
 def update_pillar(directory, checksum):
     local_client = salt.client.LocalClient()
     print('Updating the pillar')
 
-    run_and_eval('config.deploy_roles')
+    # TODO: eval return
+    result = exec_runner('config.deploy_roles')
 
     ret: str = local_client.cmd(
         # TODO: target deepsea_minions
-        "*", 'saltutil.refresh_pillar', tgt_type='glob')
+        "*",
+        'saltutil.refresh_pillar',
+        tgt_type='glob')
+
+
 
     print("Updating the directory's checksum")
     update_md5(directory, checksum)
@@ -26,7 +31,9 @@ def sync_modules(directory, checksum):
     print('Updating the modules')
     ret: str = local_client.cmd(
         # TODO: target deepsea_minions
-        "*", 'saltutil.sync_modules', tgt_type='glob')
+        "*",
+        'saltutil.sync_modules',
+        tgt_type='glob')
     print("Updating the directory's checksum")
     update_md5(directory, checksum)
     print("Salt modules are up to date.")
@@ -84,7 +91,7 @@ def minion_modules_have_changes(directory, checksum_path):
     return False
 
 
-def pillar_questioneer(non_interactive=False):
+def pillar_questioneer(non_interactive=False, **kwargs):
     directory = '/srv/pillar/ceph'
     checksum_path = f'{directory}/.md5.save'
     if pillar_has_changes(directory, checksum_path):
@@ -101,7 +108,7 @@ def pillar_questioneer(non_interactive=False):
             )
 
 
-def module_questioneer(non_interactive=False):
+def module_questioneer(non_interactive=False, **kwargs):
     directory = '/srv/salt/_modules'
     checksum_path = '/srv/salt/ceph/.modules.md5.save'
     if minion_modules_have_changes(directory, checksum_path):

--- a/srv/modules/runners/ext_lib/operation.py
+++ b/srv/modules/runners/ext_lib/operation.py
@@ -1,6 +1,7 @@
 from .validator import evaluate_module_return
-from .exceptions import ModuleException
+from .exceptions import ModuleException, NoMinionsFound
 from .utils import LocalClient
+from salt.exceptions import SaltClientError
 
 def exec_module(module='', function='', target='', arguments=[], **kwargs):
     """"""
@@ -11,14 +12,38 @@ def exec_module(module='', function='', target='', arguments=[], **kwargs):
     assert function
     assert target
 
+    # TODO: validate if the target actually matches something.
+    # The question is how to do that without loosing too much performance.
+    # If we pre-query the 'target' search string using test.true
+    # it might be not too bad?
+    # If we don't pre-validate the 'target' we get printed
+    # No minions matched the target. No command was sent, no jid was assigned.
+    # without additional context to the screen.
 
-    """ This is just a test for my local environment """
+    _validate_target(target, tgt_type, module, function)
+
     ret = LocalClient().cmd(
         target, f'{module}.{function}', arguments, tgt_type=tgt_type)
 
     if not evaluate_module_return(ret):
-        # evaluate_module_return_new writes a detailed message to the screen
+        # evaluate_module_return writes a detailed message to the screen
         if raise_on_failure:
             raise ModuleException(False, ret)
         return (False, ret)
     return (True, ret)
+
+
+def _validate_target(target, tgt_type, module, function):
+    import sys
+    import os
+    # When search matches no minions, salt prints to stdout.  Suppress stdout.
+    # TODO: implement this as with a contextmanager.. seems more suited than abusing
+    # 'try: finally' to re-set the default sys.stdout
+    try:
+        _stdout = sys.stdout
+        sys.stdout = open(os.devnull, 'w')
+        minions = LocalClient().cmd(target, 'test.true', [], tgt_type=tgt_type)
+        if not minions:
+            raise NoMinionsFound(False, target, module, function, tgt_type)
+    finally:
+        sys.stdout = _stdout


### PR DESCRIPTION
* pillar sync
* module sync
* custom dummy prompt

also I improved the handling for non-existent role queries.

bonus: added a DEEPSEA_DEBUG env variable check that drops
into a post mortem debugger.

Signed-off-by: Joshua Schmid <jschmid@suse.de>

