### PR TITLE
Wait for OSDs to be active after restarting (bsc#1185422)

### DIFF
--- a/srv/salt/_modules/osd.py
+++ b/srv/salt/_modules/osd.py
@@ -981,11 +981,11 @@ def wait_until_available(osd_id):
     """Wait slightly over a minute for an OSD to become available (use e.g. after restarting)"""
     timeout=0.5
     while timeout < 60:
-        time.sleep(timeout)
         _, stdout, _ = __salt__['helper.run']("ceph daemon osd.{} status 2>/dev/null | jq -r .state".format(osd_id))
         if stdout == "active":
             log.info("OSD {} is now active (timeout: {})".format(osd_id, timeout))
             return True
+        time.sleep(timeout)
         timeout *= 2
     log.error("OSD {} not active after {} seconds".format(osd_id, timeout))
     return False

--- a/srv/salt/_modules/osd.py
+++ b/srv/salt/_modules/osd.py
@@ -977,6 +977,20 @@ def takeover():
     return True
 
 
+def wait_until_available(osd_id):
+    """Wait slightly over a minute for an OSD to become available (use e.g. after restarting)"""
+    timeout=0.5
+    while timeout < 60:
+        time.sleep(timeout)
+        _, stdout, _ = __salt__['helper.run']("ceph daemon osd.{} status 2>/dev/null | jq -r .state".format(osd_id))
+        if stdout == "active":
+            log.info("OSD {} is now active (timeout: {})".format(osd_id, timeout))
+            return True
+        timeout *= 2
+    log.error("OSD {} not active after {} seconds".format(osd_id, timeout))
+    return False
+
+
 __func_alias__ = {
                 'list_': 'list',
                 }

--- a/srv/salt/ceph/osd/restart/controlled/default.sls
+++ b/srv/salt/ceph/osd/restart/controlled/default.sls
@@ -15,6 +15,12 @@ wait on processes after processing osd.{{ id }}:
     - fire_event: True
     - failhard: True
 
+ensure osd.{{ id }} is active:
+  module.run:
+    - name: osd.wait_until_available
+    - osd_id: {{ id }}
+    - failhard: True
+
 {% endfor %}
 
 unset storage restart grain:

--- a/srv/salt/ceph/osd/restart/controlled/default.sls
+++ b/srv/salt/ceph/osd/restart/controlled/default.sls
@@ -1,5 +1,6 @@
 {% if salt['cephprocesses.need_restart'](role='storage') == True %}
-{% for id in salt['osd.list']() %}
+{% set osd_list = salt['osd.list']() %}
+{% for id in osd_list %}
 restart osd {{ id }}:
   cmd.run:
     - name: "systemctl restart ceph-osd@{{ id }}.service"
@@ -14,13 +15,14 @@ wait on processes after processing osd.{{ id }}:
         'roles': ["storage"]
     - fire_event: True
     - failhard: True
+{% endfor %}
 
+{% for id in osd_list %}
 ensure osd.{{ id }} is active:
   module.run:
     - name: osd.wait_until_available
     - osd_id: {{ id }}
     - failhard: True
-
 {% endfor %}
 
 unset storage restart grain:

--- a/srv/salt/ceph/osd/restart/controlled/default.sls
+++ b/srv/salt/ceph/osd/restart/controlled/default.sls
@@ -31,6 +31,14 @@ unset storage restart grain:
     - key: restart_storage
     - val: False
 
+{% set osd_restart_delay = salt['pillar.get']('osd_restart_delay', 0) %}
+{% if osd_restart_delay %}
+delay after restarting osds:
+  module.run:
+    - name: test.sleep
+    - length: {{ osd_restart_delay }}
+{% endif %}
+
 {% else %}
 
 osdrestart.noop:


### PR DESCRIPTION
When restarting OSDs, previously we were checking that the OSD processes were running (using psutil), but not that the OSDs had completely started up.  This potentially means that if an OSD took rather longer than usual to start, the restart sequence could move along to the next node, and we could end up with multiple OSDs down across multiple nodes while doing a rolling restart.

This commit adds a call to `ceph daemon osd.$OSD_ID status` for each OSD, to ensure that the OSD has finished starting up properly.  In the normal case this will add a couple of seconds per OSD to the restart process.  Worst case, it'll hit a timeout at 64 seconds and bail out, then you need to investigate why the OSD didn't come up.

Fixes: https://bugzilla.suse.com/show_bug.cgi?id=1185422
Signed-off-by: Tim Serong <tserong@suse.com>

-----------------

**Checklist:**
- [ ] Added unittests and or functional tests
- [ ] Adapted documentation
- [ ] Referenced issues or internal bugtracker
- [ ] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
