### PR TITLE
spec: declare incompatibility with ceph < 14.2.13

### DIFF
--- a/deepsea.spec.in
+++ b/deepsea.spec.in
@@ -48,7 +48,7 @@ Requires:       python3-boto
 Requires:       python3-configobj
 Requires:       python3-netaddr
 Requires:       python3-packaging
-Requires:       python3-rados
+Requires:       python3-rados >= 14.2.13
 Requires:       python3-six
 Requires:       salt-api
 Requires:       salt-master


### PR DESCRIPTION
As of dde7dbe94325e4aebb4f4b876bc22cec0db43b15 [1] DeepSea only works with ceph
versions with the refactored "ceph-volume batch" command.

By making this explicit in deepsea.spec, users will not be able to install an
incompatible version combination and problematic configurations will be flagged
earlier.

[1] https://github.com/SUSE/DeepSea/pull/1854

Signed-off-by: Nathan Cutler <ncutler@suse.com>
