### PR TITLE
Backport: srv/salt/ceph/purge: Changed order of runner calls

### DIFF
--- a/srv/salt/ceph/purge/default.sls
+++ b/srv/salt/ceph/purge/default.sls
@@ -9,17 +9,17 @@ safety is engaged:
 
 {% endif %}
 
-reset master configuration:
-  salt.state:
-    - tgt: {{ master }}
-    - tgt_type: compound
-    - sls: ceph.reset
-
 terminate ceph osds:
   salt.runner:
     - name: osd.remove
     - arg: ['I@roles:storage']
     - force: True
+
+reset master configuration:
+  salt.state:
+    - tgt: {{ master }}
+    - tgt_type: compound
+    - sls: ceph.reset
 
 rescind roles:
   salt.state:


### PR DESCRIPTION
Fixes #


Description: Backport PR #1793 to `SES6` branch in order to fix the bug bcs #1150168 regarding `ceph.purge`.


-----------------

**Checklist:**
- [ ] Added unittests and or functional tests
- [ ] Adapted documentation
- [x] Referenced issues or internal bugtracker
- [ ] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
