### PR TITLE
[backport][ses6] use non-blocking i/o with .wait

### DIFF
--- a/srv/salt/_modules/helper.py
+++ b/srv/salt/_modules/helper.py
@@ -48,18 +48,20 @@ def run(cmd, shell=False):
         shell = True
 
     log.info("executing: {cmd}".format(cmd=cmd))
-    proc = Popen(cmd, stdout=PIPE, stderr=PIPE, shell=shell)
-    _stdout = convert_out(proc.stdout.read())
-    _stdout = _stdout.rstrip()
+    _stdout = ''
+    _stderr = ''
+    try:
+        proc = Popen(cmd, stdout=PIPE, stderr=PIPE, shell=shell)
+        _stdout, _stderr = proc.communicate()
+        _stdout = convert_out(_stdout).rstrip()
+        _stderr = convert_out(_stderr).rstrip()
+        _retcode = proc.wait()
+    except OSError as erroro:
+        log.info("""
+execution of {cmd} failed with error {errno}: {reason}
+        """.format(cmd=cmd, errno=erroro.errno, reason=erroro.strerror))
+        _retcode = 127
 
-    _stderr = convert_out(proc.stderr.read())
-    _stderr = _stderr.rstrip()
-
-    _retcode = proc.wait()
-    log.debug("returncode of {cmd}: {rc}".format(cmd=cmd, rc=_retcode))
-
-    log.debug("""stdout of {cmd}:
-{out}""".format(cmd=cmd, out=pprint.pformat(_stdout)))
-    log.debug("""stderr of {cmd}:
-{out}""".format(cmd=cmd, out=pprint.pformat(_stderr)))
+    log.debug("""stdout of {cmd}: {out}""".format(cmd=cmd, out=pprint.pformat(_stdout)))
+    log.debug("""stderr of {cmd}: {out}""".format(cmd=cmd, out=pprint.pformat(_stderr)))
     return _retcode, _stdout, _stderr


### PR DESCRIPTION
Signed-off-by: Joshua Schmid <jschmid@suse.de>
(cherry picked from commit 903e25833c2a5176772a1016715a3b4868191217)

backport of #1812 

-----------------

**Checklist:**
~- [ ] Added unittests and or functional tests~
~- [ ] Adapted documentation~
- [x] Referenced issues or internal bugtracker
- [x] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
