### PR TITLE
spec: Make deepsea-cli require deepsea

### DIFF
--- a/deepsea.spec.in
+++ b/deepsea.spec.in
@@ -804,6 +804,7 @@ Group:          System/Console
 BuildRequires:  python3-setuptools
 Requires:       python3-setuptools
 Requires:       python3-click
+Requires:       deepsea = %{version}-%{release}
 
 %description cli
 The deepsea-cli contains the deepsea command.  This command reports the


### PR DESCRIPTION
This means removing deepsea will also automatically remove deepsea-cli (see https://github.com/SUSE/doc-ses/issues/816 for related discussion).

Signed-off-by: Tim Serong <tserong@suse.com>