### PR TITLE
Add multi MDS per node feature

### DIFF
--- a/srv/salt/_modules/mds.py
+++ b/srv/salt/_modules/mds.py
@@ -11,12 +11,15 @@ import logging
 log = logging.getLogger(__name__)
 
 
-def get_name(host):
+def get_name(host, i=0):
     """
     In most cases we use the hostname of the machine as the MDS name. However
     MDS names must not start with a digit, so filter those out and prefix them
     with "mds.".
     """
+    name = host
     if host[0].isdigit():
-        return 'mds.{}'.format(host)
-    return host
+        name = 'mds.{}'.format(name)
+    if i != 0:
+        name = '{}-{}'.format(name, i + 1)
+    return name

--- a/srv/salt/_modules/mds.py
+++ b/srv/salt/_modules/mds.py
@@ -7,6 +7,8 @@ original use.
 
 from __future__ import absolute_import
 import logging
+from os import listdir
+from os.path import isdir, isfile
 # pylint: disable=incompatible-py3-code
 log = logging.getLogger(__name__)
 
@@ -23,3 +25,10 @@ def get_name(host, i=0):
     if i != 0:
         name = '{}-{}'.format(name, i + 1)
     return name
+
+
+def get_local_daemon_count():
+    p = '/var/lib/ceph/mds/'
+    dirs = [d for d in listdir(p) if isdir('{}/{}'.format(p, d)) and
+            isfile('{}/{}/keyring'.format(p, d))]
+    return len(dirs)

--- a/srv/salt/ceph/mds/auth/default.sls
+++ b/srv/salt/ceph/mds/auth/default.sls
@@ -4,7 +4,11 @@ prevent empty rendering:
     - name: skip
 
 {% for host in salt.saltutil.runner('select.minions', cluster='ceph', roles='mds', host=True) %}
-{% set name = salt['mds.get_name'](host) %}
+
+{% for i in range(salt['pillar.get']('mds_daemons_per_node', 1)) %}
+
+{% set name = salt['mds.get_name'](host, i) %}
+
 {% set client = "mds." + name %}
 {% set keyring_file = salt['keyring.file']('mds', name)  %}
 
@@ -12,6 +16,7 @@ auth {{ keyring_file }}:
   cmd.run:
     - name: "ceph auth add {{ client }} -i {{ keyring_file }}"
 
+{% endfor %}
 {% endfor %}
 
 fix salt job cache permissions:

--- a/srv/salt/ceph/mds/default.sls
+++ b/srv/salt/ceph/mds/default.sls
@@ -2,10 +2,14 @@
 include:
   - .keyring
 
-{% set name = salt['mds.get_name'](grains['host']) %}
-start mds:
+{% for i in range(salt['pillar.get']('mds_daemons_per_node', 1)) %}
+
+{% set name = salt['mds.get_name'](grains['host'], i) %}
+
+start mds {{ name }}:
   service.running:
     - name: ceph-mds@{{ name }}
     - enable: True
- 
+
+{% endfor %}
 

--- a/srv/salt/ceph/mds/key/default.sls
+++ b/srv/salt/ceph/mds/key/default.sls
@@ -3,7 +3,11 @@ prevent empty rendering:
     - name: skip
 
 {% for host in salt.saltutil.runner('select.minions', cluster='ceph', roles='mds', host=True) %}
-{% set name = salt['mds.get_name'](host) %}
+
+{% for i in range(salt['pillar.get']('mds_daemons_per_node', 1)) %}
+
+{% set name = salt['mds.get_name'](host, i) %}
+
 {% set client = "mds." + name %}
 {% set keyring_file = salt['keyring.file']('mds', name)  %}
 {{ keyring_file}}:
@@ -19,6 +23,7 @@ prevent empty rendering:
       secret: {{ salt['keyring.secret'](keyring_file) }}
     - fire_event: True
 
+{% endfor %}
 {% endfor %}
 
 fix salt job cache permissions:

--- a/srv/salt/ceph/mds/keyring/default.sls
+++ b/srv/salt/ceph/mds/keyring/default.sls
@@ -1,6 +1,8 @@
 
+{% for i in range(salt['pillar.get']('mds_daemons_per_node', 1)) %}
 
-{% set name = salt['mds.get_name'](grains['host']) %}
+{% set name = salt['mds.get_name'](grains['host'], i) %}
+
 /var/lib/ceph/mds/ceph-{{ name }}/keyring:
   file.managed:
     - source: salt://ceph/mds/cache/{{ name }}.keyring
@@ -11,3 +13,4 @@
     - makedirs: True
     - fire_event: True
 
+{% endfor %}

