### PR TITLE
upgrade: Add ability to specify registry credentials (bsc#1181095)

### DIFF
--- a/srv/modules/runners/upgrade.py
+++ b/srv/modules/runners/upgrade.py
@@ -360,7 +360,6 @@ def ceph_salt_config():
         },
         'container': {
             'registries_enabled': True,
-            'registries': [],
             'images': {
                 'ceph': 'registry.suse.com/ses/7/ceph/ceph'
             }
@@ -408,6 +407,11 @@ def ceph_salt_config():
         local.cmd(master_minion, 'pillar.get', ['ses7_container_registries']).items())[0][1]
     if container_registries:
         config['container']['registries'] = container_registries
+
+    container_auth = list(
+        local.cmd(master_minion, 'pillar.get', ['ses7_container_registry_auth']).items())[0][1]
+    if container_auth:
+        config['container']['auth'] = container_auth
 
     return json.dumps(config, indent=4)
 

--- a/srv/salt/ceph/upgrade/ses7/adopt.sls
+++ b/srv/salt/ceph/upgrade/ses7/adopt.sls
@@ -38,9 +38,6 @@ cephadm:
       - cephadm
       - podman
 
-# TODO: may need to support authenticated registries. For more details see:
-# - https://github.com/ceph/ceph-salt/pull/277
-# - https://tracker.ceph.com/issues/44886
 /etc/containers/registries.conf:
   file.managed:
     - source:
@@ -52,6 +49,18 @@ cephadm:
     - makedirs: True
     - backup: minion
     - failhard: True
+
+{% set auth = salt['pillar.get']('ses7_container_registry_auth', {}) %}
+{% if auth %}
+login to registry:
+  cmd.run:
+    - name: |
+        cephadm registry-login \
+        --registry-url {{ auth.get('registry') }} \
+        --registry-username {{ auth.get('username') }} \
+        --registry-password {{ auth.get('password') }}
+    - failhard: True
+{% endif %}
 
 pull ceph container image:
   cmd.run:


### PR DESCRIPTION
When using a local container registry with access credentials, these need to be specified in /srv/pillar/ceph/stack/global.yml so that the ceph container image can be pulled when adopting existing services. Here's an example of the format:

```
ses7_container_image: 192.168.121.1:5000/my/ceph/image
ses7_container_registry_auth:
  registry: 192.168.121.1:5000
  username: my_username_here
  password: my_very_secure_password_here
```

Fixes: https://bugzilla.suse.com/show_bug.cgi?id=1181095
Signed-off-by: Tim Serong <tserong@suse.com>

-----------------

**Checklist:**
- [ ] Added unittests and or functional tests
- [ ] Adapted documentation
- [ ] Referenced issues or internal bugtracker
- [ ] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
