### PR TITLE
dg: include unavailable disks (bsc#1181725)

### DIFF
--- a/srv/salt/_modules/dg.py
+++ b/srv/salt/_modules/dg.py
@@ -784,9 +784,6 @@ class DriveGroup(object):
             for disk in self.disks:
                 log.debug("Processing disk {}".format(disk.get('path')))
                 # continue criterias
-                if not disk.get('available'):
-                    self.ignore(disk, "Disk is not available")
-                    continue
                 if self._has_gpt(disk):
                     self.ignore(disk, "GPT headers present")
                     continue


### PR DESCRIPTION
This partially reverts 8199a3220f53e46e907a844321ae1c86475f9acb, which made DriveGroups ignore disks which `ceph-volume inventory` reported as "unavailable".  The problem with this is that it means that shared DB devices are listed as unavailable, which in turn means that when you replace an OSD whose DB is on a shared device, the DB of the *new* OSD doesn't get put on the shared device, and instead you end up with a standalone OSD.

One side effect of this is that when adding a new set of disks (spinners + SSDs), depending on the drive group configuration, the journals for the new disks may end up on existing SSDs (see https://bugzilla.suse.com/show_bug.cgi?id=1171002).  As best as I can tell, we can't fix both things at the same time in code, and if this latter problem recurs, the best solution is probably to adjust the drive groups to specify db_slots to force the correct number of OSDs-per-SSD.

Fixes: https://bugzilla.suse.com/show_bug.cgi?id=1181725
Signed-off-by: Tim Serong <tserong@suse.com>

-----------------

**Checklist:**
- [ ] Added unittests and or functional tests
- [ ] Adapted documentation
- [ ] Referenced issues or internal bugtracker
- [ ] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
