### PR TITLE
osd/replace: only access metadata if present

### DIFF
--- a/srv/modules/runners/osd.py
+++ b/srv/modules/runners/osd.py
@@ -82,7 +82,7 @@ class Util(object):
                     'The minion function caused an exception'):
                 log.error(osd_metadata)
                 return dict()
-        if isinstance(osd_metadata, list):
+        if isinstance(osd_metadata, list) and osd_metadata:
             return osd_metadata[0]
         return dict()
 


### PR DESCRIPTION
When a OSD is not actively deployed anymore
but is still present in the crushmap you want to be
able to replace it.
This patch extends the condition for such a case.

suse_internal: bsc#1157469
Signed-off-by: Joshua Schmid <jschmid@suse.de>

