### PR TITLE
Allow embedding of Grafana graphs

### DIFF
--- a/srv/salt/ceph/monitoring/grafana/default.sls
+++ b/srv/salt/ceph/monitoring/grafana/default.sls
@@ -89,6 +89,8 @@ add mgr dashboard config section:
           cert_key: /etc/grafana/grafana.key
         users:
           default_theme: light
+        security:
+          allow_embedding: true
 
 grafana-server:
   service.running:


### PR DESCRIPTION
Embedding Grafana graphs is allowed up to Grafana 6.1 by default and since [version 6.2](https://grafana.com/blog/2019/05/22/grafana-v6.2-released/
), embedding needs to be explicitly enabled.

Since Grafana has been updated in DeepSea from version 5.x to version 7.x, the change in the configuration is required.

Fixes: https://bugzilla.suse.com/show_bug.cgi?id=1186131

Signed-off-by: Patrick Seidensal <pseidensal@suse.com>


-----------------

**Checklist:**
- [ ] Added unittests and or functional tests
- [ ] Adapted documentation
- [x] Referenced issues or internal bugtracker
- [ ] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
