### PR TITLE
Extra information when PGs take too long to be in active+clean state

### DIFF
--- a/srv/modules/runners/rebuild.py
+++ b/srv/modules/runners/rebuild.py
@@ -135,8 +135,11 @@ class Rebuild(object):
             quiescent = self.local.cmd(self.master_minion,
                                        'osd.ceph_quiescent', [], tgt_type="compound")
             log.debug("quiescent: {}".format(quiescent))
-            if self.master_minion in quiescent and quiescent[self.master_minion] is True:
-                break
+            if self.master_minion in quiescent:
+                if quiescent[self.master_minion]["result"] is True:
+                    break
+                else:
+                    log.warning(quiescent[self.master_minion]["message"])
             print("Waiting for PGs to recover...")
             time.sleep(delay)
             if delay < 60:

--- a/tests/unit/runners/test_rebuild.py
+++ b/tests/unit/runners/test_rebuild.py
@@ -1,10 +1,13 @@
 from mock import patch, MagicMock, mock
 from srv.modules.runners import rebuild
-
+import pytest
 
 class TestRebuild():
     """
     """
+    @pytest.fixture(autouse=True)
+    def inject_fixtures(self, caplog):
+        self.caplog = caplog
 
     @patch('srv.modules.runners.rebuild.master_minion', autospec=True)
     @patch('salt.runner.Runner', autospec=True)
@@ -432,4 +435,34 @@ class TestRebuild():
         assert rr._check_failed.called
         assert rr._skipped_summary.called
 
+    @patch('srv.modules.runners.rebuild.master_minion', autospec=True)
+    @patch('salt.runner.Runner', autospec=True)
+    @patch('salt.client.LocalClient', autospec=True)
+    def test_run_check_warning_message_when_fails(self, localclient, runner, mm):
+        rebuild.__opts__ = {}
+        mm.return_value = 'master_minion'
+        rr = rebuild.Rebuild(['data*.ceph'])
+        rr.local.cmd = mock.Mock()
+        class LocalCmdReturnValues(object):
+            def __init__(self, *fns):
+                self.fs = iter(fns)
+            def __call__(self, *args, **kwargs):
+                f = next(self.fs)
+                return f(*args, **kwargs)
+        def scrubbing(*args, **kwargs):
+            return {"master_minion": {
+                        "result": False,
+                        "message": ("Timeout expired waiting on active+clean: "
+                                    "PGs are scrubbing, "
+                                    "disable scrubbing and retry."),
+                        "num": 128}}
+        def ok(*args, **kwargs):
+            return {"master_minion": {
+                        "result": True, "message": "PGs are active+clean", "num": 128}}
 
+        rr.local.cmd.side_effect = LocalCmdReturnValues(scrubbing, ok)
+        rr._busy_wait()
+        # we're expecting to see 1 warning line with the pgs scrubbing message
+        messages_expected = [rec for rec in self.caplog.records if 'PGs are scrubbing' in rec.message]
+        assert len(messages_expected) == 1
+        assert messages_expected[0].message == "Timeout expired waiting on active+clean: PGs are scrubbing, disable scrubbing and retry."


### PR DESCRIPTION
When running rebuild.node it waits for PGs to be in the active+clean
state.
If PGs are, for example scrubbing, the user only gets the message: "Waiting for PGs to recover..."

This branch adds extra information, showing the actual state of PGs and,
in the case that they're scrubbing, it sugests to disable scrubbing and
trying.

The return value of quiescent method has been changed to return (in addition to the return result) a message that the rebuild runner can display to the user as a warning.

Fixes: https://bugzilla.suse.com/show_bug.cgi?id=1194807
Signed-off-by: Xavi Garcia <xavi.garcia@suse.com>
