### PR TITLE
Allow custom grafana endpoint

### DIFF
--- a/srv/salt/ceph/dashboard/default.sls
+++ b/srv/salt/ceph/dashboard/default.sls
@@ -83,7 +83,8 @@ set dashboard password grain:
         - cmd: set username and password
 
 # configure grafana
-{% set grafana_minion = salt.saltutil.runner('select.one_minion', cluster='ceph', roles='grafana') %}
+{% set grafana_default = salt.saltutil.runner('select.one_minion', cluster='ceph', roles='grafana') %}
+{% set grafana_minion = salt['pillar.get']('GRAFANA_MINION', grafana_default) %}
 {% if grafana_minion %}
 set dashboard grafana url:
   cmd.run:


### PR DESCRIPTION
Signed-off-by: Eric Jackson <ejackson@suse.com>
Port: #1798 
-----------------

**Checklist:**
- [ ] Added unittests and or functional tests
- [ ] Adapted documentation
- [ ] Referenced issues or internal bugtracker
- [ ] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
