### PR TITLE
fix many-to-many not allowed in Grafana dashboard

### DIFF
--- a/srv/salt/ceph/monitoring/prometheus/files/prometheus.yml.j2
+++ b/srv/salt/ceph/monitoring/prometheus/files/prometheus.yml.j2
@@ -14,6 +14,7 @@ rule_files:
 scrape_configs:
   # The job name is added as a label `job=<job_name>` to any timeseries scraped from this config.
   - job_name: 'ceph-mgr'
+    honor_labels: true
     scrape_interval: {{ salt['pillar.get']('monitoring:prometheus:scrape_interval:ceph', '10s')|yaml }}
     file_sd_configs:
       - files: [ '/etc/prometheus/SUSE/scrape_configs/ceph/mgr_exporter.yml' ]


### PR DESCRIPTION
One part of the issue is that the metrics from the ceph mgr contain labels for `instance`, though, the `instance` label is also automatically populated by Prometheus. When Prometheus does that, the instance label becomes the hostname of the Ceph manager node, which is wrong. By setting `honor_labels` in the scrape configuration of `ceph-mgr` to `true`, the instances labels exported by the Prometheus manager module are preserved.

Partly fixes bsc#1175585

Signed-off-by: Patrick Seidensal <pseidensal@suse.com>

-----------------

**Checklist:**
- [x] Added unittests and or functional tests
- [ ] Adapted documentation
- [x] Referenced issues or internal bugtracker
- [x] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
