### PR TITLE
rgw/dashboard: use rgw_frontend_ssl_port in SSL scenario

### DIFF
--- a/srv/salt/ceph/rgw/dashboard.sls
+++ b/srv/salt/ceph/rgw/dashboard.sls
@@ -8,10 +8,18 @@ configure dashboard rgw secret key:
     - name: "ceph dashboard set-rgw-api-secret-key $(radosgw-admin user info --uid=admin | jq -r .keys[0].secret_key)"
     - fire_event: True
 
+{% set rgw_init = pillar.get('rgw_init', 'default') %}
+{% if rgw_init == "default-ssl" %}
+configure dashboard rgw port:
+  cmd.run:
+    - name: "ceph dashboard set-rgw-api-port {{ pillar.get('rgw_frontend_ssl_port', 443) }}"
+    - fire_event: True
+{% else %}
 configure dashboard rgw port:
   cmd.run:
     - name: "ceph dashboard set-rgw-api-port {{ pillar.get('rgw_frontend_port', 80) }}"
     - fire_event: True
+{% endif %}
 
 {% set rgw_minions = salt.saltutil.runner('select.minions', cluster='ceph', roles='rgw') %}
 {% if not rgw_minions %}


### PR DESCRIPTION
When RGW is deployed with SSL according to the SES6 documentation [1],
we are ensured that rgw_init will be set to the string "default-ssl".

[1] https://documentation.suse.com/ses/6/single-html/ses-admin/#ogw-ssl-simple

Fixes: https://bugzilla.suse.com/show_bug.cgi?id=1178355
Signed-off-by: Nathan Cutler <ncutler@suse.com>