### PR TITLE
Runners can work as intended in orchestrations

### DIFF
--- a/srv/modules/runners/validate.py
+++ b/srv/modules/runners/validate.py
@@ -1419,6 +1419,7 @@ def pillar(cluster=None, printer=None, **kwargs):
     valid.report()
 
     if valid.errors:
+        __context__['retcode'] = 1
         return False
 
     return True

--- a/srv/modules/utils/ready.py
+++ b/srv/modules/utils/ready.py
@@ -158,6 +158,7 @@ def check(cluster, fail_on_warning=True, **kwargs):
     _check.report()
 
     if _check.warnings and fail_on_warning:
+        __context__['retcode'] = 1
         return False
     return True
 

--- a/srv/salt/ceph/stage/deploy/core/default.sls
+++ b/srv/salt/ceph/stage/deploy/core/default.sls
@@ -1,33 +1,17 @@
 {% set master = salt['master.minion']() %}
 
-{% set FAIL_ON_WARNING = salt['pillar.get']('FAIL_ON_WARNING', 'True') %}
+ready check:
+  salt.runner:
+    - name: ready.check
+      kwarg:
+        cluster: 'ceph'
+        fail_on_warning: {{ pillar.get('FAIL_ON_WARNING', 'True') }}
 
-{% if salt['saltutil.runner']('ready.check', cluster='ceph', fail_on_warning=FAIL_ON_WARNING)  == False %}
-ready check failed:
-  salt.state:
-    - name: "Fail on Warning is True"
-    - tgt: {{ master }}
-    - failhard: True
-
-{% endif %}
-
-{# Salt orchestrate ignores return codes of other salt runners. #}
-#validate:
-#  salt.runner:
-#    - name: validate.pillar
-
-{# Until return codes fail correctly and the above can be uncommented, #}
-{# rely on the side effect of the runner printing its output and failing #}
-{# on a bogus state #}
-{% if salt['saltutil.runner']('validate.pillar', cluster='ceph') == False %}
-validate failed:
-  salt.state:
-    - name: just.exit
-    - tgt: {{ master }}
-    - failhard: True
-
-{% endif %}
-
+validate:
+  salt.runner:
+    - name: validate.pillar
+      kwarg:
+        cluster: 'ceph'
 
 {% if salt['pillar.get']('time_service') != "disabled" %}
 time:


### PR DESCRIPTION
From Salt 2018.3, the retcode is honored and orchestrations fail
correctly.

Signed-off-by: Eric Jackson <ejackson@suse.com>

-----------------

**Checklist:**
- [ ] Added unittests and or functional tests
- [ ] Adapted documentation
- [ ] Referenced issues or internal bugtracker
- [ ] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
