### PR TITLE
Fix setting custom Grafana certificates and Prometheus CLI flags

### DIFF
--- a/srv/salt/ceph/monitoring/grafana/create_configs.sls
+++ b/srv/salt/ceph/monitoring/grafana/create_configs.sls
@@ -10,7 +10,7 @@
 
 /srv/salt/ceph/monitoring/grafana/cache/tls/certs/grafana.crt:
   file.managed:
-    - source: {{ pillar['monitoring:grafana:ssl_cert'] }}
+    - source: {{ salt['pillar.get']('monitoring:grafana:ssl_cert') }}
     - user: {{ salt['deepsea.user']() }}
     - group: {{ salt['deepsea.group']() }}
     - mode: 600
@@ -19,7 +19,7 @@
 
 /srv/salt/ceph/monitoring/grafana/cache/tls/certs/grafana.key:
   file.managed:
-    - source: {{ pillar['monitoring:grafana:ssl_key'] }}
+    - source: {{ salt['pillar.get']('monitoring:grafana:ssl_key') }}
     - user: {{ salt['deepsea.user']() }}
     - group: {{ salt['deepsea.group']() }}
     - mode: 600

--- a/srv/salt/ceph/monitoring/prometheus/default.sls
+++ b/srv/salt/ceph/monitoring/prometheus/default.sls
@@ -40,10 +40,9 @@ ceph-prometheus-alerts:
     - makedirs: True
     - fire_event: True
 
-{% if salt['pillar.get']('monitoring:prometheus:additional_flags', False) %}
 /etc/sysconfig/prometheus:
   file.managed:
-    - content: ARGS="{{ pillar['monitoring:prometheus:additional_flags'] }}"
+    - contents: ARGS="{{ salt['pillar.get']('monitoring:prometheus:additional_flags', '') }}"
     - user: root
     - group: root
     - mode: 644
@@ -51,7 +50,6 @@ ceph-prometheus-alerts:
     - fire_event: True
     - watch_in:
       - service: prometheus
-{% endif %}
 
 {% for rule_file in salt['pillar.get']('monitoring:prometheus:rule_files', []) %}
 {% set file_name = salt['cmd.shell']("basename" + rule_file) %}


### PR DESCRIPTION
Signed-off-by: Patrick Seidensal <pseidensal@suse.com>

Fixes issues in using pillar values for setting custom Grafana certificates and providing additional command line flags for Prometheus (to increase retention time, for instance).

The template inside these conditions has probably never worked, as it cannot be compiled. The conditional code is only compiled if the pillar values are specified, so it didn't reveal an issue if those features weren't used, which seems to have always been the case.

-----------------

**Checklist:**
- [ ] Added unittests and or functional tests
- [ ] Adapted documentation
- [ ] Referenced issues or internal bugtracker
- [ ] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
