### PR TITLE
monitoring: enable custom scrape configurations

### DIFF
--- a/srv/salt/ceph/monitoring/prometheus/files/prometheus.yml.j2
+++ b/srv/salt/ceph/monitoring/prometheus/files/prometheus.yml.j2
@@ -13,6 +13,11 @@ rule_files:
 
 scrape_configs:
   # The job name is added as a label `job=<job_name>` to any timeseries scraped from this config.
+  {% for config in salt['pillar.get']('monitoring:prometheus:custom_scrape_configs', {}) %}
+  {%- for key, value in config.items() %}
+  {%- if loop.first %}- {% else %}  {% endif %}{{- key }}: {{ value | json}}
+  {% endfor %}
+  {%- endfor -%}
   - job_name: 'ceph-mgr'
     honor_labels: true
     scrape_interval: {{ salt['pillar.get']('monitoring:prometheus:scrape_interval:ceph', '10s')|yaml }}


### PR DESCRIPTION
Scrape configurations cannot be loaded externally by using a statement
like `include` inside the Prometheus configuration file. The
configuration management system is supposed to create the Prometheus
configuration file appropriately. By using service discovery the user
wouldn't be able to configure some details like the `scrape_interval` or
those would need to be configured separately.

This implementation enables to provide a whole block to
`/srv/pillar/ceph/stack/global.yml` under the
`monitoring:prometheus:custom_scrape_configs` hierarchy and does so by
iterating the keys and values for least implementation effort.

Fixes: https://bugzilla.suse.com/show_bug.cgi?id=1179029

Signed-off-by: Patrick Seidensal <pseidensal@suse.com>


