### PR TITLE
srv/salt/ceph/purge: Changed order of runner calls

### DIFF
--- a/srv/salt/ceph/purge/default.sls
+++ b/srv/salt/ceph/purge/default.sls
@@ -9,17 +9,17 @@ safety is engaged:
 
 {% endif %}
 
-reset master configuration:
-  salt.state:
-    - tgt: {{ master }}
-    - tgt_type: compound
-    - sls: ceph.reset
-
 terminate ceph osds:
   salt.runner:
     - name: osd.remove
     - arg: ['I@roles:storage']
     - force: True
+
+reset master configuration:
+  salt.state:
+    - tgt: {{ master }}
+    - tgt_type: compound
+    - sls: ceph.reset
 
 rescind roles:
   salt.state:


### PR DESCRIPTION
Swapped the order of 'ceph'reset' and 'osd.remove' in order to provide a
fix for bcs #1150168

Signed-off-by: Georgios Kyratsas <gkyratsas@suse.com>

Fixes # `ceph.purge`


Description:
I have deployed a basic test for `ceph.purge` in order to have it in CI where purge was failing every single time (reported in bcs #1150168). So I worked with @swiftgist and he helped me find the issue.

-----------------

**Checklist:**
- [ ] Added unittests and or functional tests
- [ ] Adapted documentation
- [x] Referenced issues or internal bugtracker
- [ ] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
