### PR TITLE
prevent installation of node_exporter update due to LTTS

### DIFF
--- a/srv/salt/ceph/monitoring/prometheus/exporters/node_exporter.sls
+++ b/srv/salt/ceph/monitoring/prometheus/exporters/node_exporter.sls
@@ -1,6 +1,7 @@
 install node exporter package:
   pkg.installed:
     - name: golang-github-prometheus-node_exporter
+    - version: 0.14.0
     - refresh: True
     - fire_event: True
 


### PR DESCRIPTION
Signed-off-by: Patrick Seidensal <pseidensal@suse.com>

Fixes bsc#1174292


Description: Fixes and issue with an update of the node-exporter package by installing the compatible version instead of the updated one.


-----------------

**Checklist:**
- [ ] Added unittests and or functional tests
- [ ] Adapted documentation
- [x] Referenced issues or internal bugtracker
- [ ] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
