### PR TITLE
[SES6] Allow for graceful rerunning when removing the cephfs configuration

### DIFF
--- a/srv/salt/ceph/remove/mds/default.sls
+++ b/srv/salt/ceph/remove/mds/default.sls
@@ -6,19 +6,19 @@ remove mds nop:
 
 fail mds:
   cmd.run:
-    - name: "ceph mds fail 0"
+    - name: "ceph mds fail 0 || :"
 
 remove cephfs:
   cmd.run:
-    - name: "ceph fs rm cephfs --yes-i-really-mean-it"
+    - name: "ceph fs rm cephfs --yes-i-really-mean-it || :"
 
 remove metadata:
   cmd.run:
-    - name: "ceph osd pool delete cephfs_metadata cephfs_metadata --yes-i-really-really-mean-it"
+    - name: "ceph osd pool delete cephfs_metadata cephfs_metadata --yes-i-really-really-mean-it || :"
 
 remove data:
   cmd.run:
-    - name: "ceph osd pool delete cephfs_data cephfs_data --yes-i-really-really-mean-it"
+    - name: "ceph osd pool delete cephfs_data cephfs_data --yes-i-really-really-mean-it || :"
 
 {% endif %}
 


### PR DESCRIPTION
Signed-off-by: Eric Jackson <ejackson@suse.com>
bnc:1155260

-----------------

**Checklist:**
- [ ] Added unittests and or functional tests
- [ ] Adapted documentation
- [x] Referenced issues or internal bugtracker
- [x] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
