### PR TITLE
osd: forcefully mark an osd as down after stopping the service

### DIFF
--- a/srv/modules/runners/osd.py
+++ b/srv/modules/runners/osd.py
@@ -216,6 +216,7 @@ class OSDUtil(Util):
         try:
             self._service('disable')
             self._service('stop')
+            self._mark_osd('down')
             # The original implementation
             # pkilled (& -9 -f'd ) the osd-process
             # including a double check with pgrep


### PR DESCRIPTION
Signed-off-by: Joshua Schmid <jschmid@suse.de>

Fixes bsc#1171451

Description:

We seem to have an issue with ceph 14.2.8+ and osd replacements/removals where the step in `osd.remove/replace` that is supposed to destroy/purge the osd from the crushmap bails out when the osd is not in the expected 'down' state. This should happen automatically after the osd daemon has stopped. Apparently there's a timing issue somewhere. An easy and non-intrusive workaround is to manually force the osd down _after_ checks have passed.

-----------------

**Checklist:**
- [ ] Added unittests and or functional tests
- [ ] Adapted documentation
- [x] Referenced issues or internal bugtracker
- [ ] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
