### PR TITLE
Do not remove ceph-grafana-dashboards on mgr nodes

### DIFF
--- a/srv/salt/ceph/rescind/grafana/default.sls
+++ b/srv/salt/ceph/rescind/grafana/default.sls
@@ -21,10 +21,12 @@ grafana:
     - name: grafana
     - fire_event: true
 
+{% if 'mgr' not in salt['pillar.get']('roles') %}
 ceph grafana dashboard:
   pkg.removed:
     - name: ceph-grafana-dashboards
     - fire_event: true
+{% endif %}
 
 /etc/grafana/provisioning/datasources/ses_datasource.yaml:
   file.absent

--- a/srv/salt/ceph/rescind/mgr/dashboard/default.sls
+++ b/srv/salt/ceph/rescind/mgr/dashboard/default.sls
@@ -3,4 +3,8 @@ uninstall ceph mgr dashboard:
   pkg.removed:
     - name: ceph-mgr-dashboard
 
+uninstall grafana dashboard:
+  pkg.removed:
+    - name: ceph-grafana-dashboards
+
 


### PR DESCRIPTION
The ceph-mgr-dashboard requires the ceph-grafana-dashboards, so only
uninstall the ceph-grafana-dashboards from minions that have neither
grafana nor mgr roles.

Signed-off-by: Eric Jackson <ejackson@suse.com>
bsc: 1168359

-----------------

**Checklist:**
- [ ] Added unittests and or functional tests
- [ ] Adapted documentation
- [x] Referenced issues or internal bugtracker
- [ ] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
