### PR TITLE
monitoring: put node_exporter ARGS all on one line (bsc#1188486)

### DIFF
--- a/srv/salt/ceph/monitoring/prometheus/exporters/node_exporter.sls
+++ b/srv/salt/ceph/monitoring/prometheus/exporters/node_exporter.sls
@@ -29,10 +29,7 @@ set node exporter service args:
     - name: /etc/sysconfig/prometheus-node_exporter
     - mode: 644
     - contents: |
-        ARGS="--collector.diskstats.ignored-devices=^(ram|loop|fd)\d+$ \
-              --collector.filesystem.ignored-mount-points=^/(sys|proc|dev|run)($|/) \
-              --collector.textfile.directory=/var/lib/prometheus/node-exporter \
-              --collector.bonding --collector.ntp"
+        ARGS="--collector.diskstats.ignored-devices=^(ram|loop|fd)\d+$ --collector.filesystem.ignored-mount-points=^/(sys|proc|dev|run)($|/) --collector.textfile.directory=/var/lib/prometheus/node-exporter --collector.bonding --collector.ntp"
 
 {% if grains.get('os', '') == 'CentOS' %}
 


### PR DESCRIPTION
There's a problem in /bin/fillup, where it sometimes doesn't parse multiline strings properly in sysconfig files.  This results in
corruption of /etc/sysconfig/prometheus-node_exporter when the golang-github-prometheus-node_exporter package is updated.  We can work around this by putting all the arguments on one line.  See https://bugzilla.opensuse.org/show_bug.cgi?id=1153280 and https://github.com/openSUSE/fillup/issues/1 for the underyling issue.

Fixes: https://bugzilla.suse.com/show_bug.cgi?id=1188486
Signed-off-by: Tim Serong <tserong@suse.com>