### PR TITLE
Ignore disks with GPT headers or unavailable

### DIFF
--- a/srv/modules/runners/disks.py
+++ b/srv/modules/runners/disks.py
@@ -252,6 +252,14 @@ def report(**kwargs):
     return DriveGroups(**kwargs).call_out('deploy', alias='report')
 
 
+def inventory(**kwargs):
+    """ Get the OSD deployment report """
+    ret = report(**kwargs)
+    ignored = DriveGroups(**kwargs).call_out('ignored')
+    ret.extend(ignored)
+    return ret
+
+
 def help_():
     """ Help/Usage class
     """


### PR DESCRIPTION
Since the blkid_api is not available, use blkid() directly.  Add a
separate command currently rather than changing disks.report.

Signed-off-by: Eric Jackson <ejackson@suse.com>
bsc: 1171002, 1171887

-----------------

**Checklist:**
- [ ] Added unittests and or functional tests
- [ ] Adapted documentation
- [x] Referenced issues or internal bugtracker
- [ ] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
