### PR TITLE
aa-teardown can fail if apparmor is disabled on the boot command line

### DIFF
--- a/srv/salt/ceph/apparmor/default-teardown.sls
+++ b/srv/salt/ceph/apparmor/default-teardown.sls
@@ -7,6 +7,8 @@ aa-teardown:
   cmd.run:
     - onlyif:
       - which aa-teardown
+    - onfail:
+      - test: apparmor
 
 stop apparmor:
   service.dead:


### PR DESCRIPTION
Signed-off-by: Eric Jackson <ejackson@suse.com>
bnc: 1174536

-----------------

**Checklist:**
- [ ] Added unittests and or functional tests
- [ ] Adapted documentation
- [x] Referenced issues or internal bugtracker
- [ ] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
