### PR TITLE
Workaround for python-rados package version

### DIFF
--- a/srv/salt/ceph/packages/common/default.sls
+++ b/srv/salt/ceph/packages/common/default.sls
@@ -20,7 +20,6 @@ stage prep dependencies suse:
       - pciutils
       - gptfdisk
       - python3-boto
-      - python3-rados
       - python3-netaddr
       - iperf
       - lsof
@@ -33,6 +32,11 @@ stage prep dependencies suse:
       - ceph
     - fire_event: True
     - refresh: True
+
+stage prep dependencies suse:
+  pkg.installed:
+    - pkgs:
+      - python3-rados
 
 {% elif os == 'Ubuntu' %}
 


### PR DESCRIPTION
Zypper cannot successfully resolve both ceph and python-rados in the
same path, but will pick the previous version of librados when
python-rados is separated.  This allows Stage 0 to complete. Manual
intervention may remain on the Salt master due to the deepsea rpm.

Signed-off-by: Eric Jackson <ejackson@suse.com>
-----------------

**Checklist:**
- [ ] Added unittests and or functional tests
- [ ] Adapted documentation
- [ ] Referenced issues or internal bugtracker
- [ ] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
