### PR TITLE
Fix case where remove_subnet_list is None

### DIFF
--- a/srv/modules/runners/net.py
+++ b/srv/modules/runners/net.py
@@ -467,7 +467,10 @@ def _remove_minion_exclude(addresses, remove_subnet_list):
         r"([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])" +
         r"(\/([0-9]|[1-2][0-9]|3[0-2]))$")
     log.debug("_remove_minion_exclude: removing {} ".format(remove_subnet_list))
-    remove_subnets = remove_subnet_list.split(",")
+    if remove_subnet_list:
+        remove_subnets = remove_subnet_list.split(",")
+    else:
+        remove_subnets = []
     remove_list = []
     for subnet in remove_subnets:
         if pattern_ipcidr.match(subnet):


### PR DESCRIPTION
Signed-off-by: Eric Jackson <ejackson@suse.com>

Found in the field.  When `remove_subnet_list` is None, the error is 

```
  File "/srv/modules/runners/net.py", line 470, in _remove_minion_exclude
    remove_subnets = remove_subnet_list.split(",")
AttributeError: 'NoneType' object has no attribute 'split'
```

-----------------

**Checklist:**
- [ ] Added unittests and or functional tests
- [ ] Adapted documentation
- [ ] Referenced issues or internal bugtracker
- [ ] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