--- a/srv/salt/ceph/mds/restart/controlled/default.sls
+++ b/srv/salt/ceph/mds/restart/controlled/default.sls
@@ -1,18 +1,22 @@
 {% if salt['cephprocesses.need_restart'](role='mds') == True %}
-{% set name = salt['mds.get_name'](grains['host']) %}
 
-restart:
+{% for i in range(salt['pillar.get']('mds_daemons_per_node', 1)) %}
+
+{% set name = salt['mds.get_name'](grains['host'], i) %}
+
+restart {{ name }}:
   cmd.run:
     - name: "systemctl restart ceph-mds@{{ name }}.service"
     - unless: "systemctl is-failed ceph-mds@{{ name }}.service"
     - fire_event: True
+
+{% endfor %}
 
 unset mds restart grain:
   module.run:
     - name: grains.setval
     - key: restart_mds
     - val: False
-
 
 {% else %}
 

--- a/srv/salt/ceph/mds/restart/force/default.sls
+++ b/srv/salt/ceph/mds/restart/force/default.sls
@@ -1,6 +1,11 @@
-{% set name = salt['mds.get_name'](grains['host']) %}
-restart:
+
+{% for i in range(salt['pillar.get']('mds_daemons_per_node', 1)) %}
+
+{% set name = salt['mds.get_name'](grains['host'], i) %}
+
+restart {{ name }}:
   cmd.run:
     - name: "systemctl restart ceph-mds@{{ name }}.service"
     - unless: "systemctl is-failed ceph-mds@{{ name }}.service"
     - fire_event: True
+{% endfor %}

--- a/srv/salt/ceph/mds/shutdown.sls
+++ b/srv/salt/ceph/mds/shutdown.sls
@@ -1,5 +1,9 @@
-{% set name = salt['mds.get_name'](grains['host']) %}
 
-shutdown daemon:
+{% for i in range(salt['pillar.get']('mds_daemons_per_node', 1)) %}
+
+{% set name = salt['mds.get_name'](grains['host'], i) %}
+
+shutdown daemon {{ name }}:
   service.dead:
     - name: ceph-mds@{{ name }}
+{% endfor %}

--- a/srv/salt/ceph/rescind/mds/default.sls
+++ b/srv/salt/ceph/rescind/mds/default.sls
@@ -3,17 +3,41 @@ mds nop:
   test.nop
 
 {% if 'mds' not in salt['pillar.get']('roles') %}
-{% set name = salt['mds.get_name'](grains['host']) %}
+{% for i in range(salt['pillar.get']('mds_daemons_per_node', 1)) %}
+
+{% set name = salt['mds.get_name'](grains['host'], i) %}
 stop mds {{ name }}:
   service.dead:
     - name: ceph-mds@{{ name }}
     - enable: False
 
-stop mds:
+stop mds {{ name }} noid:
   service.dead:
     - name: ceph-mds@mds
     - enable: False
 
+{% endfor %}
+
 include:
 - .keyring
+
+{% else %}
+{% set existing_mds = salt['mds.get_local_daemon_count']() %}
+{% for i in range(salt['pillar.get']('mds_daemons_per_node', 1), existing_mds) %}
+
+{% set name = salt['mds.get_name'](grains['host'], i) %}
+stop mds {{ name }}:
+  service.dead:
+    - name: ceph-mds@{{ name }}
+    - enable: False
+
+stop mds {{ name }} noid:
+  service.dead:
+    - name: ceph-mds@mds
+    - enable: False
+
+/var/lib/ceph/mds/ceph-{{ name }}/keyring:
+  file.absent
+{% endfor %}
+
 {% endif %}

--- a/srv/salt/ceph/rescind/mds/keyring/default.sls
+++ b/srv/salt/ceph/rescind/mds/keyring/default.sls
@@ -1,9 +1,12 @@
 
-{% set name = salt['mds.get_name'](grains['host']) %}
+{% for i in range(salt['pillar.get']('mds_daemons_per_node', 1)) %}
+
+{% set name = salt['mds.get_name'](grains['host'], i) %}
 /var/lib/ceph/mds/ceph-{{ name }}/keyring:
   file.absent
 
+{% endfor %}
+
 /var/lib/ceph/mds/ceph-mds/keyring:
   file.absent
-
 


### PR DESCRIPTION
Description:
This pr enables deploying multiple MDS daemons per node. This is configured by adding `mds_daemons_per_node: $n` to the pillar. This can be done either globally (via ` /srv/pillar/ceph/stack/global.yml`) or only on specific MDS nodes (via one of the files in `/srv/pillar/ceph/stack/ceph/minions/`). Rescind, restart and the shirnk to update functionality can handle multiple daemons per node.

-----------------
