### PR TITLE
Remove python dependency on host when building local rpm

### DIFF
--- a/deepsea.spec.in
+++ b/deepsea.spec.in
@@ -65,7 +65,7 @@ A collection of Salt files providing a deployment of Ceph as a series of stages.
 %setup
 
 %build
-make DESTDIR=%{buildroot} pyc VERSION=%{version}
+make DESTDIR=%{buildroot} setup.py VERSION=%{version}
 
 %install
 make DESTDIR=%{buildroot} DOCDIR=%{_docdir} copy-files VERSION=%{version}


### PR DESCRIPTION
Signed-off-by: Eric Jackson <ejackson@suse.com>

Description:
The pyc files require build host to have a compatible python3 to build an rpm.  

-----------------

**Checklist:**
- [ ] Added unittests and or functional tests
- [ ] Adapted documentation
- [ ] Referenced issues or internal bugtracker
- [ ] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
