### PR TITLE
Rework config change detection to handle global.conf correctly (bsc#1181183)

### DIFF
--- a/man/deepsea-commands.7
+++ b/man/deepsea-commands.7
@@ -1087,29 +1087,6 @@ salt-run validate.deploy
 .RE
 salt-run validate.saltapi
 .PP
-salt-run changed.rgw
-.RS
-.RE
-salt-run changed.mds
-.RS
-.RE
-salt-run changed.osd
-.RS
-.RE
-salt-run changed.mon
-.RS
-.RE
-salt-run changed.igw
-.RS
-.RE
-salt-run changed.global
-.RS
-.RE
-salt-run changed.client
-.RS
-.RE
-salt-run changed.config name=service
-.PP
 
 .SH AUTHOR
 Eric Jackson <ejackson@suse.com>

--- a/srv/salt/ceph/functests/1node/restart/common.sls
+++ b/srv/salt/ceph/functests/1node/restart/common.sls
@@ -52,9 +52,9 @@ distribute ceph.conf {{ service }}:
     - tgt_type: compound
     - sls: ceph.configuration
 
-check changes {{ service }}:
+check changes:
   salt.runner:
-    - name: changed.{{ service }}
+    - name: changed.any
 
 check {{ service }}:
   salt.state:
@@ -89,9 +89,9 @@ redistribute ceph.conf {{ service }}:
     - tgt_type: compound
     - sls: ceph.configuration
 
-check changes again {{ service }}:
+check changes again:
   salt.runner:
-    - name: changed.{{ service }}
+    - name: changed.any
 
 check {{ service }} again:
   salt.state:

--- a/srv/salt/ceph/stage/deploy/core/default.sls
+++ b/srv/salt/ceph/stage/deploy/core/default.sls
@@ -11,6 +11,11 @@ ready check failed:
 
 {% endif %}
 
+{# This checks for config file changes and sets restart grains if necessary   #}
+{# (the config_has_changed value is unused, but is necessary in order for the #}
+{# runner to actually be invoked in this context) #}
+{% set config_has_changed = salt['saltutil.runner']('changed.any') %}
+
 {# Salt orchestrate ignores return codes of other salt runners. #}
 #validate:
 #  salt.runner:
@@ -55,18 +60,6 @@ configuration:
     - tgt: 'I@cluster:ceph'
     - tgt_type: compound
     - sls: ceph.configuration
-
-# this gets pre-parsed anyways.. maybe put this ontop
-# replace with changed.all runner
-{% set ret_mon = salt.saltutil.runner('changed.mon') %}
-{% set ret_osd = salt['saltutil.runner']('changed.osd') %}
-{% set ret_mgr = salt['saltutil.runner']('changed.mgr') %}
-{% for config in salt['pillar.get']('rgw_configurations', [ 'rgw' ]) %}
-{% set ret_rgw_conf = salt.saltutil.runner('changed.config', role_name=config) %}
-{% endfor %}
-{% set ret_client = salt['saltutil.runner']('changed.client') %}
-{% set ret_global = salt['saltutil.runner']('changed.global') %}
-{% set ret_mds = salt['saltutil.runner']('changed.mds') %}
 
 admin:
   salt.state:

--- a/srv/salt/ceph/stage/iscsi/core/default.sls
+++ b/srv/salt/ceph/stage/iscsi/core/default.sls
@@ -54,9 +54,9 @@ apply igw config:
     - sls: ceph.igw.config.apply_iscsi_config
     - failhard: True
 
-check if igw config changed:
+check if any config changed:
   salt.runner:
-    - name: changed.igw
+    - name: changed.any
     - failhard: True
 
 auth:

--- a/tests/unit/runners/test_changed.py
+++ b/tests/unit/runners/test_changed.py
@@ -34,20 +34,20 @@ class TestChanged():
     def test_create_checksum(self, glob_mock, hashlib_mock, cfg, role):
         fs.CreateFile("{}/{}".format(conf_dir, 'rgw.conf'), contents="foo=bar")
         glob_mock.return_value = ["{}/{}".format(conf_dir, 'rgw.conf')]
-        cfg = cfg(role=role(role_name='rgw'))
+        cfg = cfg(role(role_name='rgw'))
         ret = cfg.create_checksum()
         assert isinstance(ret, MagicMock) is True
 
     @patch('srv.modules.runners.changed.log')
     def test_create_checksum_no_files(self, log_mock, cfg, role):
-        cfg = cfg(role=role(role_name='rgw'))
+        cfg = cfg(role(role_name='rgw'))
         ret = cfg.create_checksum()
         assert ret is None
 
     @patch('srv.modules.runners.changed.log')
     def test_write_checksum(self, log_mock, cfg, role):
         fs.CreateFile("{}/{}".format(checksum_dir, 'rgw.conf'), contents="foo=bar")
-        cfg = cfg(role=role(role_name='rgw'))
+        cfg = cfg(role(role_name='rgw'))
         m = mock_open()
         with patch('builtins.open', m, create=True):
             ret = cfg.write_checksum('0b0b0b0b0b0b0b0b0b0b0')
@@ -61,28 +61,23 @@ class TestChanged():
     @patch('srv.modules.runners.changed.open')
     def test_read_checksum(self, open_mock, log_mock, cfg, role):
         fs.CreateFile("{}/{}".format(checksum_dir, 'rgw.conf'), contents="foo=bar")
-        cfg = cfg(role=role(role_name='rgw'))
+        cfg = cfg(role(role_name='rgw'))
         ret = cfg.read_checksum()
         open_mock.assert_called_with('/srv/salt/ceph/configuration/files/ceph.conf.checksum/rgw.conf', 'r')
         log_mock.debug.assert_called()
 
     @patch('srv.modules.runners.changed.log')
     def test_read_checksum_no_file(self, log_mock, cfg, role):
-        cfg = cfg(role=role(role_name='rgw'))
+        cfg = cfg(role(role_name='rgw'))
         ret = cfg.read_checksum()
         log_mock.debug.assert_called()
         assert ret is None
-
-    def test_dependencies(self, cfg, role):
-        cfg = cfg(role=role(role_name='rgw'))
-        ret = cfg.role.dependencies
-        assert type(ret) is list
 
     @patch('srv.modules.runners.changed.Config.create_checksum')
     @patch('srv.modules.runners.changed.Config.read_checksum')
     @patch('srv.modules.runners.changed.log')
     def test_has_changes_eq(self, log_mock, read_cs_mock, create_cs_mock, cfg, role):
-        cfg = cfg(role=role(role_name='rgw'))
+        cfg = cfg(role(role_name='rgw'))
         read_cs_mock.return_value = "0b0b"
         create_cs_mock.return_value = "0b0b"
         ret = cfg.has_change()
@@ -94,7 +89,7 @@ class TestChanged():
     @patch('srv.modules.runners.changed.Config.write_checksum')
     @patch('srv.modules.runners.changed.log')
     def test_has_changes_not_eq(self, log_mock, write_cs_mock, read_cs_mock, create_cs_mock, cfg, role):
-        cfg = cfg(role=role(role_name='rgw'))
+        cfg = cfg(role(role_name='rgw'))
         read_cs_mock.return_value = "1b1b"
         create_cs_mock.return_value = "0b0b"
         ret = cfg.has_change()
@@ -106,11 +101,10 @@ class TestChanged():
     @patch('srv.modules.runners.changed.Config.read_checksum')
     @patch('srv.modules.runners.changed.log')
     def test_has_changes_no_current_or_prev_cs(self, log_mock, read_cs_mock, create_cs_mock, cfg, role):
-        cfg = cfg(role=role(role_name='rgw'))
+        cfg = cfg(role(role_name='rgw'))
         read_cs_mock.return_value = None
         create_cs_mock.return_value = None
         ret = cfg.has_change()
-        log_mock.debug.assert_called()
         assert ret is False
 
     @patch('srv.modules.runners.changed.Config.create_checksum')
@@ -118,56 +112,9 @@ class TestChanged():
     @patch('srv.modules.runners.changed.log')
     @patch('srv.modules.runners.changed.Config.write_checksum')
     def test_has_changes_no_current_cs(self, write_cs_mock, log_mock, read_cs_mock, create_cs_mock, cfg, role):
-        cfg = cfg(role=role(role_name='rgw'))
+        cfg = cfg(role(role_name='rgw'))
         read_cs_mock.return_value = None
         create_cs_mock.return_value = 'NotNone'
         ret = cfg.has_change()
-        log_mock.debug.assert_called()
         assert write_cs_mock.called is True
         assert ret is True
-
-    @patch('salt.client.LocalClient', autospec=True)
-    @patch('srv.modules.runners.changed.requires_conf_change')
-    def test_rgw(self, rcc_mock, salt_mock):
-        rcc_mock.assert_called
-
-    @patch('salt.client.LocalClient', autospec=True)
-    @patch('srv.modules.runners.changed.requires_conf_change')
-    def test_mds(self, rcc_mock, salt_mock):
-        rcc_mock.assert_called
-
-    @patch('salt.client.LocalClient', autospec=True)
-    @patch('srv.modules.runners.changed.requires_conf_change')
-    def test_mgr(self, rcc_mock, salt_mock):
-        changed.mgr()
-        rcc_mock.assert_called
-
-    @patch('salt.client.LocalClient', autospec=True)
-    @patch('srv.modules.runners.changed.requires_conf_change')
-    def test_osd(self, rcc_mock, salt_mock):
-        changed.osd()
-        rcc_mock.assert_called
-
-    @patch('salt.client.LocalClient', autospec=True)
-    @patch('srv.modules.runners.changed.requires_conf_change')
-    def test_mon(self, rcc_mock, salt_mock):
-        changed.mon()
-        rcc_mock.assert_called
-
-    @patch('salt.client.LocalClient', autospec=True)
-    @patch('srv.modules.runners.changed.requires_conf_change')
-    def test_global_(self, rcc_mock, salt_mock):
-        changed.global_()
-        rcc_mock.assert_called
-
-    @patch('salt.client.LocalClient', autospec=True)
-    @patch('srv.modules.runners.changed.requires_conf_change')
-    def test_client(self, rcc_mock, salt_mock):
-        changed.client()
-        rcc_mock.assert_called
-
-    @patch('salt.client.LocalClient', autospec=True)
-    @patch('srv.modules.runners.changed.requires_conf_change')
-    def test_igw(self, rcc_mock, salt_mock):
-        changed.igw()
-        rcc_mock.assert_called


### PR DESCRIPTION
This rather large change makes DeepSea schedule all daemons for restart if global.conf has changed.  The original (unimplemented) idea is that there was going to be a tree of roles, so each individual role could depend on global.conf, so if global.conf changed, it would propagate through this tree.  Unfortunately, that was never going to work due to the way the checksum verification/generation is done.  The original implementation called changed.mon, then changed.osd, then changed.mgr in that order.  If each of those in turn were to check if the global config had changed, then that'd be true on the first call, so the mons would get their restart flag set, but would no longer be true for subsequent calls (the mgr and osd wouldn't be restarted).  So I got rid of that entire tree concept altogether, and collapsed everything back to one function which checks for all possible changes and sets the restart grains appropriately.
    
Fixes: https://bugzilla.suse.com/show_bug.cgi?id=1181183
Signed-off-by: Tim Serong <tserong@suse.com>