### PR TITLE
Don't use punctuation when generating dashboard admin password

### DIFF
--- a/srv/salt/ceph/dashboard/default.sls
+++ b/srv/salt/ceph/dashboard/default.sls
@@ -1,5 +1,5 @@
 {% set dashboard_user = salt['pillar.get']('dashboard_user', 'admin') %}
-{% set dashboard_pw = salt['pillar.get']('dashboard_password', salt['grains.get']('dashboard_creds:' ~ dashboard_user , salt['random.get_str'](10))) %}
+{% set dashboard_pw = salt['pillar.get']('dashboard_password', salt['grains.get']('dashboard_creds:' ~ dashboard_user , salt['random.get_str'](10,punctuation=False))) %}
 {% set dashboard_ssl = salt['pillar.get']('dashboard_ssl', True) %}
 {% set dashboard_ssl_cert = salt['pillar.get']('dashboard_ssl_cert', None) %}
 {% set dashboard_ssl_key = salt['pillar.get']('dashboard_ssl_key', None) %}


### PR DESCRIPTION
If the string generated by random.get_str includes punctuation, it can break the parsing of the jinja template and/or screw up the line that echoes the password into `ceph dashboard ac-user-create`.  Salt 3004 added the ability to limit what characters are used in the password, so let's turn off punctuation to avoid this problem.

Fixes: https://bugzilla.suse.com/show_bug.cgi?id=1200794
Signed-off-by: Tim Serong <tserong@suse.com>