### PR TITLE
Add SES6->7 Upgrade Helpers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -794,6 +794,10 @@ copy-files:
 	# state files - update
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/upgrade
 	install -m 644 srv/salt/ceph/upgrade/*.sls $(DESTDIR)/srv/salt/ceph/upgrade
+	install -d -m 755 $(DESTDIR)/srv/salt/ceph/upgrade/ses7
+	install -m 644 srv/salt/ceph/upgrade/ses7/*.sls $(DESTDIR)/srv/salt/ceph/upgrade/ses7
+	install -d -m 755 $(DESTDIR)/srv/salt/ceph/upgrade/ses7/files
+	install -m 644 srv/salt/ceph/upgrade/ses7/files/*.j2 $(DESTDIR)/srv/salt/ceph/upgrade/ses7/files
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/updates
 	install -m 644 srv/salt/ceph/updates/*.sls $(DESTDIR)/srv/salt/ceph/updates/
 	install -d -m 755 $(DESTDIR)/srv/salt/ceph/updates/restart

--- a/deepsea.spec.in
+++ b/deepsea.spec.in
@@ -411,6 +411,8 @@ systemctl try-restart salt-api > /dev/null 2>&1 || :
 %dir /srv/salt/ceph/maintenance/upgrade/report
 %dir /srv/salt/ceph/maintenance/upgrade/cleanup
 %dir /srv/salt/ceph/upgrade
+%dir /srv/salt/ceph/upgrade/ses7
+%dir /srv/salt/ceph/upgrade/ses7/files
 %dir /srv/salt/ceph/updates
 %dir /srv/salt/ceph/updates/master
 %dir /srv/salt/ceph/updates/salt
@@ -756,6 +758,8 @@ systemctl try-restart salt-api > /dev/null 2>&1 || :
 %config /srv/salt/ceph/tuned/files/latency.conf
 %config /srv/salt/ceph/tuned/files/throughput.conf
 %config /srv/salt/ceph/upgrade/*.sls
+%config /srv/salt/ceph/upgrade/ses7/*.sls
+%config /srv/salt/ceph/upgrade/ses7/files/*.j2
 %config /srv/salt/ceph/maintenance/noout/*.sls
 %config /srv/salt/ceph/maintenance/upgrade/*.sls
 %config /srv/salt/ceph/maintenance/upgrade/master/*.sls

--- a/srv/modules/runners/upgrade.py
+++ b/srv/modules/runners/upgrade.py
@@ -172,7 +172,7 @@ def _sort_nodes_by_role(nodes, roles):
     actually figure out what roles are assigned to each node in the nodes list.
     """
     nodes_sorted = []
-    for role in ['master', 'mon', 'mgr', 'mds', 'storage', 'rgw', 'igw', 'ganesha']:
+    for role in ['master', 'mon', 'mgr', 'storage', 'mds', 'rgw', 'igw', 'ganesha']:
         role_nodes = [node for node in roles if role in roles[node] and node in nodes]
         role_nodes.sort()
         nodes_sorted.extend([node for node in role_nodes if node not in nodes_sorted])
@@ -217,13 +217,62 @@ def status():
     __opts__['grains'] = __grains__
     __utils__ = salt.loader.utils(__opts__)
     __salt__ = salt.loader.minion_mods(__opts__, utils=__utils__)
+    master_minion = __salt__['master.minion']()
 
-    os_codename, _, ceph_version = __utils__['status.get_sys_versions']()
+    local = salt.client.LocalClient()
+
     # os_codename and ceph_version are pretty strings, e.g.:
     # - SUSE Linux Enterprise Server 15 SP1
     # - ceph version 14.2.1-468-g994fd9e0cc (994fd9e0cc[...]) nautilus (stable)
     # (Unless a node is down, in which case they'll be "Unknown (node down?)"
     # or "Not installed" if Ceph is not installed yet)
+    os_codename, _, ceph_version = __utils__['status.get_sys_versions']()
+
+    # Following is possibly a slightly obscure test.  We want to run a bunch of pre-upgrade
+    # checks when upgrading from SES6->7, but, this upgrade runner could also be invoked
+    # on a system which is part way through a SES5->6 upgrade, in which case some nodes
+    # would be SLE 12 SP3 and some would be SLE 15 SP1.  So, we check if there's any oses
+    # that aren't a variant on SLE 15 (or are down/Unkown).  If the list is empty, we
+    # assume we're on a SLE 15 SP1 or SP2 base, and can sensibly run the SES6->7 checks.
+    non_sle_15 = [os for os in set(os_codename.values())
+                    if not os.startswith("SUSE Linux Enterprise Server 15")
+                    and not os.startswith("Unknown")]
+    if len(non_sle_15) == 0:
+        require_osd_release = list(local.cmd(master_minion, 'osd.require_osd_release', []).items())[0][1]
+        if require_osd_release[0] < 'n':
+            print("'require-osd-release' is currently '{}', but must be set to 'nautilus'".format(require_osd_release))
+            print("before upgrading to SES 7.  Please run `ceph osd require-osd-release nautilus`")
+            print("to fix this before proceeding further.")
+            print("")
+
+        filestore_osds = list(local.cmd(master_minion, 'cmd.run',
+            ["ceph osd metadata | jq '.[] | select(.osd_objectstore == \"filestore\") | .id'"]).items())[0][1].split()
+        if filestore_osds:
+            print("The following OSDs are using FileStore:")
+            print("  {}".format(', '.join(filestore_osds)))
+            print("All FileStore OSDs must be converted to BlueStore before upgrading to SES 7.")
+            print("")
+
+        filesystems = list(local.cmd(master_minion, 'cmd.run',
+            ["ceph fs ls --format=json|jq -r '.[][\"name\"]'"]).items())[0][1].split()
+        if filesystems:
+            for fs in filesystems:
+                max_mds = int(list(local.cmd(master_minion, 'cmd.run',
+                    ["ceph fs get {}|awk '/max_mds/ {{print $2}}'".format(fs)]).items())[0][1])
+                if max_mds > 1:
+                    print("The '{}' filesystem has {} MDS daemons.".format(fs, max_mds))
+                    print("Before upgrading MDS daemons, reduce the number of ranks to 1 by running")
+                    print("`ceph fs set {} max_mds 1`".format(fs))
+                    print("")
+            up_standbys = int(list(local.cmd(master_minion, 'cmd.run',
+                ["ceph status --format=json-pretty|jq -r '.[\"fsmap\"][\"up:standby\"]'"]).items())[0][1])
+            if up_standbys > 0:
+                if up_standbys > 1:
+                    print("There are {} standby MDS daemons running.".format(up_standbys))
+                else:
+                    print("There is 1 standby MDS daemon running.")
+                print("All standby MDS daemons must to be stopped prior to upgrading them.")
+                print("")
 
     if len(set(os_codename.values())) == 1 and len(set(ceph_version.values())) == 1:
         # OS version and ceph version are the same across the whole cluster
@@ -231,7 +280,7 @@ def status():
         print("  ceph: {}".format(next(iter(ceph_version.values()))))
         print("  os: {}".format(next(iter(os_codename.values()))))
         print("")
-        return True
+        return ""
 
     # We've got different versions of base OS, or ceph, or both, so we need:
     # - all the roles, to provide advice on what next to upgrade
@@ -244,7 +293,6 @@ def status():
     if down_nodes:
         search += " and not ( {} )".format("or ".join(down_nodes))
 
-    local = salt.client.LocalClient()
     roles = local.cmd(search, 'pillar.get', ['roles'], tgt_type="compound")
 
     os_release = local.cmd(search, 'grains.get', ['osrelease'], tgt_type="compound")

--- a/srv/salt/ceph/upgrade/ses7/adopt.sls
+++ b/srv/salt/ceph/upgrade/ses7/adopt.sls
@@ -1,0 +1,61 @@
+{% if grains.get('oscodename', '') != 'SUSE Linux Enterprise Server 15 SP2' %}
+
+not running sle 15 sp2:
+  test.fail_without_changes:
+    - name: |
+        This host is not running SUSE Linux Enterprise Server 15 SP2.
+        Please upgrade the operating system first, before running the adopt process.
+    - failhard: True
+
+{% endif %}
+
+# This check is so we bail out in case of a half upgraded system (for example,
+# if someone runs `zypper dup` with both SES6 and SES7 repos available, they'll
+# potentially still have ceph nautilus installed, which we really don't want).
+# TODO: figure out how to print a friendly error message in this case
+ceph must be octopus if installed:
+  cmd.run:
+    - name: "[ ! -x /usr/bin/ceph ] || ceph --version | grep -q 'ceph version 15'"
+    - failhard: True
+
+{% set ses7_container_image = salt['pillar.get']('ses7_container_image', 'registry.suse.com/ses/7/ceph/ceph') %}
+
+cephadm:
+  pkg.installed:
+    - pkgs:
+      - cephadm
+      - podman
+
+# TODO: may need to support authenticated registries. For more details see:
+# - https://github.com/ceph/ceph-salt/pull/277
+# - https://tracker.ceph.com/issues/44886
+/etc/containers/registries.conf:
+  file.managed:
+    - source:
+        - salt://ceph/upgrade/ses7/files/registries.conf.j2
+    - template: jinja
+    - user: root
+    - group: root
+    - mode: '0644'
+    - makedirs: True
+    - backup: minion
+    - failhard: True
+
+pull ceph container image:
+  cmd.run:
+    - name: "cephadm --image {{ ses7_container_image }} pull"
+    - unless: "podman images | grep -q {{ ses7_container_image }}"
+    - failhard: True
+
+adopt ceph daemons:
+  cmd.run:
+    - name: |
+        for DAEMON in $(cephadm ls|jq -r '.[] | select(.style=="legacy") | .name'); do
+            case $DAEMON in
+                mon*|mgr*|osd*)
+                    cephadm --image {{ ses7_container_image }} adopt --skip-pull --style legacy --force-start --name $DAEMON
+                    ;;
+            esac
+        done
+    - unless: "[ -z \"$(cephadm ls|jq -r '.[] | select(.style==\"legacy\") | .name')\" ]"
+    - failhard: True

--- a/srv/salt/ceph/upgrade/ses7/adopt.sls
+++ b/srv/salt/ceph/upgrade/ses7/adopt.sls
@@ -1,3 +1,15 @@
+{% set require_osd_release = salt['osd.require_osd_release']() %}
+{% if require_osd_release and require_osd_release != 'nautilus' %}
+require_osd_release is not nautilus:
+  test.fail_without_changes:
+    - name: |
+        'require-osd-release' is currently '{{ require_osd_release }}',
+        but must be set to 'nautilus' before upgrading to SES 7.
+        Please run `ceph osd require-osd-release nautilus` to fix this
+        before proceeding further.
+    - failhard: True
+{% endif %}
+
 {% if grains.get('oscodename', '') != 'SUSE Linux Enterprise Server 15 SP2' %}
 
 not running sle 15 sp2:

--- a/srv/salt/ceph/upgrade/ses7/files/registries.conf.j2
+++ b/srv/salt/ceph/upgrade/ses7/files/registries.conf.j2
@@ -1,0 +1,22 @@
+{% set registries = salt['pillar.get']('ses7_container_registries', []) -%}
+# This file was created by DeepSea. Changes to this file might be overwritten
+
+# For more information on this configuration file, see containers-registries.conf(5)
+
+# An array of host[:port] registries to try when pulling an unqualified image, in order
+unqualified-search-registries = ["docker.io"]
+
+{% for reg in registries %}
+[[registry]]
+{% if reg.prefix is defined %}
+prefix = "{{ reg.prefix }}"
+{% endif %}
+location = "{{ reg.location }}"
+{% if reg.insecure is defined %}
+insecure = {{ '{}'.format(reg.insecure) | lower }}
+{% endif %}
+{% if reg.blocked is defined %}
+blocked = {{ '{}'.format(reg.blocked) | lower }}
+{% endif %}
+{% endfor %}
+


### PR DESCRIPTION
This adds:

* SES6->7 pre-upgrade checks to the upgrade.status runner (bsc#1174601, bsc#1174605, jsc#SES-1196)
* upgrade.ceph_salt_config, to generate JSON for later use with `ceph-salt import`
* upgrade.generate_service_specs, to genrate YAML for later use with `ceph orch apply`
* ceph.upgrade.ses7.adopt state, to be used to run `cephadm adopt` for core daemons (mon, mgr, osd)

This PR supersedes #1840 which only included the upgrade.ceph_salt_config piece. I've fixed the "time_init: disabled" thing @Martin-Weiss mentioned. I've left the bootstrap_minion in place, because when I last tested this, it seemed ceph-salt still required it (even though it should be optional now) - possibly I did something wrong with my setup, so need to re-test that part.

-----------------

**Checklist:**
- [ ] Added unittests and or functional tests
- [ ] Adapted documentation
- [ ] Referenced issues or internal bugtracker
- [ ] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
