### PR TITLE
Sync salt dynamic modules

### DIFF
--- a/srv/salt/ceph/stage/configure/default.sls
+++ b/srv/salt/ceph/stage/configure/default.sls
@@ -10,6 +10,12 @@ validate failed:
 
 {% endif %}
 
+sync:
+  salt.state:
+    - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
+    - tgt_type: compound
+    - sls: ceph.sync
+
 push proposals:
   salt.runner:
     - name: push.proposal


### PR DESCRIPTION
For users with maintenance windows attempting to avoid running Stage 0,
synchronize Salt files in Stage 2 as well to prevent difficult to diagnose problems.

Signed-off-by: Eric Jackson <ejackson@suse.com>
bsc:1170752
-----------------

**Checklist:**
- [ ] Added unittests and or functional tests
- [ ] Adapted documentation
- [x] Referenced issues or internal bugtracker
- [ ] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
