### PR TITLE
ceph.conf: don't disable msgr2 (bsc#1180594)

### DIFF
--- a/srv/salt/ceph/configuration/files/ceph.conf.j2
+++ b/srv/salt/ceph/configuration/files/ceph.conf.j2
@@ -10,7 +10,6 @@ auth_service_required = cephx
 auth_client_required = cephx
 public_network = {{ salt['pillar.get']('public_network') }}
 cluster_network = {{ salt['pillar.get']('cluster_network') }}
-ms_bind_msgr2 = false
 
 {% set ipv6=salt['public.ipv6']() %}
 {% if ipv6 %}


### PR DESCRIPTION
This setting is no longer necessary since doc updates from https://github.com/SUSE/doc-ses/pull/348 (see also
https://github.com/SUSE/doc-ses/issues/314#issuecomment-639432080)

Fixes: https://bugzilla.suse.com/show_bug.cgi?id=1180594
Signed-off-by: Tim Serong <tserong@suse.com>