### PR TITLE
spec: Add /srv/salt/ceph/crash/files directory

### DIFF
--- a/deepsea.spec.in
+++ b/deepsea.spec.in
@@ -124,6 +124,7 @@ systemctl try-restart salt-api > /dev/null 2>&1 || :
 %dir /srv/salt/ceph/cephfs/benchmarks/files
 %dir /srv/salt/ceph/crash
 %dir /srv/salt/ceph/crash/auth
+%dir /srv/salt/ceph/crash/files
 %dir /srv/salt/ceph/crash/key
 %dir /srv/salt/ceph/metapackage
 %dir /srv/salt/ceph/dashboard


### PR DESCRIPTION
A tiny addition to 6d2687ac, needed to fix the build in IBS, which fails with:

```
... checking filelist
deepsea-[...].rpm: directories not owned by a package:
  - /srv/salt/ceph/crash/files
```

For full log, see https://build.suse.de/package/live_build_log/home:tserong/deepsea/SLE_15_SP1/x86_64

Curiously, `make rpm` from the source tree seems to work just fine, and not hit this error.

Signed-off-by: Tim Serong <tserong@suse.com>