### PR TITLE
mds/restart: only check MDS processes (not all processes)

### DIFF
--- a/srv/salt/ceph/functests/1node/restart/common.sls
+++ b/srv/salt/ceph/functests/1node/restart/common.sls
@@ -52,7 +52,7 @@ distribute ceph.conf {{ service }}:
     - tgt_type: compound
     - sls: ceph.configuration
 
-check changes:
+check {{ service }} changes:
   salt.runner:
     - name: changed.any
 
@@ -89,7 +89,7 @@ redistribute ceph.conf {{ service }}:
     - tgt_type: compound
     - sls: ceph.configuration
 
-check changes again:
+check {{ service }} changes again:
   salt.runner:
     - name: changed.any
 

--- a/srv/salt/ceph/restart/mds/default-sequential.sls
+++ b/srv/salt/ceph/restart/mds/default-sequential.sls
@@ -10,9 +10,9 @@
 
     check if all processes are still running on {{ host }} after restarting mdss:
       salt.state:
-        - tgt: '{{ salt['pillar.get']('deepsea_minions') }}'
+        - tgt: 'I@roles:mds'
         - tgt_type: compound
-        - sls: ceph.processes
+        - sls: ceph.processes.mds
         - failhard: True
 
     restarting mds on {{ host }}:


### PR DESCRIPTION
When restarting the MDS during stage 4, we were invoking ceph.processes to check if all processes were running.  The problem with doing this is that if you have custom global ceph configuration set up prior to initial deployment *and* are also deploying other stage 4 services which are normally deployed *after* MDS (i.e. RGW or Ganesha), the check for custom configuration changes flags all services for restart, so when ceph.processes is invoked it waits for all daemons to be running, even those which aren't yet deployed.  That was never going to work, so instead we're now only checking for MDS processes when restarting MDSes, which makes more sense than checking all processes anyway.

Signed-off-by: Tim Serong <tserong@suse.com>

-----------------

**Checklist:**
- [ ] Added unittests and or functional tests
- [ ] Adapted documentation
- [ ] Referenced issues or internal bugtracker
- [ ] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
