### PR TITLE
[SES5] ceph.time: work around buggy "service.running"

### DIFF
--- a/srv/salt/ceph/time/ntp/default.sls
+++ b/srv/salt/ceph/time/ntp/default.sls
@@ -26,8 +26,7 @@ sync time:
     - fire_event: True
 
 start ntp:
-  service.running:
-    - name: ntpd
-    - enable: True
+  cmd.run:
+    - name: "systemctl enable ntpd.service && systemctl start ntpd.service"
 {% endif %}
 


### PR DESCRIPTION
Fixes: https://github.com/SUSE/DeepSea/issues/1822
Signed-off-by: Nathan Cutler <ncutler@suse.com>

-----------------

**Checklist:**
- [ ] Added unittests and or functional tests
- [ ] Adapted documentation
- [x] Referenced issues or internal bugtracker
- [ ] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
