### PR TITLE
Do not run sudo installer unless necessary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -984,7 +984,7 @@ copy-files:
 	-chown $(USER):$(GROUP) $(DESTDIR)/srv/salt/ceph/configuration/files/ceph.conf.checksum || true
 
 $(DEEPSEA_DEPS):
-	([ -z "$(DEEPSEA_DEPS)" ] || $(SUDO) $(PKG_INSTALL) $(DEEPSEA_DEPS))
+	([ -z "$(DEEPSEA_DEPS)" ] || $(PKG_QUERY) $(DEEPSEA_DEPS)>/dev/null || $(SUDO) $(PKG_INSTALL) $(DEEPSEA_DEPS))
 
 install: pyc $(DEEPSEA_DEPS) copy-files
 	sed -i '/^sharedsecret: /s!{{ shared_secret }}!'`cat /proc/sys/kernel/random/uuid`'!' $(DESTDIR)/etc/salt/master.d/sharedsecret.conf


### PR DESCRIPTION
Signed-off-by: Eric Jackson <ejackson@suse.com>

Description:
No need for the Makefile to become interactive if all the dependencies are already installed.

-----------------

**Checklist:**
- [ ] Added unittests and or functional tests
- [ ] Adapted documentation
- [ ] Referenced issues or internal bugtracker
- [ ] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
