### PR TITLE
Take drivegroup targets into account for rebuild.node (bsc#1198929)

### DIFF
--- a/srv/modules/runners/disks.py
+++ b/srv/modules/runners/disks.py
@@ -144,7 +144,7 @@ class DriveGroups(object):
             log.info("Found DriveGroup <{}>".format(dg_name))
             dgo = DriveGroup(dg_name, dg_values)
             if self.target:
-                target = self.target
+                target = f"( {dgo.target()} ) and ( {self.target} )"
             else:
                 target = dgo.target()
             ret.append(

--- a/srv/salt/_modules/osd.py
+++ b/srv/salt/_modules/osd.py
@@ -485,7 +485,7 @@ class CephPGs(object):
             current = self.pg_states()
             if not current:
                 log.warning("PGs are not present")
-                return {"result": False, "message": "PGs are not present"}
+                return {"result": True, "message": "PGs are not present"}
             if len(current) == 1 and current[0]['name'] == 'active+clean':
                 log.warning("PGs are active+clean")
                 return {"result": True, "message": "PGs are active+clean"}

--- a/tests/unit/_modules/test_osd.py
+++ b/tests/unit/_modules/test_osd.py
@@ -370,7 +370,7 @@ class TestCephPGs():
             assert isinstance(result, dict)
             assert 'result' in result
             assert 'message' in result
-            assert result['result'] is False
+            assert result['result'] is True
             assert result['message'] == ("PGs are not present")
 
     def test_message_first_scrubbing_then_error(self):


### PR DESCRIPTION
Previously, `salt-run rebuild.node $NODE` would override the targets specified in drive_groups.yml, and attempt to apply
*all* drive groups to the specified node (of course only the first one would succeed and the rest would likely do nothing).  This commit makes sure that only the drive groups whose configured targets actually match the specified node are applied (see https://bugzilla.suse.com/show_bug.cgi?id=1198929)

There's also a second commit in here which makes rebuild.node work if there's no PGs at all, which I hit while testing the above. This is an edge case that I have difficulty imagining anyone hitting on a real cluster, because by the time you get to rebuilding a node you're probably running a cluster with actual data in it.