### PR TITLE
Use -i to pass credentials to "ceph dashboard" commands (bsc#1183600)

### DIFF
--- a/srv/salt/ceph/dashboard/default.sls
+++ b/srv/salt/ceph/dashboard/default.sls
@@ -70,7 +70,7 @@ dashboard user exists:
 set username and password:
   cmd.run:
     # This command is printed although the 'onchange' statement evaluates as true. This might cause confusion.
-    - name: ceph dashboard ac-user-create {{ dashboard_user }} {{ dashboard_pw }} administrator
+    - name: "echo -n {{ dashboard_pw }} | ceph dashboard ac-user-create {{ dashboard_user }} -i - administrator"
     - onchanges:
         - cmd: dashboard user exists
 

--- a/srv/salt/ceph/rgw/dashboard.sls
+++ b/srv/salt/ceph/rgw/dashboard.sls
@@ -1,11 +1,11 @@
 configure dashboard rgw access key:
   cmd.run:
-    - name: "ceph dashboard set-rgw-api-access-key $(radosgw-admin user info --uid=admin | jq -r .keys[0].access_key)"
+    - name: "echo -n $(radosgw-admin user info --uid=admin | jq -r .keys[0].access_key) | ceph dashboard set-rgw-api-access-key -i -"
     - fire_event: True
 
 configure dashboard rgw secret key:
   cmd.run:
-    - name: "ceph dashboard set-rgw-api-secret-key $(radosgw-admin user info --uid=admin | jq -r .keys[0].secret_key)"
+    - name: "echo -n $(radosgw-admin user info --uid=admin | jq -r .keys[0].secret_key) | ceph dashboard set-rgw-api-secret-key -i -"
     - fire_event: True
 
 {% set rgw_init = pillar.get('rgw_init', 'default') %}

--- a/srv/salt/ceph/stage/iscsi/dashboard.sls
+++ b/srv/salt/ceph/stage/iscsi/dashboard.sls
@@ -29,7 +29,7 @@ add iscsi gateway {{ igw_address }} to dashboard:
     - tgt: {{ master }}
     - tgt_type: compound
     - arg:
-      - "ceph dashboard iscsi-gateway-add {{ iscsi_url }}"
+      - "echo -n {{ iscsi_url }} | ceph dashboard iscsi-gateway-add -i -"
     - kwarg:
         unless: ceph dashboard iscsi-gateway-list | jq .gateways | grep -q "{{ igw_address }}:{{ iscsi_port }}"
 


### PR DESCRIPTION
Ceph Nautilus 14.2.17+ requires that user, rgw and iscsi credentials passed to `ceph dashboard` commands come via a file, rather than being specified directly as literal parameters (see https://github.com/ceph/ceph/pull/38832)

Fixes: https://bugzilla.suse.com/show_bug.cgi?id=1183600
Signed-off-by: Tim Serong <tserong@suse.com>