### PR TITLE
Grains are not used by ceph-volume

### DIFF
--- a/srv/salt/_modules/osd.py
+++ b/srv/salt/_modules/osd.py
@@ -148,14 +148,7 @@ def list_():
     mounted = [path.split('-')[1][:-5]
                for path in glob.glob("/var/lib/ceph/osd/*/fsid") if '-' in path]
     log.info("mounted osds {}".format(mounted))
-    # the 'ceph' grain will disappear over time.
-    # the 'remove osd' operation will remove the grain
-    # but the disks.deploy function will not add new a new one
-    if 'ceph' in __grains__:
-        grains = list(__grains__['ceph'].keys())
-    else:
-        grains = []
-    return list(set(mounted + grains))
+    return mounted
 
 
 def rescinded():

--- a/tests/unit/_modules/test_osd.py
+++ b/tests/unit/_modules/test_osd.py
@@ -55,18 +55,7 @@ class TestOSDInstanceMethods():
         pass
 
     @mock.patch('srv.salt._modules.osd.glob')
-    def test_list_(self, glob):
-        glob.return_value.glob = []
-        osd.__grains__ = {'ceph': {'foo': 'mocked_grain'}}
-        ret = osd.list_()
-        glob.glob.assert_called_once()
-        glob.glob.assert_called_with('/var/lib/ceph/osd/*/fsid')
-        assert 'foo' in ret
-        assert type(ret) is list
-        osd.__grains__ = {}
-
-    @mock.patch('srv.salt._modules.osd.glob')
-    def test_list_no_grains(self, glob):
+    def test_list(self, glob):
         glob.return_value.glob = []
         ret = osd.list_()
         glob.glob.assert_called_once()


### PR DESCRIPTION
During the transition from a partition based OSD to an LVM based OSD,
the grains are no longer updated.  As a result, two different storage
nodes can report the same OSD id, since the original still has a stale grain
entry.  Not including the grains will correct this collision.

Signed-off-by: Eric Jackson <ejackson@suse.com>

bsc: 1160172

-----------------

**Checklist:**
- [ ] Added unittests and or functional tests
- [ ] Adapted documentation
- [x] Referenced issues or internal bugtracker
- [x] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
