### PR TITLE
Prometheus sents pool filling up warning emails

### DIFF
--- a/srv/salt/ceph/monitoring/prometheus/files/ses_default_alerts.yml
+++ b/srv/salt/ceph/monitoring/prometheus/files/ses_default_alerts.yml
@@ -127,7 +127,7 @@ groups:
       # predict fs fillup times
       - alert: storage filling up
         expr: |
-          predict_linear(node_filesystem_free_bytes[2d], 3600 * 24 * 5) *
+          predict_linear(node_filesystem_free[2d], 3600 * 24 * 5) *
           on(instance) group_left(nodename) node_uname_info < 0
         labels:
           severity: warning
@@ -147,10 +147,8 @@ groups:
           description: Pool {{ $labels.pool }} at 90% capacity or over
       - alert: pool filling up
         expr: |
-          (
-            predict_linear(ceph_pool_stored[2d], 3600 * 24 * 5) >=
-            ceph_pool_max_avail
-          ) * on(pool_id) group_right(name) ceph_pool_metadata
+            predict_linear(ceph_pool_used_bytes[2d], 3600 * 24 * 5) >=
+            ceph_pool_available_bytes
         labels:
           severity: warning
           type: ses_default

--- a/srv/salt/ceph/monitoring/prometheus/files/ses_default_alerts.yml
+++ b/srv/salt/ceph/monitoring/prometheus/files/ses_default_alerts.yml
@@ -125,8 +125,10 @@ groups:
             Node {{ $labels.instance }} experiences packet errors > 1
             packet/s on interface {{ $lables.device }}
       # predict fs fillup times
-      - alert: storage filling
-        expr: ((node_filesystem_free - node_filesystem_size) / deriv(node_filesystem_free[2d]) <= 5) > 0
+      - alert: storage filling up
+        expr: |
+          predict_linear(node_filesystem_free_bytes[2d], 3600 * 24 * 5) *
+          on(instance) group_left(nodename) node_uname_info < 0
         labels:
           severity: warning
           type: ses_default
@@ -144,7 +146,11 @@ groups:
         annotations:
           description: Pool {{ $labels.pool }} at 90% capacity or over
       - alert: pool filling up
-        expr: (-ceph_pool_used_bytes / deriv(ceph_pool_available_bytes[2d]) <= 5 ) > 0
+        expr: |
+          (
+            predict_linear(ceph_pool_stored[2d], 3600 * 24 * 5) >=
+            ceph_pool_max_avail
+          ) * on(pool_id) group_right(name) ceph_pool_metadata
         labels:
           severity: warning
           type: ses_default


### PR DESCRIPTION
Backported from https://github.com/ceph/ceph/pull/34227/commits/6935dc55921ef533e939719bad7dc12324450bbb.

Adapt metric names and queries to node_exporter in SES5.

Fixes: bsc#1152100

Signed-off-by: Volker Theile <vtheile@suse.com>

-----------------

**Checklist:**
- [ ] Added unittests and or functional tests
- [ ] Adapted documentation
- [x] Referenced issues or internal bugtracker
- [ ] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
