### PR TITLE
Drop `--container-init` flag during cephadm adopt

### DIFF
--- a/srv/salt/ceph/upgrade/ses7/adopt.sls
+++ b/srv/salt/ceph/upgrade/ses7/adopt.sls
@@ -65,7 +65,7 @@ adopt ceph daemons:
         for DAEMON in $(cephadm ls|jq -r '.[] | select(.style=="legacy") | .name'); do
             case $DAEMON in
                 mon*|mgr*|osd*)
-                    cephadm --image {{ ses7_container_image }} adopt --container-init --skip-pull --style legacy --force-start --name $DAEMON
+                    cephadm --image {{ ses7_container_image }} adopt --skip-pull --style legacy --force-start --name $DAEMON
                     ;;
             esac
         done


### PR DESCRIPTION
cephadm will now start containers using an init process by default

After: https://github.com/ceph/ceph/pull/37764

Signed-off-by: Michael Fritch <mfritch@suse.com>

-----------------

**Checklist:**
- [ ] Added unittests and or functional tests
- [ ] Adapted documentation
- [ ] Referenced issues or internal bugtracker
- [ ] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
