### PR TITLE
[SES6] cephdisks: exclude mdraid devices

### DIFF
--- a/srv/salt/_modules/cephdisks.py
+++ b/srv/salt/_modules/cephdisks.py
@@ -178,6 +178,13 @@ class Inventory(object):
             return True
         return False
 
+    @staticmethod
+    def _is_mdraid(path: str) -> bool:
+        """ Always skip software raid setups """
+        if path.split('/')[-1].startswith('md'):
+            return True
+        return False
+
     def _has_sufficient_size(self, size: float) -> bool:
         """ Skip disks that are small than a defined threshold """
         # due to: todo http://tracker.ceph.com/issues/40776
@@ -235,13 +242,20 @@ class Inventory(object):
             if self._is_cdrom(dev.path):
                 log.debug(f"Skipping disk <{dev.path}> due to <cdrom> filter")
                 continue
+
+            if self._is_mdraid(dev.path):
+                log.debug(f"Skipping disk <{dev.path}> due to <mdraid> filter")
+                continue
+
             if self._is_rbd(dev.path):
                 log.debug(f"Skipping disk <{dev.path}> due to <rbd> filter")
                 continue
+
             if not self._has_sufficient_size(dev.size):
                 log.debug(
                     f"Skipping disk <{dev.path}> due to <too_small> filter")
                 continue
+
             # due to: todo http://tracker.ceph.com/issues/40799
             if dev.is_mapper and dev.is_encrypted:
                 log.debug(

--- a/tests/unit/_modules/test_cephdisks.py
+++ b/tests/unit/_modules/test_cephdisks.py
@@ -46,7 +46,6 @@ class TestInventory(object):
     def test_osd_list(self):
         pass
 
-
     @patch(
         "srv.salt._modules.cephdisks.open",
         new_callable=mock_open,
@@ -94,6 +93,10 @@ class TestInventory(object):
     def test_is_cdrom(self, test_fix):
         inv = test_fix()
         assert inv._is_cdrom('/dev/sr0') is True
+
+    def test_is_mdraid(self, test_fix):
+        inv = test_fix()
+        assert inv._is_mdraid('/dev/md127') is True
 
     def test_is_cdrom_10(self, test_fix):
         inv = test_fix()
@@ -219,6 +222,15 @@ class TestInventory(object):
         inv = test_fix(conf)
         ret = inv.filter_()
         assert len(ret) == 1
+
+    def test_filter_mdraid(self, test_fix):
+        conf = dict(
+            pieces=1,
+            device_config=dict(
+                path='/dev/md127'))
+        inv = test_fix(conf)
+        ret = inv.filter_()
+        assert len(ret) == 0
 
     @pytest.mark.skip(reason="Offloaded to ceph-volume")
     def test_find_by_osd_id(self):


### PR DESCRIPTION
Fixes: bsc#1158196

Although it's still controversial to use RAID devices as OSDs, this patch excludes all /dev/md* devices from the list of possible OSDs.

-----------------

**Checklist:**
- [x] Added unittests and or functional tests
~- [ ] Adapted documentation~
- [x] Referenced issues or internal bugtracker
- [ ] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
