### PR TITLE
Use python3.6 for tox and travis

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -41,7 +41,7 @@ unsafe-load-any-extension=no
 extension-pkg-whitelist=
 
 # Fileperms Lint Plugin Settings
-fileperms-default=0644
+fileperms-default=0o644
 fileperms-ignore-paths=setup.py,tests/runtests.py,tests/jenkins*.py,tests/saltsh.py,tests/buildpackage.py
 
 # Minimum Python Version To Enforce

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,19 @@
 language: python
 python:
-  - 2.7
+  - 3.6
 install:
     - make setup.py
     - pip install tox
-env:
-  - TOXENV=py27
+    # Travis CI sets umask 002 which messes up the file permissions checks,
+    # so delete the fileperms plugin from .pylintrc to workaround this :-/
+    - sed -i '/fileperms/'d .pylintrc
 matrix:
   fast_finish: true
   include:
-    - python: 3.5
+    - python: 3.6
       env: TOXENV=lint
-    - python: 2.7
-      env: TOXENV=py27
+    - python: 3.6
+      env: TOXENV=py3
 script:
   - tox -e $TOXENV
 cache: pip

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ deps =
     salt<2018.10.13
 
 [testenv:py3]
-basepython = python3
+basepython = python3.6
 setenv = PYTHONPATH = {toxinidir}/srv/modules/utils
 commands =
     py.test --cov=. --tb=line -v --ignore=cli/ --junitxml=junit-{envname}.xml {posargs}
@@ -31,10 +31,11 @@ deps =
     boto
 
 [testenv:lint]
-basepython = python3
+basepython = python3.6
 setenv = PYTHONPATH = {toxinidir}/srv/modules/utils
 commands = pylint --rcfile=.pylintrc  srv/
 deps =
     {[base]deps}
     pylint<2.0
+    isort<5
     saltpylint<2018.10.13


### PR DESCRIPTION
Commit f8a6269 switched to using generic python3, allegedly because Tumbleweed had python 3.7, not 3.6.  I assume that was true at the time, because I wrote it, but given that python 3.6 *is* currently available on Tumbleweed, perhaps I was mistaken.  Anyway, it makes the most sense to force testing with python3.6, because that's what we deploy against with SES6 on SLE 15 SP1.

This commit also:

- Forces the use of isort < 5 when running lint, because version 5 produces a pile of "module 'isort' has no attribute 'SortImports'" errors, and no actual useful lint output.
- Gets rid of the file permission checks when running in Travis CI, because Travis sets umask 002, which messes up the file permissions during `git clone`, and causes all the tests to fail.

Signed-off-by: Tim Serong <tserong@suse.com>