### PR TITLE
Add dedicated ganesha_config pool for dashboard

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -294,6 +294,8 @@ copy-files:
 	install -m 644 srv/salt/ceph/ganesha/keyring/*.sls $(DESTDIR)/srv/salt/ceph/ganesha/keyring/
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/ganesha/install
 	install -m 644 srv/salt/ceph/ganesha/install/*.sls $(DESTDIR)/srv/salt/ceph/ganesha/install/
+	install -d -m 755 $(DESTDIR)/srv/salt/ceph/ganesha/pool
+	install -m 644 srv/salt/ceph/ganesha/pool/*.sls $(DESTDIR)/srv/salt/ceph/ganesha/pool/
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/ganesha/service
 	install -m 644 srv/salt/ceph/ganesha/service/*.sls $(DESTDIR)/srv/salt/ceph/ganesha/service/
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/ganesha/restart

--- a/deepsea.spec.in
+++ b/deepsea.spec.in
@@ -148,6 +148,7 @@ systemctl try-restart salt-api > /dev/null 2>&1 || :
 %dir /srv/salt/ceph/ganesha/restart
 %dir /srv/salt/ceph/ganesha/restart/force
 %dir /srv/salt/ceph/ganesha/restart/controlled
+%dir /srv/salt/ceph/ganesha/pool
 %dir /srv/salt/ceph/ganesha/service
 %dir /srv/salt/ceph/igw
 %dir %attr(0700, salt, salt) /srv/salt/ceph/igw/cache
@@ -511,6 +512,7 @@ systemctl try-restart salt-api > /dev/null 2>&1 || :
 %config /srv/salt/ceph/ganesha/restart/*.sls
 %config /srv/salt/ceph/ganesha/restart/force/*.sls
 %config /srv/salt/ceph/ganesha/restart/controlled/*.sls
+%config /srv/salt/ceph/ganesha/pool/*.sls
 %config /srv/salt/ceph/ganesha/service/*.sls
 %config /srv/salt/ceph/igw/*.sls
 %config /srv/salt/ceph/igw/files/*.j2

--- a/srv/modules/modules/master.py
+++ b/srv/modules/modules/master.py
@@ -42,3 +42,9 @@ def find_pool(applications, preferred_pool=None):
     master = minion()
     return local.cmd(master, 'deepsea.find_pool',
                      [applications, preferred_pool])[master]
+
+def ganesha_namespace():
+    import salt.client
+    local = salt.client.LocalClient()
+    master = minion()
+    return local.cmd(master, 'cmd.run', ['ceph dashboard get-ganesha-clusters-rados-pool-namespace'])[master]

--- a/srv/salt/ceph/ganesha/config/default.sls
+++ b/srv/salt/ceph/ganesha/config/default.sls
@@ -6,7 +6,7 @@ prevent empty rendering:
   test.nop:
     - name: skip
 
-{% set nfs_pool = salt['deepsea.find_pool'](['cephfs', 'rgw']) %}
+{% set nfs_pool = "ganesha_config" %}
 
 {% for role in salt['pillar.get']('ganesha_configurations', [ 'ganesha' ]) %}
 check {{ role }}:

--- a/srv/salt/ceph/ganesha/pool/default.sls
+++ b/srv/salt/ceph/ganesha/pool/default.sls
@@ -1,0 +1,53 @@
+
+ganesha_config pool:
+  cmd.run:
+    - name: "ceph osd pool create ganesha_config 1 1"
+    - unless: "ceph osd pool ls | grep -q ganesha_config"
+    - fire_event: True
+
+ganesha_config application:
+  cmd.run:
+    - name: "ceph osd pool application enable ganesha_config nfs"
+    - fire_event: True
+
+{# Reconfigure Ganesha to use dedicated pool #}
+
+{% set nfs_pool = salt['deepsea.find_pool'](['cephfs', 'rgw']) %}
+
+{# If the original pool does not exist or has no files, then skip migrating #}
+
+{% if nfs_pool !=  None %}
+{% set files = salt['cmd.run']('rados -p ' + nfs_pool + ' -N ganesha ls') %}
+{% if files != "" %}
+
+{% set tmpdir = salt['cmd.run']("mktemp -d") %}
+
+extract configurations:
+  cmd.run:
+    - name: "for c in `rados -p {{ nfs_pool }} -N ganesha ls`; do rados -p {{ nfs_pool }} -N ganesha get $c $c; done"
+    - cwd: {{ tmpdir }}
+    - failhard: True
+
+correct url:
+  cmd.run:
+    - name: "sed -i 's!{{ nfs_pool }}!ganesha_config!g' conf-*"
+    - cwd: {{ tmpdir }}
+    - failhard: True
+
+import configurations:
+  cmd.run:
+    - name: "for c in *; do rados -p ganesha_config -N ganesha put $c $c; done"
+    - cwd: {{ tmpdir }}
+    - failhard: True
+
+
+{{ tmpdir }}:
+  file.absent
+
+{% endif %}
+{% endif %}
+
+configure dashboard:
+  cmd.run:
+    - name: "ceph dashboard set-ganesha-clusters-rados-pool-namespace ganesha_config/ganesha"
+

--- a/srv/salt/ceph/ganesha/pool/init.sls
+++ b/srv/salt/ceph/ganesha/pool/init.sls
@@ -1,0 +1,3 @@
+
+include:
+  - .{{ salt['pillar.get']('ganesha_pool', 'default') }}

--- a/srv/salt/ceph/ganesha/rados_config.sls
+++ b/srv/salt/ceph/ganesha/rados_config.sls
@@ -2,8 +2,8 @@
 
 create {{ host }} daemon rados object:
   cmd.run:
-    - name: "POOL=`salt-call --out=json deepsea.find_pool '[\"cephfs\", \"rgw\"]' 2>/dev/null | jq -r .local` && rados -p $POOL -N ganesha create conf-{{ host }}"
-    - unless: "POOL=`salt-call --out=json deepsea.find_pool '[\"cephfs\", \"rgw\"]' 2>/dev/null | jq -r .local` && rados -p $POOL -N ganesha ls | grep -q ^conf-{{ host }}$"
+    - name: "rados -p ganesha_config -N ganesha create conf-{{ host }}"
+    - unless: "rados -p $POOL -N ganesha ls | grep -q ^conf-{{ host }}$"
     - fire_event: True
 
 {% endfor %}

--- a/srv/salt/ceph/stage/ganesha/core/default.sls
+++ b/srv/salt/ceph/stage/ganesha/core/default.sls
@@ -42,12 +42,4 @@ configure dashboard cephfs permissions:
     - arg:
       - "ceph config set mgr client_mount_uid 0 && ceph config set mgr client_mount_gid 0"
 
-configure dashboard nfs:
-  salt.function:
-    - name: cmd.run
-    - tgt: {{ master }}
-    - tgt_type: compound
-    - kwarg:
-        cmd: "POOL=`salt-call --out=json deepsea.find_pool '[\"cephfs\", \"rgw\"]' 2>/dev/null | jq -r .local` && ceph dashboard set-ganesha-clusters-rados-pool-namespace $POOL/ganesha"
-
 {% endif %}

--- a/srv/salt/ceph/stage/ganesha/default.sls
+++ b/srv/salt/ceph/stage/ganesha/default.sls
@@ -1,5 +1,31 @@
 
+{% set namespace = salt['master.ganesha_namespace']() %}
+
+{% if namespace == "ganesha_config/ganesha" %}
+
 include:
-  - .migrate
   - .core
   - ...restart.ganesha.lax
+
+{% elif namespace == "" %}
+
+include:
+  - .pool
+  - .core
+  - ...restart.ganesha.lax
+
+fresh install complete:
+  test.nop
+
+{% else %}
+
+include:
+  - .migrate
+  - .pool
+  - .core
+  - ...restart.ganesha.lax
+
+migration complete:
+  test.nop
+
+{% endif %}

--- a/srv/salt/ceph/stage/ganesha/pool.sls
+++ b/srv/salt/ceph/stage/ganesha/pool.sls
@@ -1,0 +1,13 @@
+
+{% if salt.saltutil.runner('select.minions', cluster='ceph', roles='ganesha') or salt.saltutil.runner('select.minions', cluster='ceph', ganesha_configurations='*') %}
+
+{% set master = salt['master.minion']() %}
+
+dedicated pool:
+  salt.state:
+    - tgt: {{ master }}
+    - tgt_type: compound
+    - sls: ceph.ganesha.pool
+    - failhard: True
+
+{% endif %}


### PR DESCRIPTION
With a sufficient number of objects in a pool, the `rados -p POOL -N
ganesha ls` command can take several minutes to complete.  The side
effect is the dashboard can timeout.  Do *not* use cephfs_data nor rgw
for storing ganesha configurations.

Signed-off-by: Eric Jackson <ejackson@suse.com>
bnc: 1172689

-----------------

**Checklist:**
- [ ] Added unittests and or functional tests
- [ ] Adapted documentation
- [x] Referenced issues or internal bugtracker
- [x] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
