### PR TITLE
validate: check if domain grain is set

### DIFF
--- a/srv/modules/runners/validate.py
+++ b/srv/modules/runners/validate.py
@@ -706,7 +706,25 @@ class Validate(Preparation):
 
         self._set_pass_status('fqdn')
 
-    # pylint: disable=line-too-long
+    def domain(self):
+        """
+        Verify that the domain grain exists
+        """
+        for minion_id in self.grains.keys():
+            domain = self.grains[minion_id]['domain']
+            fqdn = self.grains[minion_id]['fqdn']
+            msg = f"""
+In order to determine a `domain` which is required for some features in DeepSea you need to set-up the FQDN properly.
+Example:
+A device with the hostname `myhost` in the parent domain example.com has the fully qualified domain name myhost.example.com. The FQDN uniquely distinguishes the device from any other hosts called myhost in other domains.
+
+Please make sure 'hostname --fqdn' returns an FQDN, for example, myhost.example.com
+Your currently configured FQDN is: <$fqdn>
+ """
+            if not domain:
+                self.errors.setdefault('domain', []).append(msg)
+        self._set_pass_status('domain')
+
     def openattic(self):
         """
         Check for incompatible issues for openATTIC
@@ -1416,6 +1434,7 @@ def pillar(cluster=None, printer=None, **kwargs):
     valid.pool_creation()
     valid.time_server()
     valid.fqdn()
+    valid.domain()
     valid.report()
 
     if valid.errors:


### PR DESCRIPTION
Signed-off-by: Joshua Schmid <jschmid@suse.de>

If a user misconfigured their fqdn like so:

```
# hostname --fqdn
target-00
```

[salt can't determine the `domain`](https://github.com/saltstack/salt/blob/7c0b30d9a423a4dca21c9dcaa5a35849417f5597/salt/grains/core.py#L1633-L1654
)

```python
In [2]: 'target-00'.partition('.')[::2]                                         
Out[2]: ('target-00', '')

```


[And we fail here ](https://github.com/SUSE/DeepSea/blob/04335830b8ba1630071a19fbfe400d089a139fa2/srv/salt/_modules/deepsea.py#L94-L99)

with:

`Exception: According to the 'domain' grain, the cluster does not have a DNS domain configured`

This is probably too late. Also the error message is not very descriptive.


My concern is that we break existing (working) installations that don't use SSL (yet).

Maybe raising a warning instead of an error is also fine?


-----------------

**Checklist:**
- [ ] Added unittests and or functional tests
- [ ] Adapted documentation
- [ ] Referenced issues or internal bugtracker
- [ ] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
