### PR TITLE
Pass --container-init to `cephadm adopt` (bsc#1177588)

### DIFF
--- a/srv/salt/ceph/upgrade/ses7/adopt.sls
+++ b/srv/salt/ceph/upgrade/ses7/adopt.sls
@@ -65,7 +65,7 @@ adopt ceph daemons:
         for DAEMON in $(cephadm ls|jq -r '.[] | select(.style=="legacy") | .name'); do
             case $DAEMON in
                 mon*|mgr*|osd*)
-                    cephadm --image {{ ses7_container_image }} adopt --skip-pull --style legacy --force-start --name $DAEMON
+                    cephadm --image {{ ses7_container_image }} adopt --container-init --skip-pull --style legacy --force-start --name $DAEMON
                     ;;
             esac
         done


### PR DESCRIPTION
Note that while this causes the adopted containers to be run with --init, the user must still run `ceph config set mgr mgr/cephadm/container_init true` at some point, so that any new containers created in future are also run with --init.

Signed-off-by: Tim Serong <tserong@suse.com>

Fixes https://bugzilla.suse.com/show_bug.cgi?id=1177588