### PR TITLE
[SES6] Split output to console and Salt log

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,7 @@ copy-files:
 	install -m 644 etc/salt/master.d/output.conf $(DESTDIR)/etc/salt/master.d/
 	install -m 600 etc/salt/master.d/eauth.conf $(DESTDIR)/etc/salt/master.d/
 	install -m 644 etc/salt/master.d/salt-api.conf $(DESTDIR)/etc/salt/master.d/
+	install -m 600 etc/salt/master.d/logging.conf $(DESTDIR)/etc/salt/master.d/
 	install -m 600 srv/salt/ceph/salt-api/files/sharedsecret.conf.j2 $(DESTDIR)/etc/salt/master.d/sharedsecret.conf
 	# tests
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/tests/keyrings

--- a/etc/salt/master.d/logging.conf
+++ b/etc/salt/master.d/logging.conf
@@ -1,0 +1,1 @@
+log_level_logfile: info

--- a/srv/modules/runners/disks.py
+++ b/srv/modules/runners/disks.py
@@ -6,12 +6,13 @@ Internally this will be called 'DriveGroups'
 """
 
 from __future__ import absolute_import
-import logging
 import json
 import yaml
 import salt.client
+import tee
 
-log = logging.getLogger(__name__)
+
+log = tee.console(__name__)
 
 USAGE = """
 
@@ -140,7 +141,7 @@ class DriveGroups(object):
         """ Call minion modules to get matching disks """
         ret: list = list()
         for dg_name, dg_values in self.drive_groups.items():
-            print("Found DriveGroup <{}>".format(dg_name))
+            log.info("Found DriveGroup <{}>".format(dg_name))
             dgo = DriveGroup(dg_name, dg_values)
             if self.target:
                 target = self.target
@@ -169,7 +170,7 @@ class DriveGroups(object):
             command_name = alias
         log.debug("Calling {}.{} on compound target {}".format(
             module, command_name, target))
