### PR TITLE
SES5: Fixes no UCST response after 1 seconds

### DIFF
--- a/srv/modules/runners/validate.py
+++ b/srv/modules/runners/validate.py
@@ -540,7 +540,7 @@ class Validate(object):
     def _ntp_check(self, server):
         """
         """
-        result = self._popen([ '/usr/sbin/sntp', '-t', '1', server ])
+        result = self._popen([ '/usr/sbin/sntp', server ])
         for line in result[0]:
             if re.search(r'{}'.format(server), line):
                 if re.search(r'no.*response', line):


### PR DESCRIPTION
Although this code seems to have been working for about 5 years, it doesn't do so anymore for me. I'm not sure what happened, but a second is insufficient now, and that reproducibly.

When changing the time to wait for a response up to two seconds, it works.

When the `-t <int>` argument is removed, a default of 5 seconds is used, so I decided to go with that.

Signed-off-by: Patrick Seidensal <pseidensal@suse.com>

---

So even if it turns out to be a local issue and we won't merge this change (or possibly won't create another DeepSea package to be released for SES 5), it may serve me to look the issue up if I forgot how to circumvent it or might serve as a documentation for others, who might run into it.

Note that I'm currently unable to simply `sesdev create ses5 --single-node` an SES5 cluster. At stage 3 I've got to ssh into the machine and adapt DeepSeas' code as contained in this PR, just to be able to rerun stage 3 manually, followed by having to run stage 4 manually.

---

The problem did not occur when deploying (single-node) SES6 or SES7.

The command to deploy was:

```
sesdev create ses5 --single-node -n
```

```
[...]

    master: Stage initialization output:
    master: firewall                 : disabled
    master: apparmor                 : disabled
    master: DEV_ENV                  : True
    master: fsid                     : valid
    master: public_network           : valid
    master: cluster_network          : valid
    master: cluster_interface        : valid
    master: monitors                 : valid
    master: mgrs                     : valid
    master: storage                  : valid
    master: rgw                      : valid
    master: ganesha                  : valid
    master: master_role              : valid
    master: fqdn                     : valid
    master: time_server              : ['master.ses5-mini.test 127.0.1.1 no UCST response after 1 seconds']
    master: [init] Executing runner ready.check... 
    master: 
    master:          |_  cmd.shell(/usr/sbin/iptables -S)... 
    master:                in master.ses5-mini.test... ok
    master:          |_  cmd.shell(/usr/sbin/aa-status --enabled 2>/dev/null; echo $?)... 
    master:                in master.ses5-mini.test... ok
    master:          |_  state.apply(ceph.apparmor.profiles, test=true, __kwarg__=True)... 
    master:                in master.ses5-mini.test... ok
    master: [init] Executing runner ready.check... ok
    master: [init] Executing runner changed.mon... 
    master: ok
    master: [init] Executing runner changed.osd... 
    master: ok
    master: [init] Executing runner changed.mgr... 
    master: ok
    master: [init] Executing runner changed.config... 
    master: ok
    master: [init] Executing runner changed.client... 
    master: ok
    master: [init] Executing runner changed.global... 
    master: ok
    master: [init] Executing runner changed.mds... 
    master: ok
    master: [init] Executing runner changed.igw... 
    master: ok
    master: [init] Executing runner deepsea_minions.matches... 
    master: ok
    master: [init] Executing runner select.minions... 
    master: ok
    master: [init] Executing runner select.minions... 
    master: ok
    master: [init] Executing runner select.minions... 
    master: ok
    master: [init] Executing runner select.minions... 
    master: ok
    master: [init] Executing runner select.minions... 
    master: ok
    master: Stage execution failed: 
    master:   - validate failed
    master: Error in sesdev deployment script trapped!
    master: +++ err_report 645
    master: +++ set +x
    master: => hostname: master
    master: => script: /tmp/vagrant-shell
    master: => line number: 645
    master: Bailing out!
==> master: Configuring proxy for Git...
=== Deployment Finished ===

You can login into the cluster with:

  $ sesdev ssh ses5-mini

Or, access openATTIC with:

  $ sesdev tunnel ses5-mini openattic

```
Fixes #


Description:


-----------------

**Checklist:**
- [ ] Added unittests and or functional tests
- [ ] Adapted documentation
- [ ] Referenced issues or internal bugtracker
- [ ] Ran integration tests successfully (trigger with "@susebot run teuthology" in a GitHub comment; see the [wiki](https://github.com/SUSE/DeepSea/wiki/Testing) for more information)
