### PR TITLE
ganesha: use ganesha_config pool in ganesha.report (bsc#1179621)

### DIFF
--- a/srv/modules/runners/ganesha.py
+++ b/srv/modules/runners/ganesha.py
@@ -36,7 +36,7 @@ def report():
         return "No minions found with ganesha role"
 
     master = __salt__['master.minion']()
-    nfs_pool = __salt__['master.find_pool'](['cephfs', 'rgw'])
+    nfs_pool = 'ganesha_config'
 
     rep = {}
     rep['configuration'] = {'pool': nfs_pool, 'namespace': 'ganesha'}


### PR DESCRIPTION
Commit ab6cb716 introduced a dedicated ganesha_config pool, but ganesha.report was still trying to find ganesha config in cephfs and rgw pools.  It would of course find one of those pools, but with no ganesha config object therein, resulting in an error:

```
rados_conf:
    The minion function caused an exception: Traceback (most recent call last):
      File "/usr/lib/python3.6/site-packages/salt/minion.py", line 1684, in _thread_return
        return_data = minion_instance.executors[fname](opts, data, func, args, kwargs)
      File "/usr/lib/python3.6/site-packages/salt/executors/direct_call.py", line 12, in execute
        return func(*args, **kwargs)
      File "/var/cache/salt/minion/extmods/modules/ganesha.py", line 145, in get_gateway_conf_raw
        raise Exception("Object conf-{} does not exist".format(gateway_id))
      Exception: Object conf-node3 does not exist
```

Fixes: https://bugzilla.suse.com/show_bug.cgi?id=1179621
Signed-off-by: Tim Serong <tserong@suse.com>