-        print("Calling {}.{} on compound target {}".format(
+        log.info("Calling {}.{} on compound target {}".format(
             module, command_name, target))
         ret: str = self.local_client.cmd(
             target,

--- a/srv/modules/runners/osd.py
+++ b/srv/modules/runners/osd.py
@@ -6,14 +6,15 @@ Runner to remove and replace osds
 
 from __future__ import absolute_import
 from __future__ import print_function
-import logging
 import json
 # pylint: disable=import-error,3rd-party-module-not-gated,redefined-builtin
 import salt.client
 import salt.runner
 from salt.ext.six.moves import map
+import tee
 
-log = logging.getLogger(__name__)
+
+log = tee.console(__name__)
 
 
 def help_():
@@ -171,7 +172,7 @@ class OSDUtil(Util):
         3) ceph osd destroy $id --yes-i-really-mean-it
         4) ceph-volume lvm zap --osd-id $id
         """
-        print("Preparing replacement of osd {} on host {}".format(
+        log.info("Preparing replacement of osd {} on host {}".format(
             self.osd_id, self.host))
         return self._call()
 
@@ -185,7 +186,7 @@ class OSDUtil(Util):
         5) zap doesn't destroy the partition -> find the associated partitions and
            call `ceph-volume lvm zap <device>` (optional)
         """
-        print("Removing osd {} on host {}".format(self.osd_id, self.host))
+        log.info("Removing osd {} on host {}".format(self.osd_id, self.host))
         return self._call()
 
     # pylint: disable=too-many-return-statements
@@ -200,7 +201,7 @@ class OSDUtil(Util):
             return False
 
         if not self.force:
-            print("Checking if OSD can be destroyed")
+            log.info("Checking if OSD can be destroyed")
             if self._wait_until_empty() is False:
                 return False
         try:
@@ -229,10 +230,10 @@ class OSDUtil(Util):
 
         try:
             if self.operation == 'remove':
-                print("Purging from the crushmap")
+                log.info("Purging from the crushmap")
                 self._purge_osd()
             elif self.operation == 'replace':
-                print("Marking OSD 'destroyed'")
+                log.info("Marking OSD 'destroyed'")
                 self._mark_destroyed()
             else:
                 raise RuntimeError("Unknown operation: {}".format(
@@ -265,7 +266,7 @@ class OSDUtil(Util):
 
     def _delete_grain(self):
         """ Delete grains after removing an OSD (if grain is still present) """
-        log.info("Deleting grain for osd {}".format(self.osd_id))
+        log.debug("Deleting grain for osd {}".format(self.osd_id))
         self.local.cmd(
             self.host, 'osd.delete_grain', [self.osd_id], tgt_type="glob")
         # There is no handling of returncodes in delete_grain whatsoever..
@@ -278,14 +279,14 @@ class OSDUtil(Util):
         counter = 0
         while counter < self.retries:
             if counter > 0:
-                print("Retrying...")
+                log.info("Retrying...")
             log.info("Waiting for osd {} to empty".format(self.osd_id))
             ret = self.local.cmd(
                 Util.master_minion(),
                 'osd.wait_until_empty', [self.osd_id],
                 tgt_type="glob")
             message = list(ret.values())[0]
-            print(message)
+            log.info(message)
             if message.startswith("osd.{} is safe to destroy".format(
                     self.osd_id)):
                 return True
@@ -303,7 +304,7 @@ class OSDUtil(Util):
     def _get_osd_state(self):
         """ Method to get the current osd_state """
         cmd = 'ceph osd dump --format=json'
-        log.info("Executing: {}".format(cmd))
+        log.debug("Executing: {}".format(cmd))
         ret = self.local.cmd(
             Util.master_minion(), "cmd.run", [cmd], tgt_type="glob")
         message = list(ret.values())[0]
@@ -329,7 +330,7 @@ class OSDUtil(Util):
         # That means we have to find devices by osd_id first
 
         cmd = 'ceph-volume lvm zap --osd-id {} --destroy'.format(self.osd_id)
-        log.info("Executing: {}".format(cmd))
+        log.debug("Executing: {}".format(cmd))
         ret = self.local.cmd(self.host, "cmd.run", [cmd], tgt_type="glob")
         message = list(ret.values())[0]
         if 'Zapping successful for OSD' not in message:
@@ -340,7 +341,7 @@ class OSDUtil(Util):
     def _mark_destroyed(self):
         """ Mark an osd destroyed """
         cmd = "ceph osd destroy {} --yes-i-really-mean-it".format(self.osd_id)
-        log.info("Executing: {}".format(cmd))
+        log.debug("Executing: {}".format(cmd))
         ret = self.local.cmd(
             Util.master_minion(),
             "cmd.run",
@@ -357,7 +358,7 @@ class OSDUtil(Util):
     def _purge_osd(self):
         """ Purge an osd """
         cmd = "ceph osd purge {} --yes-i-really-mean-it".format(self.osd_id)
-        log.info("Executing: {}".format(cmd))
+        log.debug("Executing: {}".format(cmd))
         ret = self.local.cmd(
             Util.master_minion(),
             "cmd.run",
@@ -372,7 +373,7 @@ class OSDUtil(Util):
 
     def _service(self, action):
         """ Wrapper to start/stop a systemd unit """
-        log.info("Calling service.{} on {}".format(action, self.osd_id))
+        log.debug("Calling service.{} on {}".format(action, self.osd_id))
         ret = self.local.cmd(
             self.host,
             'service.{}'.format(action), ['ceph-osd@{}'.format(self.osd_id)],
@@ -387,7 +388,7 @@ class OSDUtil(Util):
     def _mark_osd(self, state):
         """ Mark a osd out/in """
         cmd = "ceph osd {} {}".format(state, self.osd_id)
-        log.info("Running command {}".format(cmd))
+        log.debug("Running command {}".format(cmd))
         ret = self.local.cmd(
             Util.master_minion(),
             "cmd.run",
@@ -396,7 +397,7 @@ class OSDUtil(Util):
         )
         message = list(ret.values())[0]
         if message.startswith('marked'):
-            log.info("Marking osd {} - {} -".format(self.osd_id, state))
+            log.debug("Marking osd {} - {} -".format(self.osd_id, state))
         elif message.startswith('osd.{} is already {}'.format(
                 self.osd_id, state)):
             log.info(message)

--- a/srv/modules/utils/tee.py
+++ b/srv/modules/utils/tee.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+'''
+Provide functions for setting console log levels and formatting
+'''
+
+from __future__ import absolute_import
+import logging
+
+
+def console(name):
+    '''
+    Add console logger without timestamp
+    '''
+    if not logging.getLogger(name).handlers:
+        console_log = logging.StreamHandler()
+        console_log.setLevel(logging.INFO)
+
+        # set a format which is simpler for console use
+        formatter = logging.Formatter('%(message)s')
+        console_log.setFormatter(formatter)
+
+        # add the handler to the root logger
+        logging.getLogger(name).addHandler(console_log)
+
+    return logging.getLogger(name)

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,7 @@ deps =
 
 [testenv:py3]
 basepython = python3
+setenv = PYTHONPATH = {toxinidir}/srv/modules/utils
 commands =
     py.test --cov=. --tb=line -v --ignore=cli/ --junitxml=junit-{envname}.xml {posargs}
 
@@ -31,6 +32,7 @@ deps =
 
 [testenv:lint]
 basepython = python3
+setenv = PYTHONPATH = {toxinidir}/srv/modules/utils
 commands = pylint --rcfile=.pylintrc  srv/
 deps =
     {[base]deps}


### PR DESCRIPTION
The console output remains the same, but the output is also logged to
/var/log/salt/master.  A restart of the salt-master is necessary.

Signed-off-by: Eric Jackson <ejackson@suse.com>
jira: SES-813
-----------------

**Checklist:**
- [ ] Added unittests and or functional tests
- [ ] Adapted documentation
- [ ] Referenced issues or internal bugtracker
- [ ] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
