### PR TITLE
docs: fix c_v_commands reference typo

### DIFF
--- a/srv/modules/runners/disks.py
+++ b/srv/modules/runners/disks.py
@@ -39,7 +39,7 @@ Gives you a detailed report about what the anticipated osd layout.
 
 ## salt-run disks.deploy
 
-Will actually issue the commands generated from disks.d_v_commands.
+Will actually issue the commands generated from disks.c_v_commands.
 
 
 """


### PR DESCRIPTION
Fixes #1736

Changes:
- `commands generated from disks.d_v_commands` -> `commands generated from disks.c_v_commands` in `srv/modules/runners/disks.py` (1 occurrence(s))

Verification:
- Applied exact text replacements against the current upstream base branch.
- Verified no duplicate open PR was found for the referenced issue number(s) before opening this PR.
