### PR TITLE
ceph.updates.salt: restart salt-minion.service with bg=True

### DIFF
--- a/srv/salt/ceph/updates/salt/default.sls
+++ b/srv/salt/ceph/updates/salt/default.sls
@@ -3,9 +3,10 @@ update salt:
     - pkgs:
       - salt-minion 
     - dist-upgrade: True
+    - failhard: True
 
 restart salt-minion:
-  module.run:
-    - name: service.restart
-    - m_name: salt-minion
-
+  cmd.run:
+    - name: "salt-call service.restart salt-minion"
+    - bg: True
+    - failhard: True


### PR DESCRIPTION
Implement the latest salt-minion.service restart best practice.

Fixes: https://bugzilla.suse.com/show_bug.cgi?id=1181099
Signed-off-by: Nathan Cutler <ncutler@suse.com>