### PR TITLE
monitoring: fix node_exporter overrides in prometheus.yml (bsc#1179029)

### DIFF
--- a/srv/salt/ceph/monitoring/prometheus/default.sls
+++ b/srv/salt/ceph/monitoring/prometheus/default.sls
@@ -54,7 +54,7 @@ ceph-prometheus-alerts:
 {% endif %}
 
 {% for rule_file in salt['pillar.get']('monitoring:prometheus:rule_files', []) %}
-{% set file_name = salt['cmd.shell']("basename" + rule_file) %}
+{% set file_name = salt['cmd.shell']("basename " + rule_file) %}
 /etc/prometheus/SUSE/custom_rules/{{ file_name }}:
   file.managed:
     - source: {{ rule_file }}

--- a/srv/salt/ceph/monitoring/prometheus/files/prometheus.yml.j2
+++ b/srv/salt/ceph/monitoring/prometheus/files/prometheus.yml.j2
@@ -64,12 +64,12 @@ scrape_configs:
       {%- endfor %}
     {%- endif %}
   - job_name: 'node-exporter'
-    scrape_interval: {{ salt['pillar.get']('monitoring:prometheus:scrape_interval:node', '10s')|yaml }}
+    scrape_interval: {{ salt['pillar.get']('monitoring:prometheus:scrape_interval:node_exporter', '10s')|yaml }}
     file_sd_configs:
       - files: [ '/etc/prometheus/SUSE/scrape_configs/node_exporter/*.yml' ]
-    {%- if salt['pillar.get']('monitoring:prometheus:relabel_config:node', False) %}
+    {%- if salt['pillar.get']('monitoring:prometheus:relabel_config:node_exporter', False) %}
     relabel_configs:
-      {%- for label in salt['pillar.get']('monitoring:prometheus:relabel_config:node', []) %}
+      {%- for label in salt['pillar.get']('monitoring:prometheus:relabel_config:node_exporter', []) %}
         {%- if label.source_labels is string %}
           {%- set label_list = label.source_labels.split(',') %}
         {%- elif label.source_labels is list %}
@@ -87,9 +87,9 @@ scrape_configs:
         {%- endif %}
       {%- endfor %}
     {%- endif %}
-    {%- if salt['pillar.get']('monitoring:prometheus:metric_relabel_config:node', False) %}
-    metric_relabel_configs: {{ salt['pillar.get']('monitoring:prometheus:metric_relabel_config:node', [])|yaml }}
-      {%- for label in salt['pillar.get']('monitoring:prometheus:metric_relabel_config:node', []) %}
+    {%- if salt['pillar.get']('monitoring:prometheus:metric_relabel_config:node_exporter', False) %}
+    metric_relabel_configs: {{ salt['pillar.get']('monitoring:prometheus:metric_relabel_config:node_exporter', [])|yaml }}
+      {%- for label in salt['pillar.get']('monitoring:prometheus:metric_relabel_config:node_exporter', []) %}
       - action: {{ label.get('action', 'replace') }}
         {%- if label.get('source_labels') %}
           {%- if label.source_labels is string %}


### PR DESCRIPTION
f24acb4b changed the name of the node exporter pillar variables from "node" to "node_exporter", but missed making a matching change to the prometheus.yml config file.

This commit also fixes application of custom prometheus rule_files (there was a missing space when invoking `basename rule_file`).

Fixes https://bugzilla.suse.com/show_bug.cgi?id=1179029
Signed-off-by: Tim Serong <tserong@suse.com>